### PR TITLE
chore: use esm.sh + optionally use native esbuild

### DIFF
--- a/src/runtime/deps.ts
+++ b/src/runtime/deps.ts
@@ -1,4 +1,4 @@
-export * from "https://x.lcas.dev/preact@10.5.11/mod.js";
+export * from "https://esm.sh/preact@10.5.14";
 export {
   useCallback,
   useContext,
@@ -11,7 +11,7 @@ export {
   useReducer,
   useRef,
   useState,
-} from "https://x.lcas.dev/preact@10.5.11/hooks.js";
+} from "https://esm.sh/preact@10.5.14/hooks";
 export type {
   CreateHandle,
   EffectCallback,
@@ -20,4 +20,4 @@ export type {
   Reducer,
   Ref,
   StateUpdater,
-} from "https://x.lcas.dev/preact@10.5.11/hooks.js";
+} from "https://esm.sh/preact@10.5.14/hooks";

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -1,17 +1,22 @@
 // -- preact --
-export { renderToString } from "https://x.lcas.dev/preact@10.5.11/ssr.js";
+export { renderToString } from "https://esm.sh/preact-render-to-string@5.1.19?deps=preact@10.5.14";
 
 // -- std --
-export { extname } from "https://deno.land/std@0.102.0/path/mod.ts";
+export { extname } from "https://deno.land/std@0.108.0/path/mod.ts";
 
 // -- router --
 export * as router from "https://crux.land/router@0.0.4";
 
 // -- media types --
-export { lookup as mediaTypeLookup } from "https://deno.land/x/media_types@v2.9.3/mod.ts";
+export { lookup as mediaTypeLookup } from "https://deno.land/x/media_types@v2.10.2/mod.ts";
 
 // -- esbuild --
 // @deno-types="https://unpkg.com/esbuild-wasm@0.11.19/esm/browser.d.ts"
-import * as esbuild from "https://gist.githubusercontent.com/lucacasonato/358c6b7e8198bfb2cf3d220e49fdcf5f/raw/3714cb0f59606eefc29ed0fea36d4cd93549938b/esbuild-wasm.js";
-export { esbuild };
+import * as esbuildWasm from "https://gist.githubusercontent.com/lucacasonato/358c6b7e8198bfb2cf3d220e49fdcf5f/raw/3714cb0f59606eefc29ed0fea36d4cd93549938b/esbuild-wasm.js";
+import * as esbuildNative from "https://deno.land/x/esbuild@v0.13.2/mod.js";
+// @ts-ignore trust me
+const esbuild: typeof esbuildWasm = Deno.run === undefined
+  ? esbuildWasm
+  : esbuildNative;
+export { esbuild, esbuildWasm as esbuildTypes };
 export { denoPlugin } from "https://deno.land/x/esbuild_deno_loader@0.3.0/mod.ts";


### PR DESCRIPTION
`preact` and `preact-render-to-string` are now imported from esm.sh.

Additionally, the native binary build of esbuild will now be used in
deno cli to speed up bundle times.
