### PR TITLE
fix: 128 routes/[id]/[path] catches request for _frsh/refresh.js

### DIFF
--- a/tests/error_test.ts
+++ b/tests/error_test.ts
@@ -1,4 +1,5 @@
 import { ServerContext } from "../server.ts";
+import { REFRESH_JS_URL } from "../src/server/constants.ts";
 import { assert, assertEquals, assertStringIncludes } from "./deps.ts";
 import manifest from "./fixture_error/fresh.gen.ts";
 
@@ -30,4 +31,15 @@ Deno.test("error page rendered", async () => {
   );
   assertStringIncludes(body, `Error: boom!`);
   assertStringIncludes(body, `at render`);
+});
+Deno.test("refresh.js rendered", async () => {
+  const resp = await router(
+    new Request("https://fresh.deno.dev" + REFRESH_JS_URL),
+  );
+  assert(resp);
+  assertEquals(resp.status, 200);
+  assertEquals(
+    resp.headers.get("content-type"),
+    "application/javascript; charset=utf-8",
+  );
 });

--- a/tests/fixture_error/fresh.gen.ts
+++ b/tests/fixture_error/fresh.gen.ts
@@ -3,10 +3,12 @@
 // To update this file, run `fresh manifest`.
 
 import * as $0 from "./routes/index.tsx";
+import * as $1 from "./routes/[...all].ts";
 
 const manifest = {
   routes: {
     "./routes/index.tsx": $0,
+    "./routes/[...all].ts": $1,
   },
   islands: {},
   baseUrl: import.meta.url,

--- a/tests/fixture_error/routes/[...all].ts
+++ b/tests/fixture_error/routes/[...all].ts
@@ -1,0 +1,7 @@
+import { Handlers } from "../../../server.ts";
+
+export const handler: Handlers = {
+  GET(_req, ctx) {
+    return new Response(ctx.params.all);
+  },
+};


### PR DESCRIPTION
Fixes #128
Requests with INTERNAL_PREFIX should be handled before all other routes.