### PR TITLE
fix: webp image source

### DIFF
--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -92,7 +92,7 @@ function Intro() {
           type="image/avif"
         />
         <source
-          srcset="/illustration/2x.webp2x, /illustration/1x.webp"
+          srcset="/illustration/2x.webp 2x, /illustration/1x.webp"
           type="image/webp"
         />
         <img


### PR DESCRIPTION
Fix broken image source when serving webp format
![image](https://user-images.githubusercontent.com/10532751/171405643-382f0ddf-05db-4520-9011-9e89647e8f7f.png)
