### PR TITLE
feat: add api routes

### DIFF
--- a/example/api_deps.ts
+++ b/example/api_deps.ts
@@ -1,0 +1,1 @@
+export * from "../server.ts";

--- a/example/pages/api/joke.ts
+++ b/example/pages/api/joke.ts
@@ -1,0 +1,20 @@
+import { oak } from "../../api_deps.ts";
+
+// Jokes courtesy of https://punsandoneliners.com/randomness/programmer-jokes/
+const JOKES = [
+  "Why do Java developers often wear glasses? They can’t C#.",
+  "A SQL query walks into a bar, goes up to two tables and says “can I join you?",
+  "Wasn’t hard to crack Forrest Gump’s password. 1forrest1.",
+  "I love pressing the F5 key. It’s refreshing.",
+  "Called IT support and a chap from Australia came to fix my network connection.  I asked “Do you come from a LAN down under?”",
+  "There are 10 types of people in the world. Those who understand binary and those who don’t.",
+  "Why are assembly programmers often wet? They work below C level.",
+  "My favourite computer based band is the Black IPs.",
+  "What programme do you use to predict the music tastes of former US presidential candidates? An Al Gore Rhythm.",
+  "An SEO expert walked into a bar, pub, inn, tavern, hostelry, public house.",
+];
+
+export default (ctx: oak.Context) => {
+  const randomIndex = Math.floor(Math.random() * 10);
+  ctx.response.body = JOKES[randomIndex];
+};

--- a/example/routes.gen.ts
+++ b/example/routes.gen.ts
@@ -2,13 +2,15 @@
 // This file SHOULD be checked into source version control.
 // To update this file, run `fresh routes`.
 
-import * as $0 from "./pages/[name].tsx";
-import * as $1 from "./pages/index.tsx";
+import * as $0 from "./pages/api/joke.ts";
+import * as $1 from "./pages/[name].tsx";
+import * as $2 from "./pages/index.tsx";
 
 const routes = {
   pages: {
-    "./pages/[name].tsx": $0,
-    "./pages/index.tsx": $1,
+    "./pages/api/joke.ts": $0,
+    "./pages/[name].tsx": $1,
+    "./pages/index.tsx": $2,
   },
   baseUrl: import.meta.url,
 };

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -55,12 +55,17 @@ async function init(directory: string) {
     }
   }
 
-  await Deno.mkdir(join(directory, "pages"), { recursive: true });
+  await Deno.mkdir(join(directory, "pages", "api"), { recursive: true });
   const DEPS_TS = `export * from "${new URL(
     "../../runtime.ts",
     import.meta.url,
   )}";\n`;
   await Deno.writeTextFile(join(directory, "deps.ts"), DEPS_TS);
+  const API_DEPS_TS = `export * from "${new URL(
+    "../../server.ts",
+    import.meta.url,
+  )}";\n`;
+  await Deno.writeTextFile(join(directory, "api_deps.ts"), API_DEPS_TS);
   const PAGES_INDEX_TSX = `import { h, IS_BROWSER, useState } from "../deps.ts";
 
 export default function Home() {
@@ -107,6 +112,31 @@ export default function Greet(props: Props) {
     join(directory, "pages", "[name].tsx"),
     PAGES_GREET_TSX,
   );
+  const PAGES_API_JOKE_TS = `import { oak } from "../../api_deps.ts";
+
+// Jokes courtesy of https://punsandoneliners.com/randomness/programmer-jokes/
+const JOKES = [
+  "Why do Java developers often wear glasses? They can’t C#.",
+  "A SQL query walks into a bar, goes up to two tables and says “can I join you?",
+  "Wasn’t hard to crack Forrest Gump’s password. 1forrest1.",
+  "I love pressing the F5 key. It’s refreshing.",
+  "Called IT support and a chap from Australia came to fix my network connection.  I asked “Do you come from a LAN down under?”",
+  "There are 10 types of people in the world. Those who understand binary and those who don’t.",
+  "Why are assembly programmers often wet? They work below C level.",
+  "My favourite computer based band is the Black IPs.",
+  "What programme do you use to predict the music tastes of former US presidential candidates? An Al Gore Rhythm.",
+  "An SEO expert walked into a bar, pub, inn, tavern, hostelry, public house.",
+];
+
+export default (ctx: oak.Context) => {
+  const randomIndex = Math.floor(Math.random() * 10);
+  ctx.response.body = JOKES[randomIndex];
+};
+`;
+  await Deno.writeTextFile(
+    join(directory, "pages", "api", "joke.ts"),
+    PAGES_API_JOKE_TS,
+  );
   const TSCONFIG_JSON = JSON.stringify(
     {
       "compilerOptions": {
@@ -116,7 +146,7 @@ export default function Greet(props: Props) {
     },
     undefined,
     2,
-  );
+  ) + "\n";
   await Deno.writeTextFile(
     join(directory, "tsconfig.json"),
     TSCONFIG_JSON,
@@ -132,7 +162,7 @@ start(routes);
     MAIN_TS,
   );
   const README_MD = `# fresh project
