### PR TITLE
refactor: improved reviving of islands

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,4 +8,4 @@ test:
 	deno test -A --no-check=remote
 
 dev:
-	deno run -A --watch=www/static --no-check www/main.ts
+	deno run -A --watch=www/static,src/ --no-check www/main.ts

--- a/src/runtime/main.ts
+++ b/src/runtime/main.ts
@@ -1,0 +1,58 @@
+import { ComponentType, h, render } from "./deps.ts";
+
+function createRootFragment(
+  parent: Element,
+  replaceNode: Node | Node[],
+) {
+  replaceNode = ([] as Node[]).concat(replaceNode);
+  const s = replaceNode[replaceNode.length - 1].nextSibling;
+  function insert(c: Node, r: Node) {
+    parent.insertBefore(c, r || s);
+  }
+  // @ts-ignore this is fine
+  return parent.__k = {
+    nodeType: 1,
+    parentNode: parent,
+    firstChild: replaceNode[0],
+    childNodes: replaceNode,
+    insertBefore: insert,
+    appendChild: insert,
+    removeChild: function (c: Node) {
+      parent.removeChild(c);
+    },
+  };
+}
+
+const ISLAND_PROPS_COMPONENT = document.getElementById("__FRSH_ISLAND_PROPS");
+// deno-lint-ignore no-explicit-any
+const ISLAND_PROPS: any[] = JSON.parse(
+  ISLAND_PROPS_COMPONENT?.textContent ?? "[]",
+);
+
+export function revive(islands: Record<string, ComponentType>) {
+  function walk(node: Node | null) {
+    const tag = node!.nodeType === 8 &&
+      ((node as Comment).data.match(/^\s*frsh-(.*)\s*$/) || [])[1];
+    if (tag) {
+      const children = [];
+      const parent = node!.parentNode;
+      while ((node = node!.nextSibling) && node.nodeType !== 8) {
+        children.push(node);
+      }
+      const [id, n] = tag.split(":");
+      render(
+        h(islands[id], ISLAND_PROPS[Number(n)]),
+        createRootFragment(
+          parent! as HTMLElement,
+          children,
+          // deno-lint-ignore no-explicit-any
+        ) as any as HTMLElement,
+      );
+    }
+    const sib = node!.nextSibling;
+    if (sib) walk(sib as Comment);
+    const fc = node!.firstChild;
+    if (fc) walk(fc as Comment);
+  }
+  walk(document.body);
+}

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -5,6 +5,10 @@ export const BUILD_ID = Deno.env.get("DENO_DEPLOYMENT_ID") ||
   crypto.randomUUID();
 export const JS_PREFIX = `/js`;
 
+export function bundleAssetUrl(path: string) {
+  return `${INTERNAL_PREFIX}${JS_PREFIX}/${BUILD_ID}${path}`;
+}
+
 declare global {
   interface Crypto {
     randomUUID(): string;

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -8,7 +8,12 @@ import {
 } from "./deps.ts";
 import { Manifest } from "./mod.ts";
 import { Bundler } from "./bundle.ts";
-import { ALIVE_URL, INTERNAL_PREFIX, REFRESH_JS_URL } from "./constants.ts";
+import {
+  ALIVE_URL,
+  bundleAssetUrl,
+  INTERNAL_PREFIX,
+  REFRESH_JS_URL,
+} from "./constants.ts";
 import { JS_PREFIX } from "./constants.ts";
 import { BUILD_ID } from "./constants.ts";
 import {
@@ -294,7 +299,7 @@ export class ServerContext {
       page: Page<Data> | UnknownPage | ErrorPage,
       status: number,
     ) => {
-      const imports: string[] = [];
+      const imports: string[] = [bundleAssetUrl("/main.js")];
       if (this.#dev) {
         imports.push(REFRESH_JS_URL);
       }

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -16,10 +16,7 @@ Deno.test("/ page prerender", async () => {
   assertStringIncludes(body, "test.js");
   assertStringIncludes(body, "<p>Hello!</p>");
   assertStringIncludes(body, "<p>Viewing JIT render.</p>");
-  assertStringIncludes(
-    body,
-    `props="{&quot;message&quot;:&quot;Hello!&quot;}">`,
-  );
+  assertStringIncludes(body, `>[{"message":"Hello!"}]</script>`);
   assertStringIncludes(
     body,
     `<meta name="description" content="Hello world!" />`,


### PR DESCRIPTION
This commit improves how islands are revived. No more "foreign" elements are inserted into the HTML tree. Instead, the insertion points for islands are marked with HTML comments.
