### PR TITLE
www: cache static assets properly

### DIFF
--- a/www/routes/docs/[...slug].tsx
+++ b/www/routes/docs/[...slug].tsx
@@ -1,7 +1,15 @@
 /** @jsx h */
 /** @jsxFrag Fragment */
 
-import { apply, Fragment, h, Head, PageProps, tw } from "../../client_deps.ts";
+import {
+  apply,
+  asset,
+  Fragment,
+  h,
+  Head,
+  PageProps,
+  tw,
+} from "../../client_deps.ts";
 import { gfm, Handlers } from "../../server_deps.ts";
 import DocsSidebar from "../../components/DocsSidebar.tsx";
 import Footer from "../../components/Footer.tsx";
@@ -49,7 +57,7 @@ export default function DocsPage(props: PageProps<Data>) {
     <>
       <Head>
         <title>{props.data.page?.title ?? "Not Found"} | fresh docs</title>
-        <link rel="stylesheet" href="/gfm.css" />
+        <link rel="stylesheet" href={`/gfm.css?build=${__FRSH_BUILD_ID}`} />
       </Head>
       <Header />
       <NavigationBar active="/docs" />
@@ -62,7 +70,12 @@ export default function DocsPage(props: PageProps<Data>) {
 function Logo() {
   return (
     <a href="/" class={tw`flex mr-2`}>
-      <img src="/fresh-logo.svg" alt="Fresh logo" width={40} height={40} />
+      <img
+        src={asset("/fresh-logo.svg")}
+        alt="Fresh logo"
+        width={40}
+        height={40}
+      />
     </a>
   );
 }

--- a/www/routes/gfm.css.ts
+++ b/www/routes/gfm.css.ts
@@ -40,6 +40,7 @@ export const handler: Handlers = {
     return new Response(CSS, {
       headers: {
         "content-type": "text/css",
+        "cache-control": "public, max-age=31536000, immutable",
       },
     });
   },

--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -1,7 +1,14 @@
 /** @jsx h */
 /** @jsxFrag Fragment */
 
-import { asset, ComponentChildren, Fragment, h, Head, tw } from "../client_deps.ts";
+import {
+  asset,
+  ComponentChildren,
+  Fragment,
+  h,
+  Head,
+  tw,
+} from "../client_deps.ts";
 import Counter from "../islands/Counter.tsx";
 import LemonDrop from "../islands/LemonDrop.tsx";
 import Footer from "../components/Footer.tsx";

--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 /** @jsxFrag Fragment */
 
-import { ComponentChildren, Fragment, h, Head, tw } from "../client_deps.ts";
+import { asset, ComponentChildren, Fragment, h, Head, tw } from "../client_deps.ts";
 import Counter from "../islands/Counter.tsx";
 import LemonDrop from "../islands/LemonDrop.tsx";
 import Footer from "../components/Footer.tsx";
@@ -71,7 +71,7 @@ function Intro() {
       class={tw`max-w-screen-sm mx-auto my-16 px(4 sm:6 md:8) space-y-4`}
     >
       <img
-        src="/illust.jpeg"
+        src={asset("/illust.jpeg")}
         class={tw`w-64 mx-auto`}
         width={256}
         height={217}


### PR DESCRIPTION
Uses the `asset` function to cache the logo and illustration on the website home
page.