### PR TITLE
init: add favicon.ico to static

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -233,6 +233,13 @@ await Deno.writeTextFile(
   STATIC_LOGO,
 );
 
+const faviconArrayBuffer = await fetch("https://fresh.deno.dev/favicon.ico")
+  .then((d) => d.arrayBuffer());
+await Deno.writeFile(
+  join(directory, "static", "favicon.ico"),
+  new Uint8Array(faviconArrayBuffer),
+);
+
 let MAIN_TS = `/// <reference no-default-lib="true" />
 /// <reference lib="dom" />
 /// <reference lib="dom.asynciterable" />

--- a/init.ts
+++ b/init.ts
@@ -233,12 +233,16 @@ await Deno.writeTextFile(
   STATIC_LOGO,
 );
 
-const faviconArrayBuffer = await fetch("https://fresh.deno.dev/favicon.ico")
-  .then((d) => d.arrayBuffer());
-await Deno.writeFile(
-  join(directory, "static", "favicon.ico"),
-  new Uint8Array(faviconArrayBuffer),
-);
+try {
+  const faviconArrayBuffer = await fetch("https://fresh.deno.dev/favicon.ico")
+    .then((d) => d.arrayBuffer());
+  await Deno.writeFile(
+    join(directory, "static", "favicon.ico"),
+    new Uint8Array(faviconArrayBuffer),
+  );
+} catch {
+  // Skip this and be silent if there is a nework issue.
+}
 
 let MAIN_TS = `/// <reference no-default-lib="true" />
 /// <reference lib="dom" />


### PR DESCRIPTION
Browswers try to get `/favicon.ico` by default.
This request enters `[name].tsx` and returns greet unexpectedly.
To guard it, favicon is fetched from `https://fresh.deno.dev` and save into `static`.