### PR TITLE
fix: Remove conflicting global definition of URLPattern

### DIFF
--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -20,7 +20,4 @@ declare global {
 
   // deno-lint-ignore no-var
   var __FRSH_BUILD_ID: string;
-
-  // deno-lint-ignore no-explicit-any no-var
-  var URLPattern: any;
 }


### PR DESCRIPTION
Fixes https://github.com/lucacasonato/fresh/issues/182

After removing the _hacky_ global definition of URLPattern (now built-in with Deno v1.21.2), seems to work fine

![image](https://user-images.githubusercontent.com/38158676/167292060-9dc61379-6ea4-49f6-a13a-83dd2917751c.png)
