### PR TITLE
chore: fix `fresh init`

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -132,7 +132,7 @@ export default function Greet(props: PageProps) {
   );
 
   const ROUTES_API_JOKE_TS =
-    `import { HandlerContext } from "../server_deps.ts";
+    `import { HandlerContext } from "../../server_deps.ts";
 
 // Jokes courtesy of https://punsandoneliners.com/randomness/programmer-jokes/
 const JOKES = [


### PR DESCRIPTION
This commit fixes an import in one of the files generated by
`fresh init`.

Fixes #102
