### PR TITLE
feat: add vscode files on init

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -36,6 +36,7 @@ USAGE:
 OPTIONS:
     --force   Overwrite existing files
     --twind   Setup project to use 'twind' for styling
+    --vscode  Setup project for VSCode
 `;
 
 const CONFIRM_EMPTY_MESSAGE =
@@ -44,9 +45,11 @@ const CONFIRM_EMPTY_MESSAGE =
 const USE_TWIND_MESSAGE =
   "Do you want to use 'twind' (https://twind.dev/) for styling?";
 
+const USE_VSCODE_MESSAGE = "Do you use VS Code?";
+
 const flags = parse(Deno.args, {
-  boolean: ["force", "twind"],
-  default: { "force": null, "twind": null },
+  boolean: ["force", "twind", "vscode"],
+  default: { "force": null, "twind": null, "vscode": null },
 });
 
 if (flags._.length !== 1) {
@@ -76,9 +79,14 @@ const useTwind = flags.twind === null
   ? confirm(USE_TWIND_MESSAGE)
   : flags.twind;
 
+const useVSCode = flags.vscode === null
+  ? confirm(USE_VSCODE_MESSAGE)
+  : flags.vscode;
+
 await Deno.mkdir(join(directory, "routes", "api"), { recursive: true });
 await Deno.mkdir(join(directory, "islands"), { recursive: true });
 await Deno.mkdir(join(directory, "static"), { recursive: true });
+if (useVSCode) await Deno.mkdir(join(directory, ".vscode"), { recursive: true });
 if (useTwind) await Deno.mkdir(join(directory, "utils"), { recursive: true });
 
 const importMap = {
@@ -338,6 +346,32 @@ await Deno.writeTextFile(
   join(directory, "README.md"),
   README_MD,
 );
+
+const vscodeSettings = {
+  "deno.enable": true,
+};
+
+const VSCODE_SETTINGS = JSON.stringify(vscodeSettings, null, 2) + "\n";
+
+if (useVSCode) {
+  await Deno.writeTextFile(
+    join(directory, ".vscode", "settings.json"),
+    VSCODE_SETTINGS
+  );
+}
+
+const vscodeExtensions = {
+  recommendations: ["denoland.vscode-deno"],
+};
+
+const VSCODE_EXTENSIONS = JSON.stringify(vscodeExtensions, null, 2) + "\n";
+
+if (useVSCode) {
+  await Deno.writeTextFile(
+    join(directory, ".vscode", "extensions.json"),
+    VSCODE_EXTENSIONS
+  );
+}
 
 const manifest = await collect(directory);
 await generate(directory, manifest);

--- a/init.ts
+++ b/init.ts
@@ -86,7 +86,9 @@ const useVSCode = flags.vscode === null
 await Deno.mkdir(join(directory, "routes", "api"), { recursive: true });
 await Deno.mkdir(join(directory, "islands"), { recursive: true });
 await Deno.mkdir(join(directory, "static"), { recursive: true });
-if (useVSCode) await Deno.mkdir(join(directory, ".vscode"), { recursive: true });
+if (useVSCode) {
+  await Deno.mkdir(join(directory, ".vscode"), { recursive: true });
+}
 if (useTwind) await Deno.mkdir(join(directory, "utils"), { recursive: true });
 
 const importMap = {
@@ -356,7 +358,7 @@ const VSCODE_SETTINGS = JSON.stringify(vscodeSettings, null, 2) + "\n";
 if (useVSCode) {
   await Deno.writeTextFile(
     join(directory, ".vscode", "settings.json"),
-    VSCODE_SETTINGS
+    VSCODE_SETTINGS,
   );
 }
 
@@ -369,7 +371,7 @@ const VSCODE_EXTENSIONS = JSON.stringify(vscodeExtensions, null, 2) + "\n";
 if (useVSCode) {
   await Deno.writeTextFile(
     join(directory, ".vscode", "extensions.json"),
-    VSCODE_EXTENSIONS
+    VSCODE_EXTENSIONS,
   );
 }
 


### PR DESCRIPTION
I'm guessing a lot of people are coming to Fresh without any knowledge on Deno or never used Deno before.

This PR will add some VSCode files to ease their way into the framework by recommanding the Deno extension and enable Deno's extension by default when they open the project for the first time.

Related issue: https://github.com/denoland/fresh/issues/364