### PR TITLE
Fix build on windows

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -64,7 +64,7 @@ async function init(directory: string) {
   )}";\n`;
   await Deno.writeTextFile(join(directory, "deps.ts"), DEPS_TS);
   const PAGES_INDEX_TSX = `/** @jsx h */
-import { h, IS_BROWSER, useState } from "../deps.ts";
+import { h, IS_BROWSER, PageConfig, useState } from "../deps.ts";
 
 export default function Home() {
   return (
@@ -93,6 +93,9 @@ function Counter() {
     </div>
   );
 }
+
+export const config: PageConfig = { runtimeJS: true };
+
 `;
   await Deno.writeTextFile(
     join(directory, "pages", "index.tsx"),

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -44,8 +44,8 @@ export class Bundler {
       format: "esm",
       metafile: true,
       minify: true,
-      outdir: '.',
-      // This is requried to ensure the format of the outputFiles path is the same 
+      outdir: ".",
+      // This is requried to ensure the format of the outputFiles path is the same
       // between windows and linux
       absWorkingDir,
       outfile: "",
@@ -69,7 +69,10 @@ export class Bundler {
     const cache = new Map<string, Uint8Array>();
     const absDirUrlLength = toFileUrl(absWorkingDir).href.length;
     for (const file of bundle.outputFiles) {
-      cache.set(toFileUrl(file.path).href.substring(absDirUrlLength), file.contents);
+      cache.set(
+        toFileUrl(file.path).href.substring(absDirUrlLength),
+        file.contents,
+      );
     }
     this.#cache = cache;
 
@@ -88,8 +91,6 @@ export class Bundler {
 
   async get(path: string): Promise<Uint8Array | null> {
     const cache = await this.cache();
-    console.log('path', path)
-    console.log('cache', cache)
     return cache.get(path) ?? null;
   }
 

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -1,4 +1,4 @@
-import { denoPlugin, esbuild, esbuildTypes } from "./deps.ts";
+import { denoPlugin, esbuild, esbuildTypes, toFileUrl } from "./deps.ts";
 import { Page } from "./types.ts";
 
 let esbuildInitalized: boolean | Promise<void> = false;
@@ -36,7 +36,7 @@ export class Bundler {
         entryPoints[page.name] = `fresh:///${page.name}`;
       }
     }
-
+    const absWorkingDir = Deno.cwd();
     await ensureEsbuildInialized();
     const bundle = await esbuild.build({
       bundle: true,
@@ -44,7 +44,10 @@ export class Bundler {
       format: "esm",
       metafile: true,
       minify: true,
-      outdir: `/`,
+      outdir: '.',
+      // This is requried to ensure the format of the outputFiles path is the same 
+      // between windows and linux
+      absWorkingDir,
       outfile: "",
       platform: "neutral",
       plugins: [freshPlugin(this.#pages), denoPlugin()],
@@ -53,7 +56,6 @@ export class Bundler {
       treeShaking: true,
       write: false,
     });
-
     const metafileOutputs = bundle.metafile!.outputs;
 
     for (const path in metafileOutputs) {
@@ -65,8 +67,9 @@ export class Bundler {
     }
 
     const cache = new Map<string, Uint8Array>();
+    const absDirUrlLength = toFileUrl(absWorkingDir).href.length;
     for (const file of bundle.outputFiles) {
-      cache.set(file.path, file.contents);
+      cache.set(toFileUrl(file.path).href.substring(absDirUrlLength), file.contents);
     }
     this.#cache = cache;
 
@@ -85,6 +88,8 @@ export class Bundler {
 
   async get(path: string): Promise<Uint8Array | null> {
     const cache = await this.cache();
+    console.log('path', path)
+    console.log('cache', cache)
     return cache.get(path) ?? null;
   }
 


### PR DESCRIPTION
Fix https://github.com/lucacasonato/fresh/issues/63

The issue is that on windows the bundle.outputFiles path are absolute path, while on linux they are relative path.
So on windows the url path do not match the bundle cache path.

I have made esbuild output absolute path from for both linux and windows, based on cwd, then the cache keys are recalculated by removing the cwd path. (similar to the route gen)

tested on windows and linux.
external ref:
https://github.com/evanw/esbuild/blob/9e569c40f9f642139c59372e7321d90baeb507c1/internal/bundler/bundler.go#L1810
https://pkg.go.dev/path/filepath#Join
