### PR TITLE
chore: remove deprecated runtimeJS option

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -53,21 +53,6 @@ export interface ErrorPageProps {
 
 export interface PageConfig {
   /**
-   * By default, runtime JS is disabled. This means that interactivity on the
-   * client that depends on Preact or other JS code will not function.
-   *
-   * Runtime JS can be enabled by setting `runtimeJS` to `true`.
-   *
-   * It is recommended to keep runtime JavaScript disabled for static pages that
-   * do not require interactivity, like marketing or blog pages.
-   *
-   * Note that the runtime JS feature will likely be overhauled in the future to
-   * provide more granular control over which components need to be hydrated on
-   * the client.
-   */
-  runtimeJS?: boolean;
-
-  /**
    * A route override for the page. This is useful for pages where the route
    * can not be expressed through the filesystem routing capabilities.
    *

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -154,7 +154,6 @@ export class ServerContext {
           name,
           component,
           handler: handler ?? ((req) => router.defaultOtherHandler(req)),
-          runtimeJS: Boolean(config?.runtimeJS ?? false),
           csp: Boolean(config?.csp ?? false),
         };
       } else if (
@@ -174,7 +173,6 @@ export class ServerContext {
           component,
           handler: handler ??
             ((req, ctx) => router.defaultErrorHandler(req, ctx.error)),
-          runtimeJS: Boolean(config?.runtimeJS ?? false),
           csp: Boolean(config?.csp ?? false),
         };
       }
@@ -502,7 +500,6 @@ const DEFAULT_NOT_FOUND: UnknownPage = {
   url: "",
   name: "_404",
   handler: (req) => router.defaultOtherHandler(req),
-  runtimeJS: false,
   csp: false,
 };
 
@@ -511,7 +508,6 @@ const DEFAULT_ERROR: ErrorPage = {
   url: "",
   name: "_500",
   handler: (req, ctx) => router.defaultErrorHandler(req, ctx.error),
-  runtimeJS: false,
   csp: false,
 };
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -85,7 +85,6 @@ export interface UnknownPage {
   name: string;
   component?: ComponentType<UnknownPageProps>;
   handler: UnknownHandler;
-  runtimeJS: boolean;
   csp: boolean;
 }
 
@@ -95,7 +94,6 @@ export interface ErrorPage {
   name: string;
   component?: ComponentType<ErrorPageProps>;
   handler: ErrorHandler;
-  runtimeJS: boolean;
   csp: boolean;
 }
 


### PR DESCRIPTION
`PageConfig['runtimeJS']` was made irrelevant by #97.

Fixes #119