### PR TITLE
feat: add support for `<Head>` component

### DIFF
--- a/runtime.ts
+++ b/runtime.ts
@@ -3,3 +3,4 @@ export * from "./src/runtime/types.ts";
 export * from "./src/runtime/suspense.ts";
 export * from "./src/runtime/utils.ts";
 export * from "./src/runtime/hooks.ts";
+export * from "./src/runtime/head.ts";

--- a/src/runtime/head.ts
+++ b/src/runtime/head.ts
@@ -1,0 +1,20 @@
+import { ComponentChildren, createContext, useContext } from "./deps.ts";
+
+export interface HeadProps {
+  children: ComponentChildren;
+}
+
+export const HEAD_CONTEXT = createContext<ComponentChildren[]>([]);
+
+export function Head(props: HeadProps) {
+  let context: ComponentChildren[];
+  try {
+    context = useContext(HEAD_CONTEXT);
+  } catch {
+    throw new Error(
+      "<Head> component is not supported in the browser, or during suspense renders.",
+    );
+  }
+  context.push(props.children);
+  return null;
+}

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -159,8 +159,15 @@ export class ServerContext {
           });
           const bodyStream = new ReadableStream<Uint8Array>({
             async start(controller) {
-              for await (const chunk of body) {
-                controller.enqueue(new TextEncoder().encode(chunk));
+              try {
+                for await (const chunk of body) {
+                  controller.enqueue(new TextEncoder().encode(chunk));
+                }
+              } catch (err) {
+                console.log("Rendering failed:\n", err);
+                controller.enqueue(
+                  new TextEncoder().encode("500 Internal Server Error"),
+                );
               }
               controller.close();
             },

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -1,11 +1,14 @@
 /** @jsx h */
 /** @jsxFrag Fragment */
 
-import { Fragment, h, tw } from "../deps.ts";
+import { Fragment, h, Head, tw } from "../deps.ts";
 
 export default function MainPage() {
   return (
     <>
+      <Head>
+        <title>fresh - The next-gen web framework.</title>
+      </Head>
       <Hero />
       <NavigationBar active="/" />
       <Intro />


### PR DESCRIPTION
This component only works during SSR, during the inital render. It does
not work on renders inside a suspense boundary, or client renders.

Closes #31
