### PR TITLE
feat: Automatically apply asset caching to img src URLs

### DIFF
--- a/docs/concepts/static-files.md
+++ b/docs/concepts/static-files.md
@@ -1,22 +1,48 @@
 > TODO(lucacasonato): this page still needs to be completed
 
-Static assets should be located under the `./static` directory. To reference a
-static file in your code, use the path relative to the static folder, prefixed
-by a `/`. For example, for a file called `user.png` located inside the static
-folder, the jsx is:
+Fresh automatically serves static assets placed in a `static/` directory in the
+project root. These assets are served at the root of the webserver, with a
+higher priority than routes. This means that if a given request matches a file
+in the `static/` folder, it is always served, even if there is a route that
+would also match the request.
+
+Static asset responses automatically get a `content-type` header assigned based
+on the file extension of the file on disk. Assets are also automatically
+streamed from disk to the client to improve performance and efficiency for both
+user and server.
+
+Fresh also adds an `etag` header to assets automatically, and handles the
+`If-None-Match` header for incoming requests.
+
+### Caching
+
+By default, no caching headers are added to assets. This can be disadvantageous
+in many scenarios, so fresh makes it easy to serve assets with long cache
+lifetimes too.
+
+The first approach to do this is manual. The client runtime exports an `asset`
+function that takes an absolute path to the static asset, and returns a "locked"
+version of this path that contains a build ID for cache busting. When the asset
+is requested at this "locked" path, it will be served with a cache lifetime of
+one year.
+
+```jsx
+import { asset, h } from "../deps.ts";
+
+export default function Page() {
+  return (
+    <p>
+      <a href={asset("/brochure.pdf")}>View brochure</a>
+    </p>
+  );
+}
+```
+
+Fresh also does this automatically for `src` and `srcset` attributes in `<img>`
+and `<source>` HTML tags. These will automatically use "locked" paths if fresh
+deems it safe to do so. You can always opt out of this behaviour per tag, by
+adding the `data-fresh-disable-lock` attribute.
 
 ```jsx
 <img src="/user.png" />;
 ```
-
-For the `src` and `srcset` attributes of the `img` and `source` elements, Fresh
-will automatically add a query parameter with the deployment id and served with
-cache control of 1 year.
-
-If you want to disable this for an element, add the data attribute
-`data-no-auto-hashing` to the element.
-
-All other static files are served without caching.
-
-If you want to explicitly serve a static file with caching, use the `asset`
-function exported from `runtime.ts`.

--- a/docs/concepts/static-files.md
+++ b/docs/concepts/static-files.md
@@ -1,28 +1,19 @@
 > TODO(lucacasonato): this page still needs to be completed
 
 Static assets should be located under the `./static` directory. To reference a
-static file in your code, use the path relative to the static folder. For
-example, for a file called `user.png` located inside the static folder, the jsx
+static file in your code, use the path relative to the static folder, prefixed by a `/`. For example, for a file called `user.png` located inside the static folder, the jsx
 is:
 
 ```jsx
 <img src="/user.png" />;
 ```
 
-The static files are served by the server under 2 paths:
-
-- The standard path: `https://mydomain/my-file.png`. For that path, no caching
-  headers are added to the response.
-- The "hashed" path: `https://mydomain/_frsh/static/<BUILDID>/my-file.png`. As
-  you can see the `BUILDID` is injected into the path. This allow to burst the
-  client cache whenever a new deployment is done. The response is served with a
-  cache expiry of 1 year.
-
-By default the `img` and `source` elements used in fresh will automatically use
-the "hashed" path for the `src` and `srcset` attributes.
+For the `src` and `srcset` attributes of the `img` and `source` elements, Fresh will automatically add a query parameter with the deployment id and served with cache control of 1 year.
 
 If you want to disable this for an element, add the data attribute
 `data-no-auto-hashing` to the element.
 
-If you want to explicitly build the `hashed` path, use the `asset` function
+All other static files are served without caching.
+
+If you want to explicitly serve a static file with caching, use the `asset` function
 exported from `runtime.ts`.

--- a/docs/concepts/static-files.md
+++ b/docs/concepts/static-files.md
@@ -18,7 +18,8 @@ The static files are served by the server under 2 paths:
   client cache whenever a new deployment is done. The response is served with a
   cache expiry of 1 year.
 
-By default img elements used in fresh will automatically use the "hashed" path.
+By default the `img` and `source` elements used in fresh will automatically use
+the "hashed" path for the `src` and `srcset` attributes.
 
 If you want to disable this for an element, add the data attribute
 `data-no-auto-hashing` to the element.

--- a/docs/concepts/static-files.md
+++ b/docs/concepts/static-files.md
@@ -23,5 +23,5 @@ By default img elements used in fresh will automatically use the "hashed" path.
 If you want to disable this for an element, add the data attribute
 `data-no-auto-hashing` to the element.
 
-If you want to explicitly build the `hashed` path, use the `asset` function exported
-from `runtime.ts`.
+If you want to explicitly build the `hashed` path, use the `asset` function
+exported from `runtime.ts`.

--- a/docs/concepts/static-files.md
+++ b/docs/concepts/static-files.md
@@ -14,6 +14,6 @@ The static files can be accessed under 2 paths:
 
 By default img elements used in fresh will automatically use the "hashed" path. 
 
-If you want to disable this for an element, add the data attribute `data-no-caching` to the element.
+If you want to disable this for an element, add the data attribute `data-no-auto-hashing` to the element.
 
 If you want to explicitly build the `hashed` use the `asset` function exported from the `client_deps.ts` file.

--- a/docs/concepts/static-files.md
+++ b/docs/concepts/static-files.md
@@ -1,19 +1,22 @@
 > TODO(lucacasonato): this page still needs to be completed
 
 Static assets should be located under the `./static` directory. To reference a
-static file in your code, use the path relative to the static folder, prefixed by a `/`. For example, for a file called `user.png` located inside the static folder, the jsx
-is:
+static file in your code, use the path relative to the static folder, prefixed
+by a `/`. For example, for a file called `user.png` located inside the static
+folder, the jsx is:
 
 ```jsx
 <img src="/user.png" />;
 ```
 
