### PR TITLE
Feat: Exclude useData fetcher code from the client bundle

### DIFF
--- a/docs/data-fetching.md
+++ b/docs/data-fetching.md
@@ -23,7 +23,9 @@ Here is a usage example of a `useData` hook where the fetcher fetches the URL
 provided as the key as JSON:
 
 ```tsx
+// ./pages/index.tsx
 import { h, PageProps, useData } from "../deps.ts";
+import { fetcher } from "../server_lib/db.ts"
 
 export default function Page(_props: PageProps) {
   const info = useData("https://cdn.deno.land/std/meta/versions.json", fetcher);
@@ -41,13 +43,16 @@ export default function Page(_props: PageProps) {
     </p>
   );
 }
+```
 
+```tsx
+// ./server_lib/db.ts 
 interface ModuleInfo {
   latest: string;
   versions: string[];
 }
 
-async function fetcher(url: string): Promise<ModuleInfo | null> {
+export async function fetcher(url: string): Promise<ModuleInfo | null> {
   const resp = await fetch(url);
   if (resp.status === 200) return resp.json();
   return null;
@@ -57,3 +62,7 @@ async function fetcher(url: string): Promise<ModuleInfo | null> {
 The `useData` can not generate data client side. Calling `useData` on the client
 with a key that no data was generated for on the server will result in `useData`
 throwing an error.
+
+For reducing client bundle size and security, it is recommended to exclude the `fetcher` function code from the client bundle. To do that, the `fetcher` function must be:
+- Imported from inside a folder called `server_lib`
+- Imported as a name import called `fetcher`

--- a/docs/data-fetching.md
+++ b/docs/data-fetching.md
@@ -25,7 +25,7 @@ provided as the key as JSON:
 ```tsx
 // ./pages/index.tsx
 import { h, PageProps, useData } from "../deps.ts";
-import { fetcher } from "../server_lib/db.ts"
+import { fetcher } from "../server_lib/db.ts";
 
 export default function Page(_props: PageProps) {
   const info = useData("https://cdn.deno.land/std/meta/versions.json", fetcher);
@@ -46,7 +46,7 @@ export default function Page(_props: PageProps) {
 ```
 
 ```tsx
-// ./server_lib/db.ts 
+// ./server_lib/db.ts
 interface ModuleInfo {
   latest: string;
   versions: string[];
@@ -63,6 +63,9 @@ The `useData` can not generate data client side. Calling `useData` on the client
 with a key that no data was generated for on the server will result in `useData`
 throwing an error.
 
-For reducing client bundle size and security, it is recommended to exclude the `fetcher` function code from the client bundle. To do that, the `fetcher` function must be:
+For reducing client bundle size and security, it is recommended to exclude the
+`fetcher` function code from the client bundle. To do that, the `fetcher`
+function must be:
+
 - Imported from inside a folder called `server_lib`
 - Imported as a name import called `fetcher`

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -149,6 +149,15 @@ addEventListener("DOMContentLoaded", () => {
           return { contents, loader: "js" };
         },
       );
-    },
+
+      // exclude code located in server_lib from the bundle
+      build.onLoad(
+        { filter: /.*\/server_lib*/ }, 
+        function onLoad(): esbuildTypes.OnLoadResult | null | undefined {
+          const contents = `export const fetcher = () => {}`
+          return { contents, loader: "ts" };
+        },
+      )
+    },  
   };
 }

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -152,12 +152,12 @@ addEventListener("DOMContentLoaded", () => {
 
       // exclude code located in server_lib from the bundle
       build.onLoad(
-        { filter: /.*\/server_lib*/ }, 
+        { filter: /.*\/server_lib*/ },
         function onLoad(): esbuildTypes.OnLoadResult | null | undefined {
-          const contents = `export const fetcher = () => {}`
+          const contents = `export const fetcher = () => {}`;
           return { contents, loader: "ts" };
         },
-      )
-    },  
+      );
+    },
   };
 }

--- a/src/server/render.tsx
+++ b/src/server/render.tsx
@@ -196,7 +196,7 @@ export async function* render(
     props: PageProps;
     data?: [string, unknown][];
   } | undefined = { props, data: [...dataCache.entries()] };
