### PR TITLE
feat: deployctl is not needed anymore

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "deno.enable": true,
   "deno.lint": true,
-  "deno.unstable": false,
+  "deno.unstable": true,
   "deno.config": "./tsconfig.json"
 }

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ The `fresh` CLI can scaffold a new project for you. To scaffold a project in the
 fresh init myproject
 ```
 
-To now start the project, use [`deployctl`](https://deno.land/x/deploy):
+To now start the project, call `deno run`:
 
 ```
-deployctl run --no-check --watch main.ts
+deno run -A --unstable --config tsconfig.json --watch main.ts
 ```
 
 To deploy the script to [Deno Deploy](https://deno.com/deploy), push your

--- a/cli.ts
+++ b/cli.ts
@@ -39,7 +39,7 @@ switch (subcommand) {
     break;
   default:
     if (args.version) {
-      console.log(`deployctl ${VERSION}`);
+      console.log(`fresh ${VERSION}`);
       Deno.exit(0);
     }
     if (args.help) {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,14 +4,10 @@ Welcome to the `fresh` documentation.
 
 ## Requirements
 
-The documentation assumes you have Deno 1.9.2 or later, and `deployctl` 0.3.0
-installed.
+The documentation assumes you have Deno 1.12.0 or later installed.
 
 To install Deno, follow the installation instructions in the manual:
 https://deno.land/manual/getting_started/installation
-
-To install `deployctl`, follow the installation instructions here:
-https://deno.land/x/deploy#install
 
 ## Setup
 
@@ -46,10 +42,10 @@ To learn more about how projects are structured, take a look at the
 
 ## Running the project locally
 
-You can now run your new project locally with `deployctl`:
+You can now run your new project locally using the `deno` CLI:
 
 ```
-deployctl run --watch --no-check ./main.ts
+deno run -A --unstable --config tsconfig.json --watch main.ts
 ```
 
 The `--watch` option will cause your script to be reloaded on any changes to the

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -5,7 +5,7 @@ important files are `main.ts`, `routes.gen.ts`, and the pages and api routes in
 the `pages` subfolder.
 
 The `main.ts` file is the entrypoint to your project. It is the file you link in
-Deno Deploy, or run locally with `deployctl`.
+Deno Deploy, or run locally with the `deno` CLI.
 
 The `routes.gen.ts` file is a manifest of all pages and api routes in a project.
 When moving around or creating new pages, this file needs to be updated. This is

--- a/example/README.md
+++ b/example/README.md
@@ -2,16 +2,10 @@
 
 ### Usage
 
-Install deployctl:
-
-```
-deno install --allow-read --allow-write --allow-env --allow-net --allow-run --no-check -r -f https://deno.land/x/deploy/deployctl.ts
-```
-
 Start the project:
 
 ```
-deployctl run --no-check --watch main.ts
+deno run -A --unstable --config tsconfig.json --watch main.ts
 ```
 
 After adding, removing, or moving a page in the `pages` directory, run:

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["dom", "deno.ns", "deno.unstable"],
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment"
   }

--- a/makefile
+++ b/makefile
@@ -8,4 +8,4 @@ test:
 	deno test --no-check -A --config tsconfig.json
 
 watch_example:
-	deployctl run --watch --no-check example/main.ts
+	deno run -A --unstable --config example/tsconfig.json --watch example/main.ts

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -137,6 +137,7 @@ export default (_req: Request): Response => {
   const TSCONFIG_JSON = JSON.stringify(
     {
       "compilerOptions": {
+        "lib": ["dom", "deno.ns", "deno.unstable"],
         "jsxFactory": "h",
         "jsxFragmentFactory": "Fragment",
       },
@@ -162,16 +163,10 @@ start(routes);
 
 ### Usage
 
-Install deployctl:
-
-\`\`\`
-deno install --allow-read --allow-write --allow-env --allow-net --allow-run --no-check -r -f https://deno.land/x/deploy/deployctl.ts
-\`\`\`
-
 Start the project:
 
 \`\`\`
-deployctl run --no-check --watch main.ts
+deno run -A --unstable --config tsconfig.json --watch main.ts
 \`\`\`
 
 After adding, removing, or moving a page in the \`pages\` directory, run:

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -2,3 +2,9 @@ export const INTERNAL_PREFIX = "/_frsh";
 export const BUILD_ID = Deno.env.get("DENO_DEPLOYMENT_ID") ||
   crypto.randomUUID();
 export const JS_PREFIX = `/js`;
+
+declare global {
+  interface Crypto {
+    randomUUID(): string;
+  }
+}

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -50,7 +50,8 @@ export class ServerContext {
       if (path.startsWith("/api/")) {
         const handlers = Object.fromEntries(
           Object.entries(module as ApiRouteModule).filter(([method]) =>
-            method === "default" || router.METHODS.includes(method)
+            method === "default" ||
+            (router.METHODS as readonly string[]).includes(method)
           ),
         );
         const apiRoute: ApiRoute = {

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -14,4 +14,4 @@ export { lookup as mediaTypeLookup } from "https://deno.land/x/media_types@v2.9.
 // @deno-types="https://unpkg.com/esbuild-wasm@0.11.19/esm/browser.d.ts"
 import * as esbuild from "https://gist.githubusercontent.com/lucacasonato/358c6b7e8198bfb2cf3d220e49fdcf5f/raw/3714cb0f59606eefc29ed0fea36d4cd93549938b/esbuild-wasm.js";
 export { esbuild };
-export { denoPlugin } from "https://deno.land/x/esbuild_deno_loader@0.2.0/mod.ts";
+export { denoPlugin } from "https://deno.land/x/esbuild_deno_loader@0.3.0/mod.ts";

--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -14,7 +14,23 @@ export { router, ServerContext };
 export function start(routes: Routes) {
   const ctx = ServerContext.fromRoutes(routes);
   const app = router.router(ctx.routes());
-  addEventListener("fetch", (event: FetchEvent) => {
-    event.respondWith(app(event.request));
-  });
+  serve(app);
+}
+
+async function serve(handler: (req: Request) => Response | Promise<Response>) {
+  async function handleConn(conn: Deno.Conn) {
+    const httpConn = Deno.serveHttp(conn);
+    for await (const e of httpConn) {
+      e.respondWith(handler(e.request))
+        .catch((e) => console.error("Failed handing a request:", e));
+    }
+  }
+
+  const listener = Deno.listen({ port: 8000 });
+  const addr = listener.addr as Deno.NetAddr;
+  console.log(`Listening on http://${addr.hostname}:${addr.port}`);
+  for await (const conn of listener) {
+    handleConn(conn)
+      .catch((e) => console.error("Failed serving a connection:", e));
+  }
 }

--- a/tests/fixture/README.md
+++ b/tests/fixture/README.md
@@ -2,16 +2,10 @@
 
 ### Usage
 
-Install deployctl:
-
-```
-deno install --allow-read --allow-write --allow-env --allow-net --allow-run --no-check -r -f https://deno.land/x/deploy/deployctl.ts
-```
-
 Start the project:
 
 ```
-deployctl run --no-check --watch main.ts
+deno run -A --unstable --config tsconfig.json --watch main.ts
 ```
 
 After adding, removing, or moving a page in the `pages` directory, run:


### PR DESCRIPTION
Deno Deploy now supports Deno.listen and Deno.serveHttp.