-For the `src` and `srcset` attributes of the `img` and `source` elements, Fresh will automatically add a query parameter with the deployment id and served with cache control of 1 year.
+For the `src` and `srcset` attributes of the `img` and `source` elements, Fresh
+will automatically add a query parameter with the deployment id and served with
+cache control of 1 year.
 
 If you want to disable this for an element, add the data attribute
 `data-no-auto-hashing` to the element.
 
 All other static files are served without caching.
 
-If you want to explicitly serve a static file with caching, use the `asset` function
-exported from `runtime.ts`.
+If you want to explicitly serve a static file with caching, use the `asset`
+function exported from `runtime.ts`.

--- a/docs/concepts/static-files.md
+++ b/docs/concepts/static-files.md
@@ -1,13 +1,13 @@
 > TODO(lucacasonato): this page still needs to be completed
 
 Static assets should be located under the `./static` directory. 
-To reference a static file in the your html just use the path relative to the static folder. For example, for a file called `user.png` located inside the static folder, the jsx will be:
+To reference a static file in your code, use the path relative to the static folder. For example, for a file called `user.png` located inside the static folder, the jsx is:
 
 ```jsx
 <img src='/user.png' />
 ```
 
-The static files can be accessed under 2 paths:
+The static files are served by the server under 2 paths:
 
 - The standard path: `https://mydomain/my-file.png`. For that path, no caching headers are added to the response.
 - The "hashed" path: `https://mydomain/_frsh/static/<BUILDID>/my-file.png`. As you can see the `BUILDID` is injected into the path. This allow to burst the client cache whenever a new deployment is done. The response is served with a cache expiry of 1 year.

--- a/docs/concepts/static-files.md
+++ b/docs/concepts/static-files.md
@@ -23,5 +23,5 @@ By default img elements used in fresh will automatically use the "hashed" path.
 If you want to disable this for an element, add the data attribute
 `data-no-auto-hashing` to the element.
 
-If you want to explicitly build the `hashed` use the `asset` function exported
+If you want to explicitly build the `hashed` path, use the `asset` function exported
 from `runtime.ts`.

--- a/docs/concepts/static-files.md
+++ b/docs/concepts/static-files.md
@@ -1,1 +1,19 @@
-> TODO(lucacasonato): this page still needs to be written
+> TODO(lucacasonato): this page still needs to be completed
+
+Static assets should be located under the `./static` directory. 
+To reference a static file in the your html just use the path relative to the static folder. For example, for a file called `user.png` located inside the static folder, the jsx will be:
+
+```jsx
+<img src='/user.png' />
+```
+
+The static files can be accessed under 2 paths:
+
+- The standard path: `https://mydomain/my-file.png`. For that path, no caching headers are added to the response.
+- The "hashed" path: `https://mydomain/_frsh/static/<BUILDID>/my-file.png`. As you can see the `BUILDID` is injected into the path. This allow to burst the client cache whenever a new deployment is done. The response is served with a cache expiry of 1 year.
+
+By default img elements used in fresh will automatically use the "hashed" path. 
+
+If you want to disable this for an element, add the data attribute `data-no-caching` to the element.
+
+If you want to explicitly build the `hashed` use the `asset` function exported from the `client_deps.ts` file.

--- a/docs/concepts/static-files.md
+++ b/docs/concepts/static-files.md
@@ -1,19 +1,27 @@
 > TODO(lucacasonato): this page still needs to be completed
 
-Static assets should be located under the `./static` directory. 
-To reference a static file in your code, use the path relative to the static folder. For example, for a file called `user.png` located inside the static folder, the jsx is:
+Static assets should be located under the `./static` directory. To reference a
+static file in your code, use the path relative to the static folder. For
+example, for a file called `user.png` located inside the static folder, the jsx
+is:
 
 ```jsx
-<img src='/user.png' />
+<img src="/user.png" />;
 ```
 
 The static files are served by the server under 2 paths:
 
-- The standard path: `https://mydomain/my-file.png`. For that path, no caching headers are added to the response.
-- The "hashed" path: `https://mydomain/_frsh/static/<BUILDID>/my-file.png`. As you can see the `BUILDID` is injected into the path. This allow to burst the client cache whenever a new deployment is done. The response is served with a cache expiry of 1 year.
+- The standard path: `https://mydomain/my-file.png`. For that path, no caching
+  headers are added to the response.
+- The "hashed" path: `https://mydomain/_frsh/static/<BUILDID>/my-file.png`. As
+  you can see the `BUILDID` is injected into the path. This allow to burst the
+  client cache whenever a new deployment is done. The response is served with a
+  cache expiry of 1 year.
 
-By default img elements used in fresh will automatically use the "hashed" path. 
+By default img elements used in fresh will automatically use the "hashed" path.
 
-If you want to disable this for an element, add the data attribute `data-no-auto-hashing` to the element.
+If you want to disable this for an element, add the data attribute
+`data-no-auto-hashing` to the element.
 
-If you want to explicitly build the `hashed` use the `asset` function exported from `runtime.ts`.
+If you want to explicitly build the `hashed` use the `asset` function exported
+from `runtime.ts`.

--- a/docs/concepts/static-files.md
+++ b/docs/concepts/static-files.md
@@ -16,4 +16,4 @@ By default img elements used in fresh will automatically use the "hashed" path.
 
 If you want to disable this for an element, add the data attribute `data-no-auto-hashing` to the element.
 
-If you want to explicitly build the `hashed` use the `asset` function exported from the `client_deps.ts` file.
+If you want to explicitly build the `hashed` use the `asset` function exported from `runtime.ts`.

