### PR TITLE
refactor: dev mode also depends on DENO_ENV variable

### DIFF
--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -2,10 +2,10 @@ import { INTERNAL_PREFIX } from "../runtime/utils.ts";
 
 export const REFRESH_JS_URL = `${INTERNAL_PREFIX}/refresh.js`;
 export const ALIVE_URL = `${INTERNAL_PREFIX}/alive`;
-export const BUILD_ID = Deno.env.get("DENO_DEPLOYMENT_ID") ||
-  crypto.randomUUID();
+export const BUILD_ID = Deno.env.get("DENO_DEPLOYMENT_ID") || crypto.randomUUID();
 export const JS_PREFIX = `/js`;
-export const DEBUG = !Deno.env.get("DENO_DEPLOYMENT_ID");
+export const DENO_ENV = Deno.env.get("DENO_ENV");
+export const DEBUG = !Deno.env.get("DENO_DEPLOYMENT_ID") && DENO_ENV !== "prod";
 
 export function bundleAssetUrl(path: string) {
   return `${INTERNAL_PREFIX}${JS_PREFIX}/${BUILD_ID}${path}`;

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -11,7 +11,7 @@ import {
 import { h } from "preact";
 import { Manifest } from "./mod.ts";
 import { Bundler } from "./bundle.ts";
-import { ALIVE_URL, BUILD_ID, JS_PREFIX, REFRESH_JS_URL } from "./constants.ts";
+import { ALIVE_URL, BUILD_ID, JS_PREFIX, REFRESH_JS_URL, DENO_ENV } from "./constants.ts";
 import DefaultErrorHandler from "./default_error_page.tsx";
 import {
   AppModule,
@@ -82,7 +82,7 @@ export class ServerContext {
     this.#notFound = notFound;
     this.#error = error;
     this.#bundler = new Bundler(this.#islands, importMapURL);
-    this.#dev = typeof Deno.env.get("DENO_DEPLOYMENT_ID") !== "string"; // Env var is only set in prod (on Deploy).
+    this.#dev = !Deno.env.get("DENO_DEPLOYMENT_ID") && DENO_ENV !== "prod";
   }
 
   /**


### PR DESCRIPTION
Check for `Deno.env.get("DENO_ENV")` for prod mode instead of depending only to `Deno.env.get("DENO_DEPLOYMENT_ID")`
So we can just add:
```
DENO_ENV=prod
```
Also this should be solution for: https://github.com/lucacasonato/fresh/issues/84