### PR TITLE
Remove curly braces in import for Countdown

### DIFF
--- a/docs/getting-started/adding-interactivity.md
+++ b/docs/getting-started/adding-interactivity.md
@@ -74,7 +74,7 @@ client with the correct props:
 
 /** @jsx h */
 import { h } from "$fresh/runtime.ts";
-import { Countdown } from "../islands/Countdown.tsx";
+import Countdown from "../islands/Countdown.tsx";
 
 export default function Page() {
   const date = new Date();


### PR DESCRIPTION
Since Countdown is a default export, putting curly braces here will raise an error