### PR TITLE
Fix default port number in docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ The `--watch` option will cause your script to be reloaded on any changes to the
 source. If you do not want this you can omit the `--watch` option.
 
 After you have started the project, you can view it in your browser at
-http://localhost:8080. You will first get served a JIT server rendered page,
+http://localhost:8000. You will first get served a JIT server rendered page,
 which will get hydrated using client side JS after a few moments.
 
 ## Deploying the project to Deno Deploy


### PR DESCRIPTION
Despite #50, the Markdown docs still says 8080 instead of 8000 :(