### PR TITLE
feat: stream static files

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,4 +8,4 @@ test:
 	deno test -A --no-check
 
 dev:
-	deno run -A --watch --no-check www/main.ts
+	deno run -A --watch=www/static --no-check www/main.ts


### PR DESCRIPTION
This commit adds support for streaming static files. Instead of them
being fully buffered in memory, they are now streamed directly to the
client.
