### PR TITLE
fixing function name in dynamic-routes doc

### DIFF
--- a/docs/getting-started/dynamic-routes.md
+++ b/docs/getting-started/dynamic-routes.md
@@ -30,7 +30,7 @@ as arguments in it's `props` object though.
 /** @jsx h */
 import { h, PageProps } from "$fresh/runtime.ts";
 
-export default function AboutPage(props: PageProps) {
+export default function GreetPage(props: PageProps) {
   const { name } = props.params;
   return (
     <main>


### PR DESCRIPTION
In this section we are adding a new Greeting Page. I think the function for this page should be named appropriately to the content it is rendering.