### PR TITLE
perf: reuse URL for each request

### DIFF
--- a/src/server/context_test.ts
+++ b/src/server/context_test.ts
@@ -19,6 +19,6 @@ Deno.test("selectMiddlewares", () => {
   const mwRoutes = middlewaresPath.map((path) =>
     middlewarePathToPattern(path)
   ) as MiddlewareRoute[];
-  const mws = selectMiddlewares(url, mwRoutes);
+  const mws = selectMiddlewares(new URL(url), mwRoutes);
   assert(mws.length === 3);
 });


### PR DESCRIPTION
Minor improvement to throughput. Default app:

```
# main
Running 10s test @ http://127.0.0.1:8000
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   477.26us  223.62us  14.86ms   98.15%
    Req/Sec    10.57k   583.87    11.01k    98.02%
  Latency Distribution
     50%  457.00us
     75%  469.00us
     90%  490.00us
     99%  747.00us
  212537 requests in 10.10s, 102.16MB read
Requests/sec:  21041.02
Transfer/sec:     10.11MB
```

```
# This patch
wrk -d 10s --latency http://127.0.0.1:8000
Running 10s test @ http://127.0.0.1:8000
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   429.60us  215.02us  14.50ms   98.04%
    Req/Sec    11.76k   683.10    12.32k    96.53%
  Latency Distribution
     50%  409.00us
     75%  421.00us
     90%  442.00us
     99%  694.00us
  236346 requests in 10.10s, 113.60MB read
Requests/sec:  23399.90
Transfer/sec:     11.25MB
```
