### PR TITLE
[proposal] feat: add overridable root document

### DIFF
--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -29,6 +29,7 @@ export type {
 } from "./types.ts";
 export { RenderContext } from "./render.tsx";
 export type { InnerRenderFunction } from "./render.tsx";
+export { Body, Links, Meta, Scripts, Styles } from "./template.tsx";
 
 export interface Manifest {
   routes: Record<

--- a/src/server/template.tsx
+++ b/src/server/template.tsx
@@ -1,0 +1,114 @@
+/** @jsx h */
+import { ComponentChildren, createContext, Fragment, h } from "preact";
+import { Root, RootProps } from "./types.ts"
+
+export interface TemplateOptions {
+  bodyHtml: string;
+  headComponents: ComponentChildren[];
+  imports: (readonly [string, string])[];
+  styles: string[];
+  preloads: string[];
+  lang: string;
+  root: Root;
+}
+
+export const TemplateContext = createContext<TemplateOptions | undefined>(undefined);
+
+export function Scripts() {
+  return (
+    <TemplateContext.Consumer>
+      {(context) => {
+        return (
+          <Fragment>
+            {context?.imports.map(([src, nonce]) => (
+              <script src={src} nonce={nonce} type="module"></script>
+            ))}
+          </Fragment>
+        );
+      }}
+    </TemplateContext.Consumer>
+  );
+}
+
+export function Links() {
+  return (
+    <TemplateContext.Consumer>
+      {(context) => {
+        return (
+          <Fragment>
+            {context?.preloads.map((src) => (
+              <link rel="modulepreload" href={src} />
+            ))}
+          </Fragment>
+        );
+      }}
+    </TemplateContext.Consumer>
+  );
+}
+
+export function Styles() {
+  return (
+    <TemplateContext.Consumer>
+      {(context) => {
+        return (
+          <style
+            id="__FRSH_STYLE"
+            dangerouslySetInnerHTML={{
+              __html: context?.styles.join("\n") || "",
+            }}
+          />
+        );
+      }}
+    </TemplateContext.Consumer>
+  );
+}
+
+export function Meta() {
+  return (
+    <TemplateContext.Consumer>
+      {(context) => {
+        return context?.headComponents;
+      }}
+    </TemplateContext.Consumer>
+  );
+}
+
+export function Body() {
+  return (
+    <TemplateContext.Consumer>
+      {(context) => {
+        return (
+          <body dangerouslySetInnerHTML={{ __html: context?.bodyHtml || "" }} />
+        );
+      }}
+    </TemplateContext.Consumer>
+  );
+}
+
+export function Template(props: TemplateOptions) {
+  const Root = props.root.component;
+
+  return (
+    <TemplateContext.Provider value={{ ...props }}>
+      <Root lang={props.lang} />
+    </TemplateContext.Provider>
+  );
+}
+
+export function DefaultRoot({ lang }: RootProps) {
+  return (
+    <html lang={lang}>
+      <head>
+        <meta charSet="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <Links />
+        <Scripts />
+        <Styles />
+        <Meta />
+      </head>
+
+      <Body />
+    </html>
+  );
+}

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -106,6 +106,44 @@ export interface AppModule {
   default: ComponentType<AppProps>;
 }
 
+// --- ROOT ---
+
+export interface RootProps {
+  // /** The URL of the request that resulted in this page being rendered. */
+  // url: URL;
+
+  // /** The route matcher (e.g. /blog/:id) that the request matched for this page
+  //  * to be rendered. */
+  // route: string;
+  lang: string
+}
+
+// export interface UnknownHandlerContext<State = Record<string, unknown>>
+//   extends ConnInfo {
+//   render: () => Response | Promise<Response>;
+//   state: State;
+// }
+
+// export type RootHandler = (
+//   req: Request,
+//   ctx: UnknownHandlerContext,
+// ) => Response | Promise<Response>;
+
+export interface RootModule {
+  default?: ComponentType<RootProps>;
+  // handler?: UnknownHandler;
+  // config?: RouteConfig;
+}
+
+export interface Root {
+  pattern: string;
+  url: string;
+  name: string;
+  component: ComponentType<RootProps>;
+  // handler: UnknownHandler;
+  // csp: boolean;
+}
+
 // --- UNKNOWN PAGE ---
 
 export interface UnknownPageProps {

--- a/www/fresh.gen.ts
+++ b/www/fresh.gen.ts
@@ -2,19 +2,21 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $0 from "./routes/docs/[...slug].tsx";
-import * as $1 from "./routes/gfm.css.ts";
-import * as $2 from "./routes/index.tsx";
-import * as $3 from "./routes/raw.ts";
+import * as $0 from "./routes/_root.tsx";
+import * as $1 from "./routes/docs/[...slug].tsx";
+import * as $2 from "./routes/gfm.css.ts";
+import * as $3 from "./routes/index.tsx";
+import * as $4 from "./routes/raw.ts";
 import * as $$0 from "./islands/Counter.tsx";
 import * as $$1 from "./islands/LemonDrop.tsx";
 
 const manifest = {
   routes: {
-    "./routes/docs/[...slug].tsx": $0,
-    "./routes/gfm.css.ts": $1,
-    "./routes/index.tsx": $2,
-    "./routes/raw.ts": $3,
+    "./routes/_root.tsx": $0,
+    "./routes/docs/[...slug].tsx": $1,
+    "./routes/gfm.css.ts": $2,
+    "./routes/index.tsx": $3,
+    "./routes/raw.ts": $4,
   },
   islands: {
     "./islands/Counter.tsx": $$0,

--- a/www/routes/_root.tsx
+++ b/www/routes/_root.tsx
@@ -1,0 +1,22 @@
+/** @jsx h */
+import { h } from "preact";
+import { Body, Links, Meta, Scripts, Styles } from "$fresh/server.ts";
+
+export default function Root({ lang }: { lang: string }) {
+  return (
+    <html lang={lang}>
+      <head>
+        <meta charSet="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <Meta />
+        <title>Hello from ./routes/_root.tsx</title>
+        <Links />
+        <Scripts />
+        <Styles />
+      </head>
+
+      <Body />
+    </html>
+  );
+}


### PR DESCRIPTION
Hello,

I was tinkering a little with the Fresh codebase. As mentioned in https://github.com/denoland/fresh/issues/338 , I think having the ability to customize the root document of your Fresh app could be a nice feature to add and could be mandatory in some situation.

Example in the Fresh website repo to illustrate (obviously, this is just to illustrate how the PR works):
`./routes/_root.tsx`
```ts
/** @jsx h */
import { h } from "preact";
import { Body, Links, Meta, Scripts, Styles } from "$fresh/server.ts";

export default function Root({ lang }: { lang: string }) { // I kept the `lang` options for retrocompatibility
  return (
    <html lang={lang}>
      <head>
        <meta charSet="UTF-8" />
        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
        <Meta />
		{/* We are now able to customize element of the HTML directly in the component giving full freedom to the end developer */}
		{/* This will be the default title if none is specify in the route <Head /> */}
        <title>Hello from ./routes/_root.tsx</title>
		{/* We can even import global stylesheet from the `static` folder */}
        <link rel="stylesheet" href="/styles/test.css" />
        <Links />
        <Scripts />
        <Styles />

      </head>

      <Body />
    </html>
  );
}

```

The codebase being pretty clean, I was able to make a prototype of the feature copying Remix-style root (https://remix.run/docs/en/v1/guides/migrating-react-router-app#creating-the-root-route) without too much modification.

The PR is pretty rough around the edge and need some clean up but I first wanted to validate the idea if this is something that could be worth pursuing first.

If this is something that is completely out of scope or not wanted, feel free to close the PR.

Happy to hear any feedback !