### PR TITLE
feat: allow lang configuration

### DIFF
--- a/src/server/render.tsx
+++ b/src/server/render.tsx
@@ -26,6 +26,7 @@ export interface RenderOptions<Data> {
   renderFn: RenderFunction;
   data?: Data;
   error?: unknown;
+  lang?: string;
 }
 
 export type InnerRenderFunction = () => string;
@@ -36,12 +37,13 @@ export class RenderContext {
   #styles: string[] = [];
   #url: URL;
   #route: string;
-  #lang = "en";
+  #lang: string;
 
-  constructor(id: string, url: URL, route: string) {
+  constructor(id: string, url: URL, route: string, lang: string) {
     this.#id = id;
     this.#url = url;
     this.#route = route;
+    this.#lang = lang;
   }
 
   /** A unique ID for this logical JIT render. */
@@ -151,6 +153,7 @@ export async function render<Data>(
     crypto.randomUUID(),
     opts.url,
     opts.route.pattern,
+    opts.lang ?? 'en',
   );
 
   if (csp) {

--- a/src/server/render.tsx
+++ b/src/server/render.tsx
@@ -153,7 +153,7 @@ export async function render<Data>(
     crypto.randomUUID(),
     opts.url,
     opts.route.pattern,
-    opts.lang ?? 'en',
+    opts.lang ?? "en",
   );
 
   if (csp) {

--- a/src/server/render_test.ts
+++ b/src/server/render_test.ts
@@ -1,0 +1,14 @@
+import { template } from "./render.tsx";
+import { assertStringIncludes } from "../../tests/deps.ts";
+Deno.test("check lang", () => {
+  const lang = "fr";
+  const body = template({
+    bodyHtml: "",
+    headComponents: [],
+    imports: [],
+    preloads: [],
+    styles: [],
+    lang: lang,
+  });
+  assertStringIncludes(body, `<html lang="${lang}">`);
+});


### PR DESCRIPTION
In render function, can set HTML lang using `ctx.lang = "fr"`, by default it remains `en`