### PR TITLE
Docs fix typo

### DIFF
--- a/docs/concepts/middleware.md
+++ b/docs/concepts/middleware.md
@@ -48,7 +48,7 @@ specific first).
 
 For example, take a project with the following routes:
 
-- `routes/_middlware.ts`
+- `routes/_middleware.ts`
 - `routes/index.ts`
 - `routes/admin/_middleware.ts`
 - `routes/admin/index.ts`
@@ -56,17 +56,17 @@ For example, take a project with the following routes:
 
 For a request to `/` the request will flow like this:
 
-1. The `routes/_middlware.ts` middlware is invoked.
+1. The `routes/_middleware.ts` middleware is invoked.
 2. Calling `ctx.next()` will invoke the `routes/index.ts` handler.
 
 For a request to `/admin` the request flow like this:
 
-1. The `routes/_middlware.ts` middlware is invoked.
+1. The `routes/_middleware.ts` middleware is invoked.
 2. Calling `ctx.next()` will invoke the `routes/admin/_middleware.ts` middlware.
 3. Calling `ctx.next()` will invoke the `routes/admin/index.ts` handler.
 
 For a request to `/admin/signin` the request flow like this:
 
-1. The `routes/_middlware.ts` middlware is invoked.
-2. Calling `ctx.next()` will invoke the `routes/admin/_middleware.ts` middlware.
+1. The `routes/_middleware.ts` middleware is invoked.
+2. Calling `ctx.next()` will invoke the `routes/admin/_middleware.ts` middleware.
 3. Calling `ctx.next()` will invoke the `routes/admin/signin.ts` handler.

--- a/docs/concepts/middleware.md
+++ b/docs/concepts/middleware.md
@@ -68,5 +68,6 @@ For a request to `/admin` the request flow like this:
 For a request to `/admin/signin` the request flow like this:
 
 1. The `routes/_middleware.ts` middleware is invoked.
-2. Calling `ctx.next()` will invoke the `routes/admin/_middleware.ts` middleware.
+2. Calling `ctx.next()` will invoke the `routes/admin/_middleware.ts`
+   middleware.
 3. Calling `ctx.next()` will invoke the `routes/admin/signin.ts` handler.

--- a/docs/concepts/routes.md
+++ b/docs/concepts/routes.md
@@ -69,8 +69,8 @@ import { h, PageProps } from "$fresh/runtime.ts";
 import { HandlerContext, Handlers } from "$fresh/server.ts";
 
 export const handler: Handlers = {
-  GET(ctx: HandlerContext) {
-    const resp = ctx.render();
+  async GET(ctx: HandlerContext) {
+    const resp = await ctx.render();
     resp.headers.set("X-Custom-Header", "Hello World");
     return resp;
   },

--- a/docs/getting-started/custom-handlers.md
+++ b/docs/getting-started/custom-handlers.md
@@ -35,8 +35,8 @@ import { h } from "$fresh/runtime.ts";
 import { Handlers } from "$fresh/server.ts";
 
 export const handler: Handlers = {
-  GET(req, ctx) {
-    const resp = ctx.render();
+  async GET(req, ctx) {
+    const resp = await ctx.render();
     resp.headers.set("X-Custom-Header", "Hello");
     return resp;
   },

--- a/docs/getting-started/custom-handlers.md
+++ b/docs/getting-started/custom-handlers.md
@@ -31,7 +31,8 @@ then adds a custom header to the response before returning it:
 // routes/about.tsx
 
 /** @jsx h */
-import { h, Handlers } from "$fresh/runtime.ts";
+import { h } from "$fresh/runtime.ts";
+import { Handlers } from "$fresh/server.ts";
 
 export const handler: Handlers = {
   GET(req, ctx) {
@@ -58,7 +59,7 @@ response:
 ```ts
 // routes/api/random-uuid.ts
 
-import { Handlers } from "$fresh/runtime.ts";
+import { Handlers } from "$fresh/server.ts";
 
 export const handler: Handlers = {
   GET(req) {

--- a/docs/getting-started/form-submissions.md
+++ b/docs/getting-started/form-submissions.md
@@ -16,7 +16,7 @@ around the HTML `<form>` element.
 next chapter explains how to progressively enhance your forms with client side
 JavaScript to make them more interactive.
 
-The way forms work in the browser, is that they peform a HTML navigation action
+The way forms work in the browser, is that they perform a HTML navigation action
 when the user submits the form. In most cases this means that when the form is
 submitted, a GET or POST request is sent to the server with the form data, which
 then responds with a new page to render.


### PR DESCRIPTION
Fix some typos in docs, "middlware" becoming "middleware", an "peform" becoming "perform".