-  
+
 ### Usage
 
 Install deployctl:
@@ -152,7 +182,6 @@ After adding, removing, or moving a page in the \`pages\` directory, run:
 \`\`\`
 fresh routes
 \`\`\`
-
 `;
   await Deno.writeTextFile(
     join(directory, "README.md"),

--- a/src/cli/routes.ts
+++ b/src/cli/routes.ts
@@ -43,7 +43,7 @@ export async function routes(directory: string) {
   const folder = walk(pagesDir, {
     includeDirs: false,
     includeFiles: true,
-    exts: ["tsx", "jsx"],
+    exts: ["tsx", "jsx", "ts", "js"],
   });
   for await (const entry of folder) {
     if (entry.isFile) {

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -1,5 +1,5 @@
 import { denoPlugin, esbuild } from "./deps.ts";
-import { Page } from "./page.ts";
+import { Page } from "./routes.ts";
 
 let esbuildInitalized: boolean | Promise<void> = false;
 async function ensureEsbuildInialized() {

--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -1,17 +1,23 @@
 import { oak } from "./deps.ts";
-import { Page, PageModule, processRoutes } from "./page.ts";
+import {
+  ApiRoute,
+  ApiRouteModule,
+  Page,
+  PageModule,
+  processRoutes,
+} from "./routes.ts";
 import { installRoutes } from "./router.ts";
 
 export interface Routes {
-  pages: Record<string, PageModule>;
+  pages: Record<string, PageModule | ApiRouteModule>;
   baseUrl: string;
 }
 
-export { installRoutes };
+export { installRoutes, oak };
 
 export function start(routes: Routes) {
-  const pages = processRoutes(routes);
-  const app = createDefaultServer(pages);
+  const [pages, apiRoutes] = processRoutes(routes);
+  const app = createDefaultServer(pages, apiRoutes);
   app.addEventListener("error", (err) => {
     console.error(err.error);
   });
@@ -19,10 +25,13 @@ export function start(routes: Routes) {
   addEventListener("fetch", app.fetchEventHandler());
 }
 
-export function createDefaultServer(pages: Page[]): oak.Application {
+export function createDefaultServer(
+  pages: Page[],
+  apiRoutes: ApiRoute[],
+): oak.Application {
   const router = new oak.Router();
 
-  installRoutes(router, pages);
+  installRoutes(router, pages, apiRoutes);
 
   const app = new oak.Application();
 

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -1,6 +1,6 @@
 import { renderToString } from "./deps.ts";
 import * as rt from "../runtime/deps.ts";
-import { Page } from "./page.ts";
+import { Page } from "./routes.ts";
 import { BUILD_ID, INTERNAL_PREFIX, JS_PREFIX } from "./constants.ts";
 
 export function render(page: Page, params: Record<string, string>): string {

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -1,17 +1,25 @@
 import { extname, oak } from "./deps.ts";
 import { Bundler } from "./bundle.ts";
 import { render } from "./render.ts";
-import { Page } from "./page.ts";
+import { ApiRoute, Page } from "./routes.ts";
 import { BUILD_ID, INTERNAL_PREFIX, JS_PREFIX } from "./constants.ts";
 
 /** This function installs all routes required by fresh onto an oak router. */
-export function installRoutes(router: oak.Router, pages: Page[]) {
+export function installRoutes(
+  router: oak.Router,
+  pages: Page[],
+  apiRoutes: ApiRoute[],
+) {
   for (const page of pages) {
     router.get<Record<string, string>>(page.route, (ctx) => {
       ctx.response.status = 200;
       ctx.response.type = "html";
       ctx.response.body = render(page, ctx.params);
     });
+  }
+
+  for (const apiRoute of apiRoutes) {
+    router.all(apiRoute.route, apiRoute.handler);
   }
 
   const internal = internalRouter(pages);


### PR DESCRIPTION
This commit adds API routes. These routes are located in the
./pages/api/ directory. Each file in there will have it's default
export invoked for HTTP calls to the corresponding route.

Closes #3
