### PR TITLE
chore: remove --no-check flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can scaffold a new project by running the Fresh init script. To scaffold a
 project in the `myproject` folder, run the following:
 
 ```sh
-deno run -A --no-check https://raw.githubusercontent.com/lucacasonato/fresh/main/init.ts my-project
+deno run -A https://raw.githubusercontent.com/lucacasonato/fresh/main/init.ts my-project
 ```
 
 To now start the project, use `deno task`:

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,8 +1,8 @@
 {
   "tasks": {
-    "test": "deno test -A --no-check=remote && deno check --config=www/deno.json www/main.ts www/dev.ts && deno check init.ts",
-    "fixture": "deno run -A --watch=static/,routes/,islands/ tests/fixture/dev.ts",
-    "www": "deno run -A --watch=static/,routes/,islands/ www/dev.ts"
+    "test": "deno test -A && deno check --config=www/deno.json www/main.ts www/dev.ts && deno check init.ts",
+    "fixture": "deno run -A --watch=static/,routes/ tests/fixture/dev.ts",
+    "www": "deno run -A --watch=static/,routes/ www/dev.ts"
   },
   "importMap": "./tests/fixture/import_map.json"
 }

--- a/docs/getting-started/create-a-project.md
+++ b/docs/getting-started/create-a-project.md
@@ -10,7 +10,7 @@ will scaffold out a new project with some example files to get you started.
 To create a new project in the directory `"my-project"`, run:
 
 ```
-$ deno run -A --no-check https://raw.githubusercontent.com/lucacasonato/fresh/main/init.ts my-project
+$ deno run -A https://raw.githubusercontent.com/lucacasonato/fresh/main/init.ts my-project
 The manifest has been generated for 3 routes and 1 islands.
 
 Project created!

--- a/docs/getting-started/running-locally.md
+++ b/docs/getting-started/running-locally.md
@@ -29,19 +29,14 @@ fresh server will automatically reload whenever you make a change to your code.
 By default `--watch` only watches over files in your module graph. Some project
 files like static files are not part of the module graph, but you probably want
 to restart/reload whenever you make a change to them too. This can be done by
-passing the extra folder as an argument: `--watch=static/`.
-
-Finally you might want to add a `--no-check` flag to disable the type checking
-during development. Typically many people already get type checking from their
-editor through the use of the Deno language server, so this is a good way to
-speed up the inner loop iteration time. During CI you probably want to run with
-`--no-check=remote` disable type checking of remote dependencies (because these
-are out of your control).
+passing the extra folder as an argument: `--watch=static/`. You should also add
+`routes/` to the watch list, so that the server restarts automatically whenever
+you add a new route.
 
 Combining all of this we get the following `deno run` command:
 
 ```
-$ deno run --allow-net --allow-read --allow-env --allow-run --watch=static/ --no-check main.ts
+$ deno run --allow-net --allow-read --allow-env --allow-run --watch=static/,routes/ main.ts
 Watcher Process started.
 Server listening on http://localhost:8000
 ```

--- a/examples/counter/deno.json
+++ b/examples/counter/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "start": "deno run -A --watch=static/,routes/,islands/ dev.ts"
+    "start": "deno run -A --watch=static/,routes/ dev.ts"
   },
   "importMap": "./import_map.json"
 }

--- a/examples/counter/dev.ts
+++ b/examples/counter/dev.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run -A --watch=static/,routes/,islands/
+#!/usr/bin/env -S deno run -A --watch=static/,routes/
 
 import dev from "$fresh/dev.ts";
 

--- a/init.ts
+++ b/init.ts
@@ -177,7 +177,7 @@ await start(manifest);
 const MAIN_TS_PATH = join(directory, "main.ts");
 await Deno.writeTextFile(MAIN_TS_PATH, MAIN_TS);
 
-const DEV_TS = `#!/usr/bin/env -S deno run -A --watch=static/,routes/,islands/
+const DEV_TS = `#!/usr/bin/env -S deno run -A --watch=static/,routes/
 
 import dev from "$fresh/dev.ts";
 
@@ -194,7 +194,7 @@ try {
 const DENO_CONFIG = JSON.stringify(
   {
     tasks: {
-      start: "deno run -A --watch=static/,routes/,islands/ --no-check dev.ts",
+      start: "deno run -A --watch=static/,routes/ dev.ts",
     },
     importMap: "./import_map.json",
   },

--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -46,7 +46,7 @@ Deno.test({
 
     await t.step("execute init command", async () => {
       const cliProcess = Deno.run({
-        cmd: ["deno", "run", "-A", "--no-check", "init.ts", tmpDirName],
+        cmd: ["deno", "run", "-A", "init.ts", tmpDirName],
         stdout: "null",
       });
       const { code } = await cliProcess.status();
@@ -103,7 +103,7 @@ Deno.test({
 
     await t.step("start up the server and access the root page", async () => {
       const serverProcess = Deno.run({
-        cmd: ["deno", "run", "-A", "--no-check", "main.ts"],
+        cmd: ["deno", "run", "-A", "main.ts"],
         stdout: "piped",
         stderr: "inherit",
         cwd: tmpDirName,

--- a/tests/fixture/dev.ts
+++ b/tests/fixture/dev.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run -A --watch=static/,routes/,islands/
+#!/usr/bin/env -S deno run -A --watch=static/,routes/
 
 import dev from "$fresh/dev.ts";
 

--- a/tests/fixture_error/dev.ts
+++ b/tests/fixture_error/dev.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run -A --watch=static/,routes/,islands/
+#!/usr/bin/env -S deno run -A --watch=static/,routes/
 
 import dev from "$fresh/dev.ts";
 

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -5,7 +5,7 @@ Deno.test({
   async fn(t) {
     // Preparation
     const serverProcess = Deno.run({
-      cmd: ["deno", "run", "-A", "--no-check", "./tests/fixture/main.ts"],
+      cmd: ["deno", "run", "-A", "./tests/fixture/main.ts"],
       stdout: "piped",
       stderr: "inherit",
     });

--- a/www/deno.json
+++ b/www/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "start": "deno run -A --watch=static/,routes/,islands/ dev.ts"
+    "start": "deno run -A --watch=static/,routes/ dev.ts"
   },
   "importMap": "./import_map.json"
 }

--- a/www/dev.ts
+++ b/www/dev.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run -A --watch=static/,routes/,islands/
+#!/usr/bin/env -S deno run -A --watch=static/,routes/
 
 import dev from "$fresh/dev.ts";
 

--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -153,13 +153,13 @@ function GettingStarted() {
         <a href="https://deno.land" class={tw`text-blue-600 hover:underline`}>
           Deno CLI
         </a>{" "}
-        version 1.22.3 or higher installed.
+        version 1.23.0 or higher installed.
       </p>
       <p class={tw`text-gray-600`}>
         Then you can use the Fresh init script to bootstrap a new project:
       </p>
       <pre class={tw`overflow-x-auto py-2 px-4 bg(gray-100)`}>
-        {"deno run -A --no-check https://raw.githubusercontent.com/lucacasonato/fresh/main/init.ts my-app"}
+        {"deno run -A https://raw.githubusercontent.com/lucacasonato/fresh/main/init.ts my-app"}
       </pre>
       <p class={tw`text-gray-600`}>
         Enter the newly created project directory and run the following command


### PR DESCRIPTION
Since Deno 1.23.0, `--no-check` has become the default type checking
mode for `deno run`. As such, we don't need to specify this flag
anymore.
