### PR TITLE
Navigate Documentation with Unicode Arrows

### DIFF
--- a/www/routes/docs/[...slug].tsx
+++ b/www/routes/docs/[...slug].tsx
@@ -239,7 +239,7 @@ function ForwardBackButtons(props: { slug: string }) {
     <div class={tw`mt-8 flex flex(col md:row) gap-4`}>
       {previous && (
         <a href={previous.href} class={tw`${button} text-left`}>
-          <span class={upper}>{"<-"} Previous</span>
+          <span class={upper}>{"←"} Previous</span>
           <span class={lower}>
             <span class={category}>
               {previous.category
@@ -252,7 +252,7 @@ function ForwardBackButtons(props: { slug: string }) {
       )}
       {next && (
         <a href={next.href} class={tw`${button} text-right`}>
-          <span class={upper}>Next {"->"}</span>
+          <span class={upper}>Next {"→"}</span>
           <span class={lower}>
             <span class={category}>
               {next.category


### PR DESCRIPTION
Prefer unicode arrows to those made of ascii art.

I continue my Fresh tutorial by forking, editing, and testing the fresh www server.

Notice how nice the arrows at the bottom of this screen shot look. Sweet.

<img width="749" alt="image" src="https://user-images.githubusercontent.com/12127/174417500-718a6936-0ded-4b35-ad60-e76bafd39f28.png">