--- a/src/runtime/main.ts
+++ b/src/runtime/main.ts
@@ -1,4 +1,4 @@
-import { ComponentType, h, render, options } from "./deps.ts";
+import { ComponentType, h, options, render } from "./deps.ts";
 import { assetHashingHook } from "./utils.ts";
 
 function createRootFragment(
@@ -65,6 +65,6 @@ export function revive(islands: Record<string, ComponentType>) {
 
 const originalHook = options.vnode;
 options.vnode = (vnode) => {
-  assetHashingHook(vnode)
+  assetHashingHook(vnode);
   if (originalHook) originalHook(vnode);
 };

--- a/src/runtime/main.ts
+++ b/src/runtime/main.ts
@@ -1,4 +1,5 @@
-import { ComponentType, h, render } from "./deps.ts";
+import { ComponentType, h, render, options } from "./deps.ts";
+import { assetHashingHook } from "./utils.ts";
 
 function createRootFragment(
   parent: Element,
@@ -61,3 +62,9 @@ export function revive(islands: Record<string, ComponentType>) {
   }
   walk(document.body);
 }
+
+const originalHook = options.vnode;
+options.vnode = (vnode) => {
+  assetHashingHook(vnode)
+  if (originalHook) originalHook(vnode);
+};

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -31,14 +31,23 @@ export function asset(path: string) {
   }
 }
 
-// apply the asset function a srcset
-export function assetSrcSet(srcset: string) {
-  const srcsetParts = srcset.split(",");
-  return srcsetParts.map((part) => {
-    const sections = part.trim().split(" ");
-    sections[0] = asset(sections[0]);
-    return sections.join(" ");
-  }).join(", ");
+/** Apply the `asset` function to urls in a `srcset` attribute. */
+export function assetSrcSet(srcset: string): string {
+  if (srcset.includes("(")) return srcset; // Bail if the srcset contains complicated syntax.
+  const parts = srcset.split(",");
+  const constructed = [];
+  for (const part of parts) {
+    const trimmed = part.trimStart();
+    const leadingWhitespace = part.length - trimmed.length;
+    if (trimmed === "") return srcset; // Bail if the srcset is malformed.
+    let urlEnd = trimmed.indexOf(" ");
+    if (urlEnd === -1) urlEnd = trimmed.length;
+    const leading = part.substring(0, leadingWhitespace);
+    const url = trimmed.substring(0, urlEnd);
+    const trailing = trimmed.substring(urlEnd);
+    constructed.push(leading + asset(url) + trailing);
+  }
+  return constructed.join(",");
 }
 
 export function assetHashingHook(

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -17,8 +17,8 @@ export function asset(path: string) {
 export function assetHashingHook(vnode: VNode) {
   if (vnode.type === "img") {
     const props = (vnode.props as HTMLImageElement);
-    // deno-lint-ignore no-explicit-any
     if (
+      // deno-lint-ignore no-explicit-any
       props.src && !(props as any)["data-no-auto-hashing"] &&
       // do not apply the for assets that are already targetting the a frsh special handling
       !props.src.startsWith(INTERNAL_PREFIX) &&

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -14,16 +14,18 @@ export function asset(path: string) {
   return `${INTERNAL_PREFIX}${STATIC_PREFIX}/${__FRSH_BUILD_ID}${path}`;
 }
 
-export function assetHashingHook(vnode: VNode){
+export function assetHashingHook(vnode: VNode) {
   if (vnode.type === "img") {
-    const props = (vnode.props as HTMLImageElement)
+    const props = (vnode.props as HTMLImageElement);
     // deno-lint-ignore no-explicit-any
-    if (props.src && !(props as any)['data-no-auto-hashing'] 
+    if (
+      props.src && !(props as any)["data-no-auto-hashing"] &&
       // do not apply the for assets that are already targetting the a frsh special handling
-      && !props.src.startsWith(INTERNAL_PREFIX)
+      !props.src.startsWith(INTERNAL_PREFIX) &&
       // Only apply for assets that is referenced from the static folder, i.e path starting by '/'
-      && props.src.startsWith('/')) {
-      (vnode.props as HTMLImageElement).src = asset(props.src)
-    }  
+      props.src.startsWith("/")
+    ) {
+      (vnode.props as HTMLImageElement).src = asset(props.src);
+    }
   }
 }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -48,6 +48,8 @@ export function assetHashingHook(vnode: VNode) {
     if ((props as any)["data-no-auto-hashing"]) return;
 
     if (typeof props.src === "string") props.src = asset(props.src);
-    if (typeof props.srcset === "string") props.srcset = assetSrcSet(props.srcset);
+    if (typeof props.srcset === "string") {
+      props.srcset = assetSrcSet(props.srcset);
+    }
   }
 }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -28,30 +28,28 @@ export function assetHashingHook(vnode: VNode) {
   if (vnode.type === "img" || vnode.type === "source") {
     const props = (vnode.props as HTMLImageElement);
     // deno-lint-ignore no-explicit-any
-    if ((props as any)["data-no-auto-hashing"]) {
-      // skip
-    } else {
-      // apply for src
-      if (
-        props.src &&
-        // do not apply the for assets that are already targetting a fresh special handling
-        !props.src.startsWith(INTERNAL_PREFIX) &&
-        // Only apply for assets that is referenced from the static folder, i.e path starting by '/'
-        props.src.startsWith("/")
-      ) {
-        (vnode.props as HTMLImageElement).src = asset(props.src);
-      }
+    if ((props as any)["data-no-auto-hashing"]) return;
 
-      // apply for srcset
-      if (
-        props.srcset &&
-        // do not apply the for assets that are already targetting a fresh special handling
-        !props.srcset.startsWith(INTERNAL_PREFIX) &&
-        // Only apply for assets that is referenced from the static folder, i.e path starting by '/'
-        props.srcset.startsWith("/")
-      ) {
-        (vnode.props as HTMLImageElement).srcset = assetSrcSet(props.srcset);
-      }
+    // apply for src
+    if (
+      props.src &&
+      // do not apply the for assets that are already targetting a fresh special handling
+      !props.src.startsWith(INTERNAL_PREFIX) &&
+      // Only apply for assets that is referenced from the static folder, i.e path starting by '/'
+      props.src.startsWith("/")
+    ) {
+      props.src = asset(props.src);
+    }
+
+    // apply for srcset
+    if (
+      props.srcset &&
+      // do not apply the for assets that are already targetting a fresh special handling
+      !props.srcset.startsWith(INTERNAL_PREFIX) &&
+      // Only apply for assets that is referenced from the static folder, i.e path starting by '/'
+      props.srcset.startsWith("/")
+    ) {
+      props.srcset = assetSrcSet(props.srcset);
     }
   }
 }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -47,26 +47,7 @@ export function assetHashingHook(vnode: VNode) {
     // deno-lint-ignore no-explicit-any
     if ((props as any)["data-no-auto-hashing"]) return;
 
-    // apply for src
-    if (
-      props.src &&
-      // do not apply the for assets that are already targetting a fresh special handling
-      !props.src.startsWith(INTERNAL_PREFIX) &&
-      // Only apply for assets that is referenced from the static folder, i.e path starting by '/'
-      props.src.startsWith("/")
-    ) {
-      props.src = asset(props.src);
-    }
-
-    // apply for srcset
-    if (
-      props.srcset &&
-      // do not apply the for assets that are already targetting a fresh special handling
-      !props.srcset.startsWith(INTERNAL_PREFIX) &&
-      // Only apply for assets that is referenced from the static folder, i.e path starting by '/'
-      props.srcset.startsWith("/")
-    ) {
-      props.srcset = assetSrcSet(props.srcset);
-    }
+    if (typeof props.src === "string") props.src = asset(props.src);
+    if (typeof props.srcset === "string") props.srcset = assetSrcSet(props.srcset);
   }
 }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -14,18 +14,44 @@ export function asset(path: string) {
   return `${INTERNAL_PREFIX}${STATIC_PREFIX}/${__FRSH_BUILD_ID}${path}`;
 }
 
+// apply the asset function a srcset
+export function assetSrcSet(srcset: string) {
+  const srcsetParts = srcset.split(",");
+  return srcsetParts.map((part) => {
+    const sections = part.trim().split(" ");
+    sections[0] = asset(sections[0]);
+    return sections.join(" ");
+  }).join(", ");
+}
+
 export function assetHashingHook(vnode: VNode) {
-  if (vnode.type === "img") {
+  if (vnode.type === "img" || vnode.type === "source") {
     const props = (vnode.props as HTMLImageElement);
-    if (
-      // deno-lint-ignore no-explicit-any
-      props.src && !(props as any)["data-no-auto-hashing"] &&
-      // do not apply the for assets that are already targetting the a frsh special handling
-      !props.src.startsWith(INTERNAL_PREFIX) &&
-      // Only apply for assets that is referenced from the static folder, i.e path starting by '/'
-      props.src.startsWith("/")
-    ) {
-      (vnode.props as HTMLImageElement).src = asset(props.src);
+    // deno-lint-ignore no-explicit-any
+    if ((props as any)["data-no-auto-hashing"]) {
+      // skip
+    } else {
+      // apply for src
+      if (
+        props.src &&
+        // do not apply the for assets that are already targetting a fresh special handling
+        !props.src.startsWith(INTERNAL_PREFIX) &&
+        // Only apply for assets that is referenced from the static folder, i.e path starting by '/'
+        props.src.startsWith("/")
+      ) {
+        (vnode.props as HTMLImageElement).src = asset(props.src);
+      }
+
+      // apply for srcset
+      if (
+        props.srcset &&
+        // do not apply the for assets that are already targetting a fresh special handling
+        !props.srcset.startsWith(INTERNAL_PREFIX) &&
+        // Only apply for assets that is referenced from the static folder, i.e path starting by '/'
+        props.srcset.startsWith("/")
+      ) {
+        (vnode.props as HTMLImageElement).srcset = assetSrcSet(props.srcset);
+      }
     }
   }
 }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -41,13 +41,19 @@ export function assetSrcSet(srcset: string) {
   }).join(", ");
 }
 
-export function assetHashingHook(vnode: VNode) {
+export function assetHashingHook(
+  vnode: VNode<{
+    src?: string;
+    srcset?: string;
+    ["data-fresh-disable-lock"]?: boolean;
+  }>,
+) {
   if (vnode.type === "img" || vnode.type === "source") {
-    const props = (vnode.props as HTMLImageElement);
-    // deno-lint-ignore no-explicit-any
-    if ((props as any)["data-no-auto-hashing"]) return;
-
-    if (typeof props.src === "string") props.src = asset(props.src);
+    const { props } = vnode;
+    if (props["data-fresh-disable-lock"]) return;
+    if (typeof props.src === "string") {
+      props.src = asset(props.src);
+    }
     if (typeof props.srcset === "string") {
       props.srcset = assetSrcSet(props.srcset);
     }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,3 +1,5 @@
+import { VNode } from "./deps.ts";
+
 export const INTERNAL_PREFIX = "/_frsh";
 export const STATIC_PREFIX = `/static`;
 
@@ -10,4 +12,18 @@ export const IS_BROWSER = typeof document !== "undefined";
  */
 export function asset(path: string) {
   return `${INTERNAL_PREFIX}${STATIC_PREFIX}/${__FRSH_BUILD_ID}${path}`;
+}
+
+export function assetHashingHook(vnode: VNode){
+  if (vnode.type === "img") {
+    const props = (vnode.props as HTMLImageElement)
+    // deno-lint-ignore no-explicit-any
+    if (props.src && !(props as any)['data-no-caching'] 
+      // do not apply the for assets that are already targetting the a frsh special handling
+      && !props.src.startsWith(INTERNAL_PREFIX)
+      // Only apply for assets that is referenced from the static folder, i.e path starting by '/'
+      && props.src.startsWith('/')) {
+      (vnode.props as HTMLImageElement).src = asset(props.src)
+    }  
+  }
 }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -18,7 +18,7 @@ export function assetHashingHook(vnode: VNode){
   if (vnode.type === "img") {
     const props = (vnode.props as HTMLImageElement)
     // deno-lint-ignore no-explicit-any
-    if (props.src && !(props as any)['data-no-caching'] 
+    if (props.src && !(props as any)['data-no-auto-hashing'] 
       // do not apply the for assets that are already targetting the a frsh special handling
       && !props.src.startsWith(INTERNAL_PREFIX)
       // Only apply for assets that is referenced from the static folder, i.e path starting by '/'

--- a/src/runtime/utils_test.ts
+++ b/src/runtime/utils_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "../../tests/deps.ts";
-import { asset } from "./utils.ts";
+import { asset, assetSrcSet } from "./utils.ts";
 
 globalThis.__FRSH_BUILD_ID = "ID123";
 
@@ -15,5 +15,34 @@ Deno.test("asset", () => {
   assertEquals(
     asset("https://example.com/logo.png"),
     "https://example.com/logo.png",
+  );
+});
+
+Deno.test("assetSrcSet", () => {
+  assertEquals(assetSrcSet("/img.png"), "/img.png?__frsh_c=ID123");
+  assertEquals(
+    assetSrcSet("/img.png, /img.png 2x"),
+    "/img.png?__frsh_c=ID123, /img.png?__frsh_c=ID123 2x",
+  );
+  assertEquals(assetSrcSet("/img.png 1x"), "/img.png?__frsh_c=ID123 1x");
+  assertEquals(
+    assetSrcSet("/img.png 1x, /img.png 2x"),
+    "/img.png?__frsh_c=ID123 1x, /img.png?__frsh_c=ID123 2x",
+  );
+  assertEquals(
+    assetSrcSet("/img.png 1.5x, /img.png 3x"),
+    "/img.png?__frsh_c=ID123 1.5x, /img.png?__frsh_c=ID123 3x",
+  );
+
+  //test with queries
+  assertEquals(
+    assetSrcSet("/img.png?w=140, /img.png?w=200 2x"),
+    "/img.png?w=140&__frsh_c=ID123, /img.png?w=200&__frsh_c=ID123 2x",
+  );
+
+  // test with extra spaces
+  assertEquals(
+    assetSrcSet("/img-s.png 300w,  /img-l.png  600w , /img-xl.png  900w"),
+    "/img-s.png?__frsh_c=ID123 300w, /img-l.png?__frsh_c=ID123  600w, /img-xl.png?__frsh_c=ID123  900w",
   );
 });

--- a/src/runtime/utils_test.ts
+++ b/src/runtime/utils_test.ts
@@ -43,6 +43,18 @@ Deno.test("assetSrcSet", () => {
   // test with extra spaces
   assertEquals(
     assetSrcSet("/img-s.png 300w,  /img-l.png  600w , /img-xl.png  900w"),
-    "/img-s.png?__frsh_c=ID123 300w, /img-l.png?__frsh_c=ID123  600w, /img-xl.png?__frsh_c=ID123  900w",
+    "/img-s.png?__frsh_c=ID123 300w,  /img-l.png?__frsh_c=ID123  600w , /img-xl.png?__frsh_c=ID123  900w",
+  );
+
+  // test with ( syntax
+  assertEquals(
+    assetSrcSet("/img.png ( 140,0w)"),
+    "/img.png ( 140,0w)",
+  );
+
+  // test with invalid parts
+  assertEquals(
+    assetSrcSet("/img.png,, /img-s.png 300w"),
+    "/img.png,, /img-s.png 300w",
   );
 });

--- a/src/server/render.tsx
+++ b/src/server/render.tsx
@@ -297,7 +297,7 @@ let ISLAND_PROPS: unknown[] = [];
 const originalHook = options.vnode;
 let ignoreNext = false;
 options.vnode = (vnode) => {
-  assetHashingHook(vnode)
+  assetHashingHook(vnode);
   const originalType = vnode.type as ComponentType<unknown>;
   if (typeof vnode.type === "function") {
     const island = ISLANDS.find((island) => island.component === originalType);

--- a/src/server/render.tsx
+++ b/src/server/render.tsx
@@ -18,6 +18,7 @@ import { HEAD_CONTEXT } from "../runtime/head.ts";
 import { CSP_CONTEXT, nonce, NONE, UNSAFE_INLINE } from "../runtime/csp.ts";
 import { ContentSecurityPolicy } from "../runtime/csp.ts";
 import { bundleAssetUrl } from "./constants.ts";
+import { assetHashingHook } from "../runtime/utils.ts";
 
 export interface RenderOptions<Data> {
   page: Page<Data> | UnknownPage | ErrorPage;
@@ -296,6 +297,7 @@ let ISLAND_PROPS: unknown[] = [];
 const originalHook = options.vnode;
 let ignoreNext = false;
 options.vnode = (vnode) => {
+  assetHashingHook(vnode)
   const originalType = vnode.type as ComponentType<unknown>;
   if (typeof vnode.type === "function") {
     const island = ISLANDS.find((island) => island.component === originalType);

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -9,23 +9,24 @@ import * as $3 from "./routes/_app.tsx";
 import * as $4 from "./routes/_middleware.ts";
 import * as $5 from "./routes/_render.ts";
 import * as $6 from "./routes/api/get_only.ts";
-import * as $7 from "./routes/books/[id].tsx";
-import * as $8 from "./routes/connInfo.ts";
-import * as $9 from "./routes/failure.ts";
-import * as $10 from "./routes/index.tsx";
-import * as $11 from "./routes/intercept.tsx";
-import * as $12 from "./routes/intercept_args.tsx";
-import * as $13 from "./routes/layeredMdw/_middleware.ts";
-import * as $14 from "./routes/layeredMdw/layer2-no-mw/without_mw.ts";
-import * as $15 from "./routes/layeredMdw/layer2/_middleware.ts";
-import * as $16 from "./routes/layeredMdw/layer2/abc.ts";
-import * as $17 from "./routes/layeredMdw/layer2/layer3/[id].ts";
-import * as $18 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
-import * as $19 from "./routes/middleware_root.ts";
-import * as $20 from "./routes/params.tsx";
-import * as $21 from "./routes/props/[id].tsx";
-import * as $22 from "./routes/static.tsx";
-import * as $23 from "./routes/wildcard.tsx";
+import * as $7 from "./routes/assetsCaching/index.tsx";
+import * as $8 from "./routes/books/[id].tsx";
+import * as $9 from "./routes/connInfo.ts";
+import * as $10 from "./routes/failure.ts";
+import * as $11 from "./routes/index.tsx";
+import * as $12 from "./routes/intercept.tsx";
+import * as $13 from "./routes/intercept_args.tsx";
+import * as $14 from "./routes/layeredMdw/_middleware.ts";
+import * as $15 from "./routes/layeredMdw/layer2-no-mw/without_mw.ts";
+import * as $16 from "./routes/layeredMdw/layer2/_middleware.ts";
+import * as $17 from "./routes/layeredMdw/layer2/abc.ts";
+import * as $18 from "./routes/layeredMdw/layer2/layer3/[id].ts";
+import * as $19 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
+import * as $20 from "./routes/middleware_root.ts";
+import * as $21 from "./routes/params.tsx";
+import * as $22 from "./routes/props/[id].tsx";
+import * as $23 from "./routes/static.tsx";
+import * as $24 from "./routes/wildcard.tsx";
 import * as $$0 from "./islands/Test.tsx";
 
 const manifest = {
@@ -37,23 +38,24 @@ const manifest = {
     "./routes/_middleware.ts": $4,
     "./routes/_render.ts": $5,
     "./routes/api/get_only.ts": $6,
-    "./routes/books/[id].tsx": $7,
-    "./routes/connInfo.ts": $8,
-    "./routes/failure.ts": $9,
-    "./routes/index.tsx": $10,
-    "./routes/intercept.tsx": $11,
-    "./routes/intercept_args.tsx": $12,
-    "./routes/layeredMdw/_middleware.ts": $13,
-    "./routes/layeredMdw/layer2-no-mw/without_mw.ts": $14,
-    "./routes/layeredMdw/layer2/_middleware.ts": $15,
-    "./routes/layeredMdw/layer2/abc.ts": $16,
-    "./routes/layeredMdw/layer2/layer3/[id].ts": $17,
-    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $18,
-    "./routes/middleware_root.ts": $19,
-    "./routes/params.tsx": $20,
-    "./routes/props/[id].tsx": $21,
-    "./routes/static.tsx": $22,
-    "./routes/wildcard.tsx": $23,
+    "./routes/assetsCaching/index.tsx": $7,
+    "./routes/books/[id].tsx": $8,
+    "./routes/connInfo.ts": $9,
+    "./routes/failure.ts": $10,
+    "./routes/index.tsx": $11,
+    "./routes/intercept.tsx": $12,
+    "./routes/intercept_args.tsx": $13,
+    "./routes/layeredMdw/_middleware.ts": $14,
+    "./routes/layeredMdw/layer2-no-mw/without_mw.ts": $15,
+    "./routes/layeredMdw/layer2/_middleware.ts": $16,
+    "./routes/layeredMdw/layer2/abc.ts": $17,
+    "./routes/layeredMdw/layer2/layer3/[id].ts": $18,
+    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $19,
+    "./routes/middleware_root.ts": $20,
+    "./routes/params.tsx": $21,
+    "./routes/props/[id].tsx": $22,
+    "./routes/static.tsx": $23,
+    "./routes/wildcard.tsx": $24,
   },
   islands: {
     "./islands/Test.tsx": $$0,

--- a/tests/fixture/islands/Test.tsx
+++ b/tests/fixture/islands/Test.tsx
@@ -1,12 +1,12 @@
 /** @jsx h */
 
-import { asset, h } from "../client_deps.ts";
+import { h } from "../client_deps.ts";
 
 export default function Test(props: { message: string }) {
   return (
     <div>
       <p>{props.message}</p>
-      <img src={asset("/image.png")} />
+      <img id="img-in-island" src="/image.png" height={130} />
     </div>
   );
 }

--- a/tests/fixture/islands/Test.tsx
+++ b/tests/fixture/islands/Test.tsx
@@ -6,7 +6,12 @@ export default function Test(props: { message: string }) {
   return (
     <div>
       <p>{props.message}</p>
-      <img id="img-in-island" src="/image.png" height={130} />
+      <img
+        id="img-in-island"
+        src="/image.png"
+        srcset="/image.png 1x"
+        height={130}
+      />
     </div>
   );
 }

--- a/tests/fixture/routes/assetsCaching/index.tsx
+++ b/tests/fixture/routes/assetsCaching/index.tsx
@@ -13,7 +13,7 @@ export default function Home() {
       <img
         id="img-without-hashing"
         src="/image.png"
-        data-no-auto-hashing={true}
+        data-fresh-disable-lock
         height={130}
       />
 

--- a/tests/fixture/routes/assetsCaching/index.tsx
+++ b/tests/fixture/routes/assetsCaching/index.tsx
@@ -1,0 +1,37 @@
+/** @jsx h */
+
+import { asset, h } from "../../client_deps.ts";
+import Test from "../../islands/Test.tsx";
+
+export default function Home() {
+  return (
+    <div>
+      <div style={{ marginTop: 20 }}>img-with-hashing</div>
+      <img id="img-with-hashing" src="/image.png" height={130} />
+
+      <div style={{ marginTop: 20 }}>img-with-explicit-hashing</div>
+      <img
+        id="img-with-explicit-hashing"
+        src={asset("/image.png")}
+        height={130}
+      />
+
+      <div style={{ marginTop: 20 }}>img-without-hashing</div>
+      <img
+        id="img-without-hashing"
+        src="/image.png"
+        data-no-caching={true}
+        height={130}
+      />
+
+      <Test message="In island" />
+
+      <div style={{ marginTop: 20 }}>img-external</div>
+      <img
+        id="img-missing"
+        src="https://fresh.deno.dev/favicon.ico"
+        height={130}
+      />
+    </div>
+  );
+}

--- a/tests/fixture/routes/assetsCaching/index.tsx
+++ b/tests/fixture/routes/assetsCaching/index.tsx
@@ -20,7 +20,7 @@ export default function Home() {
       <img
         id="img-without-hashing"
         src="/image.png"
-        data-no-caching={true}
+        data-no-auto-hashing={true}
         height={130}
       />
 

--- a/tests/fixture/routes/assetsCaching/index.tsx
+++ b/tests/fixture/routes/assetsCaching/index.tsx
@@ -9,13 +9,6 @@ export default function Home() {
       <div style={{ marginTop: 20 }}>img-with-hashing</div>
       <img id="img-with-hashing" src="/image.png" height={130} />
 
-      <div style={{ marginTop: 20 }}>img-with-explicit-hashing</div>
-      <img
-        id="img-with-explicit-hashing"
-        src={asset("/image.png")}
-        height={130}
-      />
-
       <div style={{ marginTop: 20 }}>img-without-hashing</div>
       <img
         id="img-without-hashing"

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -201,7 +201,9 @@ Deno.test("static file - by file path", async () => {
 
 Deno.test("static file - by 'hashed' path", async () => {
   // Check that the file path have the BUILD_ID
-  const resp = await router(new Request("https://fresh.deno.dev/assetsCaching"));
+  const resp = await router(
+    new Request("https://fresh.deno.dev/assetsCaching"),
+  );
   const body = await resp.text();
   const imgFilePath = body.match(/img id="img-with-hashing" src="(.*?)"/)?.[1];
   assert(imgFilePath);
@@ -227,23 +229,38 @@ Deno.test("static file - by 'hashed' path", async () => {
   );
   assertEquals(resp3.status, 304);
 
-  const imgFilePathWithExplicitHashing = body.match(/img id="img-with-explicit-hashing" src="(.*?)"/)?.[1];
+  const imgFilePathWithExplicitHashing = body.match(
+    /img id="img-with-explicit-hashing" src="(.*?)"/,
+  )?.[1];
   assert(imgFilePathWithExplicitHashing);
-  const numberOfBuildIDInPath = imgFilePathWithExplicitHashing.split('/').filter(st => st === globalThis.__FRSH_BUILD_ID).length
-  assert(numberOfBuildIDInPath === 1, `explicit hashing incorrect. found ${numberOfBuildIDInPath} BUILDID in path`)
+  const numberOfBuildIDInPath =
+    imgFilePathWithExplicitHashing.split("/").filter((st) =>
+      st === globalThis.__FRSH_BUILD_ID
+    ).length;
+  assert(
+    numberOfBuildIDInPath === 1,
+    `explicit hashing incorrect. found ${numberOfBuildIDInPath} BUILDID in path`,
+  );
 
-  const imgFilePathWithNoCache = body.match(/img id="img-without-hashing" src="(.*?)"/)?.[1];
+  const imgFilePathWithNoCache = body.match(
+    /img id="img-without-hashing" src="(.*?)"/,
+  )?.[1];
   assert(imgFilePathWithNoCache);
-  assert(!imgFilePathWithNoCache.includes(globalThis.__FRSH_BUILD_ID), "img-without-hashing")
+  assert(
+    !imgFilePathWithNoCache.includes(globalThis.__FRSH_BUILD_ID),
+    "img-without-hashing",
+  );
 
   const imgInIsland = body.match(/img id="img-in-island" src="(.*?)"/)?.[1];
   assert(imgInIsland);
-  assert(imgInIsland.includes(globalThis.__FRSH_BUILD_ID), 'img-in-island')
-  
+  assert(imgInIsland.includes(globalThis.__FRSH_BUILD_ID), "img-in-island");
+
   const imgMissing = body.match(/img id="img-missing" src="(.*?)"/)?.[1];
   assert(imgMissing);
-  assert(!imgMissing.includes(globalThis.__FRSH_BUILD_ID), 'Applying hash on unknown asset')
-
+  assert(
+    !imgMissing.includes(globalThis.__FRSH_BUILD_ID),
+    "Applying hash on unknown asset",
+  );
 });
 
 Deno.test("/params/:path*", async () => {

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -201,9 +201,9 @@ Deno.test("static file - by file path", async () => {
 
 Deno.test("static file - by 'hashed' path", async () => {
   // Check that the file path have the BUILD_ID
-  const resp = await router(new Request("https://fresh.deno.dev/"));
+  const resp = await router(new Request("https://fresh.deno.dev/assetsCaching"));
   const body = await resp.text();
-  const imgFilePath = body.match(/img src="(.*?)"/)?.[1];
+  const imgFilePath = body.match(/img id="img-with-hashing" src="(.*?)"/)?.[1];
   assert(imgFilePath);
   assert(imgFilePath.includes(globalThis.__FRSH_BUILD_ID));
 
@@ -226,6 +226,24 @@ Deno.test("static file - by 'hashed' path", async () => {
     }),
   );
   assertEquals(resp3.status, 304);
+
+  const imgFilePathWithExplicitHashing = body.match(/img id="img-with-explicit-hashing" src="(.*?)"/)?.[1];
+  assert(imgFilePathWithExplicitHashing);
+  const numberOfBuildIDInPath = imgFilePathWithExplicitHashing.split('/').filter(st => st === globalThis.__FRSH_BUILD_ID).length
+  assert(numberOfBuildIDInPath === 1, `explicit hashing incorrect. found ${numberOfBuildIDInPath} BUILDID in path`)
+
+  const imgFilePathWithNoCache = body.match(/img id="img-without-hashing" src="(.*?)"/)?.[1];
+  assert(imgFilePathWithNoCache);
+  assert(!imgFilePathWithNoCache.includes(globalThis.__FRSH_BUILD_ID), "img-without-hashing")
+
+  const imgInIsland = body.match(/img id="img-in-island" src="(.*?)"/)?.[1];
+  assert(imgInIsland);
+  assert(imgInIsland.includes(globalThis.__FRSH_BUILD_ID), 'img-in-island')
+  
+  const imgMissing = body.match(/img id="img-missing" src="(.*?)"/)?.[1];
+  assert(imgMissing);
+  assert(!imgMissing.includes(globalThis.__FRSH_BUILD_ID), 'Applying hash on unknown asset')
+
 });
 
 Deno.test("/params/:path*", async () => {

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -247,7 +247,7 @@ Deno.test("static file - by 'hashed' path", async () => {
   // verify that the asset hook is applied to the srcset
   const imgInIslandSrcSet = body.match(/srcset="(.*?)"/)?.[1];
   assert(imgInIslandSrcSet);
-  console.log(imgInIslandSrcSet)
+  console.log(imgInIslandSrcSet);
   assert(
     imgInIslandSrcSet.includes(globalThis.__FRSH_BUILD_ID),
     "img-in-island-srcset",

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -1,5 +1,4 @@
 import { ServerContext } from "../server.ts";
-import { assetSrcSet } from "../src/runtime/utils.ts";
 import { assert, assertEquals, assertStringIncludes } from "./deps.ts";
 import manifest from "./fixture/fresh.gen.ts";
 
@@ -230,20 +229,6 @@ Deno.test("static file - by 'hashed' path", async () => {
   );
   assertEquals(resp3.status, 304);
 
-  // ensure asset hook is not applied on file that already have a hashed path
-  const imgFilePathWithExplicitHashing = body.match(
-    /img id="img-with-explicit-hashing" src="(.*?)"/,
-  )?.[1];
-  assert(imgFilePathWithExplicitHashing);
-  const numberOfBuildIDInPath =
-    imgFilePathWithExplicitHashing.split("/").filter((st) =>
-      st === globalThis.__FRSH_BUILD_ID
-    ).length;
-  assert(
-    numberOfBuildIDInPath === 1,
-    `explicit hashing incorrect. found ${numberOfBuildIDInPath} BUILDID in path`,
-  );
-
   // ensure asset hook is not applied on file explicitly excluded with attribute
   const imgFilePathWithNoCache = body.match(
     /img id="img-without-hashing" src="(.*?)"/,
@@ -262,9 +247,9 @@ Deno.test("static file - by 'hashed' path", async () => {
   // verify that the asset hook is applied to the srcset
   const imgInIslandSrcSet = body.match(/srcset="(.*?)"/)?.[1];
   assert(imgInIslandSrcSet);
-  assertEquals(
-    imgInIslandSrcSet,
-    `/_frsh/static/${globalThis.__FRSH_BUILD_ID}/image.png 1x`,
+  console.log(imgInIslandSrcSet)
+  assert(
+    imgInIslandSrcSet.includes(globalThis.__FRSH_BUILD_ID),
     "img-in-island-srcset",
   );
 
@@ -357,23 +342,4 @@ Deno.test({
     // by the reponse header in layer 0
     assertEquals(resp.headers.get("server"), "fresh test server");
   },
-});
-
-Deno.test("applyAssetSrcSet", () => {
-  let srcset = "";
-  let expected = "";
-
-  srcset = "/illustration/2x.avif";
-  expected = `/_frsh/static/${globalThis.__FRSH_BUILD_ID}/illustration/2x.avif`;
-  assert(assetSrcSet(srcset), expected);
-
-  srcset = "/illustration/2x.avif 2x, /illustration/1x.avif";
-  expected =
-    `/_frsh/static/${globalThis.__FRSH_BUILD_ID}/illustration/2x.avif 2x, /_frsh/static/${globalThis.__FRSH_BUILD_ID}/illustration/1x.avif`;
-  assertEquals(assetSrcSet(srcset), expected);
-
-  srcset = "/illustration/1x.avif,    /illustration/2x.avif 2x";
-  expected =
-    `/_frsh/static/${globalThis.__FRSH_BUILD_ID}/illustration/1x.avif, /_frsh/static/${globalThis.__FRSH_BUILD_ID}/illustration/2x.avif 2x`;
-  assertEquals(assetSrcSet(srcset), expected);
 });

--- a/www/routes/docs/[...slug].tsx
+++ b/www/routes/docs/[...slug].tsx
@@ -71,7 +71,7 @@ function Logo() {
   return (
     <a href="/" class={tw`flex mr-3 items-center`}>
       <img
-        src={asset("/logo.svg")}
+        src="/logo.svg"
         alt="Fresh logo"
         width={40}
         height={40}

--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -88,20 +88,16 @@ function Intro() {
     >
       <picture>
         <source
-          srcset={`${asset("/illustration/2x.avif")} 2x, ${
-            asset("/illustration/1x.avif")
-          }`}
+          srcset="/illustration/2x.avif 2x, /illustration/1x.avif"
           type="image/avif"
         />
         <source
-          srcset={`${asset("/illustration/2x.webp")} 2x, ${
-            asset("/illustration/1x.webp")
-          }`}
+          srcset="/illustration/2x.webp2x, /illustration/1x.webp"
           type="image/webp"
         />
         <img
-          src={asset("/illustration/1x.jpeg")}
-          srcset={`${asset("/illustration/2x.jpeg")} 2x`}
+          src="/illustration/1x.jpeg"
+          srcset="/illustration/2x.jpeg 2x"
           class={tw`w-64 mx-auto`}
           width={800}
           height={678}

--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -96,7 +96,7 @@ function Intro() {
           type="image/webp"
         />
         <img
-          src="/illustration/1x.jpeg"
+          src="/illustration/1x.jpg"
           srcset="/illustration/2x.jpeg 2x"
           class={tw`w-64 mx-auto`}
           width={800}

--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -97,7 +97,7 @@ function Intro() {
         />
         <img
           src="/illustration/1x.jpg"
-          srcset="/illustration/2x.jpeg 2x"
+          srcset="/illustration/2x.jpg 2x"
           class={tw`w-64 mx-auto`}
           width={800}
           height={678}


### PR DESCRIPTION
fix https://github.com/lucacasonato/fresh/issues/167

> This would be done only for asset URLs that we definitely know to be static assets (the server knows the paths of all assets in the static/ directory).

I stumble on this because the preact hook needs to run on the client when an island is revived. This would require to pass the list of asset to the client, maybe using the island props, which would be cumbersome. Instead the hook assume that if the src path is starting with `/` then it must be a static asset as this is what fresh also assume.  WDYT ?