### PR TITLE
Add documentation section in readme and fix blue links

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,5 @@ project to GitHub, create a `fresh` project, and link it to `main.ts` file in
 the created repository.
 
 For a more in-depth getting started guide, visit the
-[Getting Started](https://fresh.deno.dev/docs/getting-started) page in the `fresh` docs.
+[Getting Started](https://fresh.deno.dev/docs/getting-started) page in the
+`fresh` docs.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ the framework.
 - TypeScript out of the box
 - File-system routing à la Next.js
 
+## Documentation
+
+The [documentation](https://fresh.deno.dev/docs/) is available on
+[fresh.deno.dev](https://fresh.deno.dev/).
+
 ## Install
 
 To install, run the following command. This will add `fresh` CLI to your PATH.
@@ -53,4 +58,4 @@ project to GitHub, create a `fresh` project, and link it to `main.ts` file in
 the created repository.
 
 For a more in-depth getting started guide, visit the
-[Getting Started](./docs/getting-started.md) page in the `fresh` docs.
+[Getting Started](https://fresh.deno.dev/docs/getting-started) page in the `fresh` docs.

--- a/www/client_deps.ts
+++ b/www/client_deps.ts
@@ -5,6 +5,7 @@ import * as colors from "https://esm.sh/twind@0.16.16/colors";
 export { apply, setup, tw };
 export const theme = {
   colors: {
+    blue: colors.blue,
     black: colors.black,
     gray: colors.gray,
     green: colors.green,


### PR DESCRIPTION

1. The online documentation link is not easy to find. It is currently only showing in the about section which is hidden quickly when scrolling down to read the readme. I have added a more explicit section in the readme.

2. In the online home page the blue color is not showing up as it is used not present in the theme.
    before 
    <img width="344" alt="image" src="https://user-images.githubusercontent.com/10268458/168421353-cff9a646-58b0-48d9-818e-bfb272c685d9.png">
    after 
    <img width="364" alt="image" src="https://user-images.githubusercontent.com/10268458/168421337-27547a7d-fb24-4f0a-9e0b-76c681ee7273.png">




