### PR TITLE
www: use `tabular-nums` on Counter count

### DIFF
--- a/www/islands/Counter.tsx
+++ b/www/islands/Counter.tsx
@@ -22,7 +22,7 @@ export default function Counter(props: CounterProps) {
       >
         <IconMinus />
       </RoundedButton>
-      <div class={tw`text-3xl`}>{count}</div>
+      <div class={tw`text-3xl tabular-nums`}>{count}</div>
       <RoundedButton
         title="Add 1"
         onClick={() => setCount(count + 1)}


### PR DESCRIPTION
`font-variant-numeric: tabular-nums` makes each number glyph take up the same amount of space, which in turn makes the add and subtract buttons move less about when altering the count. This has a slight accessibility benefit, but adds some extra whitespace between some combinations of numbers when the count is 10 or above.

Before: 
![](https://user-images.githubusercontent.com/9085189/174058371-d46be293-3d63-4ac2-8e9e-d74ba0e69b98.png)

After:
![](https://user-images.githubusercontent.com/9085189/174058436-c128db4b-9829-4a94-9d67-fb25357401a8.png)


This change is purely for improving(?) UX on the Fresh landing page and I won't be offended if it's not the kind of submissions you consider adding. Thanks anyways for making such a cool framework! Can't wait to see its future.