### PR TITLE
BREAKING: disable runtime JS by default

### DIFF
--- a/example/pages/index.tsx
+++ b/example/pages/index.tsx
@@ -2,7 +2,7 @@
 
 import { RoundedButton } from "../components/Button.tsx";
 import { IconMinus, IconPlus } from "../components/Icons.tsx";
-import { h, IS_BROWSER, tw, useState } from "../deps.ts";
+import { h, IS_BROWSER, PageConfig, tw, useState } from "../deps.ts";
 
 export default function Home() {
   return (
@@ -43,3 +43,5 @@ function Counter() {
     </div>
   );
 }
+
+export const config: PageConfig = { runtimeJS: true };

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -21,12 +21,12 @@ export interface PageConfig {
   /**
    * By default, runtime JS is disabled. This means that interactivity on the
    * client that depends on Preact or other JS code will not function.
-   * 
+   *
    * Runtime JS can be enabled by setting `runtimeJS` to `true`.
-   * 
+   *
    * It is recommended to keep runtime JavaScript disabled for static pages that
    * do not require interactivity, like marketing or blog pages.
-   * 
+   *
    * Note that the runtime JS feature will likely be overhauled in the future to
    * provide more granular control over which components need to be hydrated on
    * the client.

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -19,13 +19,17 @@ export interface PageProps {
 
 export interface PageConfig {
   /**
-   * Setting this flag to `false` disables all client side runtime JS. This
-   * means that all interactivity on the client that depends on Preact or other
-   * JS code will not function. This option is set to `true` (runtime javascript
-   * is enabled) by default.
-   *
-   * It is recommended to disable runtime JavaScript for static pages that do
-   * not require interactivity, like marketing or blog pages.
+   * By default, runtime JS is disabled. This means that interactivity on the
+   * client that depends on Preact or other JS code will not function.
+   * 
+   * Runtime JS can be enabled by setting `runtimeJS` to `true`.
+   * 
+   * It is recommended to keep runtime JavaScript disabled for static pages that
+   * do not require interactivity, like marketing or blog pages.
+   * 
+   * Note that the runtime JS feature will likely be overhauled in the future to
+   * provide more granular control over which components need to be hydrated on
+   * the client.
    */
   runtimeJS?: boolean;
 }

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -59,7 +59,7 @@ export class ServerContext {
           name,
           component,
           handler,
-          runtimeJS: config?.runtimeJS ?? true,
+          runtimeJS: config?.runtimeJS ?? false,
         };
         pages.push(page);
       } else if (

--- a/tests/fixture/pages/[name].tsx
+++ b/tests/fixture/pages/[name].tsx
@@ -1,6 +1,6 @@
 /** @jsx h */
 
-import { h } from "../deps.ts";
+import { h, PageConfig } from "../deps.ts";
 
 interface Props {
   params: Record<string, string | string[]>;
@@ -9,3 +9,5 @@ interface Props {
 export default function Greet(props: Props) {
   return <div>Hello {props.params.name}</div>;
 }
+
+export const config: PageConfig = { runtimeJS: true };

--- a/tests/fixture/pages/index.tsx
+++ b/tests/fixture/pages/index.tsx
@@ -1,6 +1,6 @@
 /** @jsx h */
 
-import { h, IS_BROWSER, useData } from "../deps.ts";
+import { h, IS_BROWSER, PageConfig, useData } from "../deps.ts";
 
 export default function Home() {
   const message = useData("home", (key) => {
@@ -15,3 +15,5 @@ export default function Home() {
     </div>
   );
 }
+
+export const config: PageConfig = { runtimeJS: true };

--- a/tests/fixture/pages/props/[id].tsx
+++ b/tests/fixture/pages/props/[id].tsx
@@ -1,7 +1,9 @@
 /** @jsx h */
 
-import { h, PageProps } from "../../deps.ts";
+import { h, PageConfig, PageProps } from "../../deps.ts";
 
 export default function Home(props: PageProps) {
   return <div>{JSON.stringify(props)}</div>;
 }
+
+export const config: PageConfig = { runtimeJS: true };

--- a/tests/fixture/pages/static.tsx
+++ b/tests/fixture/pages/static.tsx
@@ -1,9 +1,7 @@
 /** @jsx h */
 
-import { h, PageConfig } from "../deps.ts";
+import { h } from "../deps.ts";
 
 export default function StaticPage() {
   return <p>This is a static page.</p>;
 }
-
-export const config: PageConfig = { runtimeJS: false };


### PR DESCRIPTION
This commit disables runtime JS by default. This stems from the observation that most pages are static, and thus do not need runtime JS.