### PR TITLE
docs: fix typos

### DIFF
--- a/docs/concepts/data-fetching.md
+++ b/docs/concepts/data-fetching.md
@@ -3,10 +3,10 @@ description: |
   Data fetching in Fresh happens inside of route handler functions. These can pass route data to the page via page props.
 ---
 
-Server side data fetching in Fresh is acomplished through asynchronous
+Server side data fetching in Fresh is accomplished through asynchronous
 [handler functions][route-handlers]. These handler functions can call a
 `ctx.render()` function with the data to be rendered as an argument. This data
-can then be retreived by the page component through the `data` property on the
+can then be retrieved by the page component through the `data` property on the
 `props`.
 
 Here is an example:

--- a/docs/concepts/error-pages.md
+++ b/docs/concepts/error-pages.md
@@ -5,7 +5,7 @@ description: |
 
 Fresh supports customizing the `404 Not Found`, and the
 `500 Internal Server Error` pages. These are shown when a request is made but no
-matching route exists, and when a middelware, route handler, or page component
+matching route exists, and when a middleware, route handler, or page component
 throws an error respectively.
 
 The 404 page can be customized by creating a `_404.tsx` file in the `routes/`

--- a/docs/concepts/islands.md
+++ b/docs/concepts/islands.md
@@ -4,7 +4,7 @@ description: |
 ---
 
 Islands enable client side interactivity in Fresh. Islands are isolated Preact
-components that are are rendered on the client. This is different from all other
+components that are rendered on the client. This is different from all other
 components in Fresh, as they are usually just rendered on the server.
 
 Islands are defined by creating a file in the `islands/` folder in a Fresh

--- a/docs/concepts/islands.md
+++ b/docs/concepts/islands.md
@@ -5,7 +5,7 @@ description: |
 
 Islands enable client side interactivity in Fresh. Islands are isolated Preact
 components that are are rendered on the client. This is different from all other
-components in Fresh, as they are ususally just rendered on the server.
+components in Fresh, as they are usually just rendered on the server.
 
 Islands are defined by creating a file in the `islands/` folder in a Fresh
 project. The name of this file must be a PascalCase name of the island. The file

--- a/docs/concepts/middleware.md
+++ b/docs/concepts/middleware.md
@@ -61,7 +61,7 @@ For a request to `/` the request will flow like this:
 For a request to `/admin` the request flows like this:
 
 1. The `routes/_middleware.ts` middleware is invoked.
-2. Calling `ctx.next()` will invoke the `routes/admin/_middleware.ts` middlware.
+2. Calling `ctx.next()` will invoke the `routes/admin/_middleware.ts` middleware.
 3. Calling `ctx.next()` will invoke the `routes/admin/index.ts` handler.
 
 For a request to `/admin/signin` the request flows like this:

--- a/docs/concepts/middleware.md
+++ b/docs/concepts/middleware.md
@@ -61,7 +61,8 @@ For a request to `/` the request will flow like this:
 For a request to `/admin` the request flows like this:
 
 1. The `routes/_middleware.ts` middleware is invoked.
-2. Calling `ctx.next()` will invoke the `routes/admin/_middleware.ts` middleware.
+2. Calling `ctx.next()` will invoke the `routes/admin/_middleware.ts`
+   middleware.
 3. Calling `ctx.next()` will invoke the `routes/admin/index.ts` handler.
 
 For a request to `/admin/signin` the request flows like this:

--- a/docs/getting-started/create-a-route.md
+++ b/docs/getting-started/create-a-route.md
@@ -52,12 +52,12 @@ export default function AboutPage() {
 
 > ℹ️ The first two lines are the JSX pragma, and the import for the JSX create
 > element function. These are just boilerplate. You don't need to know exactly
-> what they do - they just ensure that JSX get's rendered correctly.
+> what they do - they just ensure that JSX gets rendered correctly.
 
 The new page will be visible at `http://localhost:8000/about`.
 
 <!-- You can find more in depth information about routes on the
-[_Concepts: Routes_][concepts-routes] documentation page page. The following
+[_Concepts: Routes_][concepts-routes] documentation page. The following
 pages in the _Getting Started_ guide will also explain more features of routes. -->
 
 [concepts-routing]: /docs/concepts/routing


### PR DESCRIPTION
this commit fixes a few small typos in the docs. I didn't try to editorialize anything here, just a few single word replacements that I picked up on while going through the docs