-  if (templateProps.data!.length === 0) {
+  if (templateProps?.data!.length === 0) {
     delete templateProps.data;
   }
 

--- a/src/server/render.tsx
+++ b/src/server/render.tsx
@@ -204,7 +204,7 @@ export async function* render(
     props: PageProps | UnknownPageProps | ErrorPageProps;
     data?: [string, unknown][];
   } | undefined = { props, data: [...dataCache.entries()] };
-  if (templateProps?.data!.length === 0) {
+  if (templateProps.data!.length === 0) {
     delete templateProps.data;
   }
 

--- a/tests/fixture/client_lib/unsecureFetcher.ts
+++ b/tests/fixture/client_lib/unsecureFetcher.ts
@@ -1,7 +1,6 @@
-
 export const publicFetcher = (_key: string) => {
-  const _apiKey = 'public_key'
+  const _apiKey = "public_key";
   return new Promise<string>((resolve) => {
     setTimeout(() => resolve("Hello!"), 100);
   });
-}
+};

--- a/tests/fixture/client_lib/unsecureFetcher.ts
+++ b/tests/fixture/client_lib/unsecureFetcher.ts
@@ -1,0 +1,7 @@
+
+export const publicFetcher = (_key: string) => {
+  const _apiKey = 'public_key'
+  return new Promise<string>((resolve) => {
+    setTimeout(() => resolve("Hello!"), 100);
+  });
+}

--- a/tests/fixture/pages/index.tsx
+++ b/tests/fixture/pages/index.tsx
@@ -1,16 +1,16 @@
 /** @jsx h */
 
+import { publicFetcher } from "../client_lib/unsecureFetcher.ts";
 import { h, IS_BROWSER, PageConfig, useData } from "../deps.ts";
+import { fetcher } from "../server_lib/call_db.ts";
 
 export default function Home() {
-  const message = useData("home", (key) => {
-    return new Promise<string>((resolve) => {
-      setTimeout(() => resolve("Hello!"), 100);
-    });
-  });
+  const message = useData("home", publicFetcher);
+  const message2 = useData("home2", fetcher);
   return (
     <div>
       <p>{message}</p>
+      <p>{message2}</p>
       <p>{IS_BROWSER ? "Viewing browser render." : "Viewing JIT render."}</p>
     </div>
   );

--- a/tests/fixture/server_lib/call_db.ts
+++ b/tests/fixture/server_lib/call_db.ts
@@ -1,8 +1,8 @@
 function callDB(): Promise<string> {
-  const _privateApiKey = 'super_secret_key'
+  const _privateApiKey = "super_secret_key";
   return new Promise((resolve) => {
-    setTimeout(() => resolve('called db with secret'), 5)
-  })
+    setTimeout(() => resolve("called db with secret"), 5);
+  });
 }
 
 export async function fetcher(_url: string): Promise<string | null> {

--- a/tests/fixture/server_lib/call_db.ts
+++ b/tests/fixture/server_lib/call_db.ts
@@ -1,0 +1,11 @@
+function callDB(): Promise<string> {
+  const _privateApiKey = 'super_secret_key'
+  return new Promise((resolve) => {
+    setTimeout(() => resolve('called db with secret'), 5)
+  })
+}
+
+export async function fetcher(_url: string): Promise<string | null> {
+  const resp = await callDB();
+  return resp;
+}

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -36,6 +36,7 @@ Deno.test("/ page prerender", async () => {
   const jsPath = body.match(/script src=\"(\/_frsh\/js\/.*?)\"/)?.[1]
   assert(jsPath)
 
+  // retrieve the bundle
   const respJs = await router(
     new Request(`https://fresh.deno.dev${jsPath}`, {
       method: "GET",
@@ -48,10 +49,13 @@ Deno.test("/ page prerender", async () => {
   assert(!respJsBody.includes('super_secret_key'))
 
   // somehow some resources are left open
-  // didn't manage to exactly find them
-  Deno.close(6)
-  Deno.close(7)
-  Deno.close(8)
+  // not sure which one
+  // forcely closing them
+  for ( const [key, value] of Object.entries(Deno.resources())){
+    if (value.includes('child')) {
+      Deno.close(+key)
+    }
+  }
 });
 
 Deno.test("/props/123 page prerender", async () => {

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -26,34 +26,33 @@ Deno.test("/ page prerender", async () => {
     `"data":[["home","Hello!"],["home2","called db with secret"]]`,
   );
 
-
   /**
    * test that the code located under server_lib
    * is not included in the bundle
    */
-  
+
   // capture the address of the js script
-  const jsPath = body.match(/script src=\"(\/_frsh\/js\/.*?)\"/)?.[1]
-  assert(jsPath)
+  const jsPath = body.match(/script src=\"(\/_frsh\/js\/.*?)\"/)?.[1];
+  assert(jsPath);
 
   // retrieve the bundle
   const respJs = await router(
     new Request(`https://fresh.deno.dev${jsPath}`, {
       method: "GET",
-      headers: { "accept": "*/*" }
+      headers: { "accept": "*/*" },
     }),
   );
 
-  const respJsBody = await respJs.text()
-  assert(respJsBody.includes('public_key'))
-  assert(!respJsBody.includes('super_secret_key'))
+  const respJsBody = await respJs.text();
+  assert(respJsBody.includes("public_key"));
+  assert(!respJsBody.includes("super_secret_key"));
 
   // somehow some resources are left open
   // not sure which one
   // forcely closing them
-  for ( const [key, value] of Object.entries(Deno.resources())){
-    if (value.includes('child')) {
-      Deno.close(+key)
+  for (const [key, value] of Object.entries(Deno.resources())) {
+    if (value.includes("child")) {
+      Deno.close(+key);
     }
   }
 });


### PR DESCRIPTION
This is an attempt at resolving https://github.com/lucacasonato/fresh/issues/65 by excluding code located under a specific `server_lib` folder from the client bundle.

