### PR TITLE
docs: add `-n fresh` to install command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ inside an existing project. The `fresh` CLI is not required for most development
 or in CI, as `fresh` does not have a build step. To install `fresh`:
 
 ```
-deno install -A -f --no-check https://raw.githubusercontent.com/lucacasonato/fresh/main/cli.ts
+deno install -A -f --no-check -n fresh https://raw.githubusercontent.com/lucacasonato/fresh/main/cli.ts
 ```
 
 ## Creating a new project


### PR DESCRIPTION
The old command resulted in a binary named `main`. The changes in this PR specify the name to avoid that.