### PR TITLE
test: add test to ensure asset mapping in islands also works correctly client side

### DIFF
--- a/tests/fixture/routes/islands/index.tsx
+++ b/tests/fixture/routes/islands/index.tsx
@@ -9,7 +9,7 @@ export default function Home() {
     <div>
       <Counter id="counter1" start={3} />
       <Counter id="counter2" start={10} />
-      <Test message=""/>
+      <Test message="" />
     </div>
   );
 }

--- a/tests/fixture/routes/islands/index.tsx
+++ b/tests/fixture/routes/islands/index.tsx
@@ -2,12 +2,14 @@
 
 import { h } from "$fresh/runtime.ts";
 import Counter from "../../islands/Counter.tsx";
+import Test from "../../islands/Test.tsx";
 
 export default function Home() {
   return (
     <div>
       <Counter id="counter1" start={3} />
       <Counter id="counter2" start={10} />
+      <Test message=""/>
     </div>
   );
 }

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -52,17 +52,17 @@ Deno.test({
       await counterTest("counter2", 10);
     });
 
-    await t.step("Ensure an island revive correctly the 'hash' path", async () => {
-      // ensure it is the same as on the server
+    await t.step("Ensure an island revive an img 'hash' path", async () => {      
+      // Ensure src path has __frsh_c=
+      const pElem = await page.waitForSelector(`#img-in-island`);
+      const srcString = (await pElem?.getProperty('src'))?.toString()!
+      assertStringIncludes(srcString, 'image.png?__frsh_c=');
+      
+      // Ensure src path is the same as server rendered
       const resp = await fetch(new Request("http://localhost:8000/islands"));
       const body = await resp.text();
       const imgFilePath = body.match(/img id="img-in-island" src="(.*?)"/)?.[1]!;
-      
-      // assertStringIncludes(body, "<div>Book 123</div>");
-      const pElem = await page.waitForSelector(`#img-in-island`);
-      const srcString = (await pElem?.getProperty('src'))?.toString()!
       assertStringIncludes(srcString, imgFilePath)
-      assertStringIncludes(srcString, 'image.png?__frsh_c=');
     });
 
     await browser.close();

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -1,4 +1,4 @@
-import { assert, delay, puppeteer, TextLineStream } from "./deps.ts";
+import { assert, assertStringIncludes, delay, puppeteer, TextLineStream } from "./deps.ts";
 
 Deno.test({
   name: "island tests",
@@ -50,6 +50,19 @@ Deno.test({
     await t.step("Ensure 2 islands on 1 page are revived", async () => {
       await counterTest("counter1", 3);
       await counterTest("counter2", 10);
+    });
+
+    await t.step("Ensure an island revive correctly the 'hash' path", async () => {
+      // ensure it is the same as on the server
+      const resp = await fetch(new Request("http://localhost:8000/islands"));
+      const body = await resp.text();
+      const imgFilePath = body.match(/img id="img-in-island" src="(.*?)"/)?.[1]!;
+      
+      // assertStringIncludes(body, "<div>Book 123</div>");
+      const pElem = await page.waitForSelector(`#img-in-island`);
+      const srcString = (await pElem?.getProperty('src'))?.toString()!
+      assertStringIncludes(srcString, imgFilePath)
+      assertStringIncludes(srcString, 'image.png?__frsh_c=');
     });
 
     await browser.close();

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -1,4 +1,10 @@
-import { assert, assertStringIncludes, delay, puppeteer, TextLineStream } from "./deps.ts";
+import {
+  assert,
+  assertStringIncludes,
+  delay,
+  puppeteer,
+  TextLineStream,
+} from "./deps.ts";
 
 Deno.test({
   name: "island tests",
@@ -52,17 +58,18 @@ Deno.test({
       await counterTest("counter2", 10);
     });
 
-    await t.step("Ensure an island revive an img 'hash' path", async () => {      
+    await t.step("Ensure an island revive an img 'hash' path", async () => {
       // Ensure src path has __frsh_c=
       const pElem = await page.waitForSelector(`#img-in-island`);
-      const srcString = (await pElem?.getProperty('src'))?.toString()!
-      assertStringIncludes(srcString, 'image.png?__frsh_c=');
-      
+      const srcString = (await pElem?.getProperty("src"))?.toString()!;
+      assertStringIncludes(srcString, "image.png?__frsh_c=");
+
       // Ensure src path is the same as server rendered
       const resp = await fetch(new Request("http://localhost:8000/islands"));
       const body = await resp.text();
-      const imgFilePath = body.match(/img id="img-in-island" src="(.*?)"/)?.[1]!;
-      assertStringIncludes(srcString, imgFilePath)
+      const imgFilePath = body.match(/img id="img-in-island" src="(.*?)"/)
+        ?.[1]!;
+      assertStringIncludes(srcString, imgFilePath);
     });
 
     await browser.close();


### PR DESCRIPTION

Follow-up of https://github.com/lucacasonato/fresh/pull/184 as per https://github.com/lucacasonato/fresh/pull/184#pullrequestreview-978959802

Add a test to ensure an image 'hashed' src path in an island is revived correctly