### PR TITLE
feat: add config option to disable runtime js

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,15 @@ Fresh does not have a build step - you write your code, deploy it to
 the framework.
 
 - No build step
-- Zero config
+- Zero config necessary
 - JIT rendering on the edge
-- Tiny (example is 3KB of JS)
-- Client side hydration
+- Tiny (example is 0-3KB of runtime JS)<sup>1</sup>
+- Optional client side hydration
 - TypeScript out of the box
 - File-system routing à la Next.js
+
+_<sup>1</sup> Client side hydration can be disabled per page. This results in
+**no JS** being shipped to the client._
 
 ## Install
 

--- a/example/pages/x/[module].tsx
+++ b/example/pages/x/[module].tsx
@@ -1,4 +1,4 @@
-import { h, PageProps, useData } from "../../deps.ts";
+import { h, PageConfig, PageProps, useData } from "../../deps.ts";
 
 export default function ModuleInfoPage({ params }: PageProps) {
   const module = params.module;
@@ -32,3 +32,5 @@ async function fetcher(url: string): Promise<ModuleInfo | null> {
   if (resp.status === 200) return resp.json();
   return null;
 }
+
+export const config: PageConfig = { runtimeJS: false };

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,3 +1,16 @@
 export interface PageProps {
   params: Record<string, string | string[]>;
 }
+
+export interface PageConfig {
+  /**
+   * Setting this flag to `false` disables all client side runtime JS. This
+   * means that all interactivity on the client that depends on Preact or other
+   * JS code will not function. This option is set to `true` (runtime javascript
+   * is enabled) by default.
+   *
+   * It is recommended to disable runtime JavaScript for static pages that do
+   * not require interactivity, like marketing or blog pages.
+   */
+  runtimeJS?: boolean;
+}

--- a/src/server/render.tsx
+++ b/src/server/render.tsx
@@ -53,6 +53,10 @@ export async function render(opts: RenderOptions): Promise<string> {
     templateProps = undefined;
   }
 
+  if (opts.imports.length === 0) {
+    templateProps = undefined;
+  }
+
   const html = template({
     bodyHtml,
     imports: opts.imports,

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,9 +1,10 @@
 import { ComponentType } from "../runtime/deps.ts";
 import { router } from "./deps.ts";
-import { PageProps } from "../runtime/types.ts";
+import { PageConfig, PageProps } from "../runtime/types.ts";
 
 export interface PageModule {
   default: ComponentType<PageProps>;
+  config?: PageConfig;
 }
 
 export interface Page {
@@ -11,6 +12,7 @@ export interface Page {
   url: string;
   name: string;
   component: ComponentType<PageProps>;
+  runtimeJS: boolean;
 }
 
 export type ApiRouteModule = {

--- a/tests/fixture/pages/static.tsx
+++ b/tests/fixture/pages/static.tsx
@@ -1,0 +1,7 @@
+import { h, PageConfig } from "../deps.ts";
+
+export default function StaticPage() {
+  return <p>This is a static page.</p>;
+}
+
+export const config: PageConfig = { runtimeJS: false };

--- a/tests/fixture/routes.gen.ts
+++ b/tests/fixture/routes.gen.ts
@@ -2,17 +2,19 @@
 // This file SHOULD be checked into source version control.
 // To update this file, run `fresh routes`.
 
-import * as $0 from "./pages/index.tsx";
+import * as $0 from "./pages/api/name.ts";
 import * as $1 from "./pages/api/get_only.ts";
-import * as $2 from "./pages/api/name.ts";
+import * as $2 from "./pages/static.tsx";
 import * as $3 from "./pages/[name].tsx";
+import * as $4 from "./pages/index.tsx";
 
 const routes = {
   pages: {
-    "./pages/index.tsx": $0,
+    "./pages/api/name.ts": $0,
     "./pages/api/get_only.ts": $1,
-    "./pages/api/name.ts": $2,
+    "./pages/static.tsx": $2,
     "./pages/[name].tsx": $3,
+    "./pages/index.tsx": $4,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -85,3 +85,15 @@ Deno.test("/api/xyz not found", async () => {
   assert(resp);
   assertEquals(resp.status, 404);
 });
+
+Deno.test("/static page prerender", async () => {
+  const resp = await router(new Request("https://fresh.deno.dev/static"));
+  assert(resp);
+  assertEquals(resp.status, 200);
+  assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
+  const body = await resp.text();
+  assert(!body.includes(`static.js`));
+  assert(!body.includes(`</script>`));
+  assertStringIncludes(body, "<p>This is a static page.</p>");
+  assert(!body.includes("__FRSH_PROPS"));
+});


### PR DESCRIPTION
The config option can be toggled per page:

```js
export const config: PageConfig = { runtimeJS: false };
```

Closes #29
