### PR TITLE
fix: update start task with no-check

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -188,7 +188,7 @@ await start(manifest);
 
   const DENO_CONFIG = `{
   "tasks": {
-    "start": "deno run -A --watch main.ts"
+    "start": "deno run -A --watch --no-check main.ts"
   }
 }`;
 


### PR DESCRIPTION
The default task `start` fails to run as a remote dependency has a type issue.  This provides a poor experience to first time users who may struggle to understand why the default example doesn't work.  This issue is resolved by adding the `--no-check` flag to the deno run command.