### PR TITLE
fix: layered middleware not working for index page

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -690,7 +690,10 @@ function serializeCSPDirectives(csp: ContentSecurityPolicyDirectives): string {
 
 export function middlewarePathToPattern(baseRoute: string) {
   baseRoute = baseRoute.slice(0, -"_middleware".length);
-  const pattern = pathToPattern(baseRoute);
-  const compiledPattern = new URLPattern({ pathname: `${pattern}*` });
+  let pattern = pathToPattern(baseRoute);
+  if (pattern.endsWith("/")) {
+    pattern = pattern.slice(0, -1) + "{/*}?";
+  }
+  const compiledPattern = new URLPattern({ pathname: pattern });
   return { pattern, compiledPattern };
 }

--- a/src/server/context_test.ts
+++ b/src/server/context_test.ts
@@ -9,16 +9,16 @@ Deno.test("selectMiddlewares", () => {
     "_middleware",
     "api/_middleware",
     "api/[id]/_middleware",
+    "api/[id]/[path]/_middleware",
 
     // should not select
     "api/xyz/_middleware",
     "api/[id]/xyz/_middleware",
-    "api/[id]/[path]/_middleware",
     "api/[id]/[path]/foo/_middleware",
   ];
   const mwRoutes = middlewaresPath.map((path) =>
     middlewarePathToPattern(path)
   ) as MiddlewareRoute[];
   const mws = selectMiddlewares(url, mwRoutes);
-  assert(mws.length === 3);
+  assert(mws.length === 4);
 });

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -20,13 +20,14 @@ import * as $14 from "./routes/layeredMdw/_middleware.ts";
 import * as $15 from "./routes/layeredMdw/layer2-no-mw/without_mw.ts";
 import * as $16 from "./routes/layeredMdw/layer2/_middleware.ts";
 import * as $17 from "./routes/layeredMdw/layer2/abc.ts";
-import * as $18 from "./routes/layeredMdw/layer2/layer3/[id].ts";
-import * as $19 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
-import * as $20 from "./routes/middleware_root.ts";
-import * as $21 from "./routes/params.tsx";
-import * as $22 from "./routes/props/[id].tsx";
-import * as $23 from "./routes/static.tsx";
-import * as $24 from "./routes/wildcard.tsx";
+import * as $18 from "./routes/layeredMdw/layer2/index.ts";
+import * as $19 from "./routes/layeredMdw/layer2/layer3/[id].ts";
+import * as $20 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
+import * as $21 from "./routes/middleware_root.ts";
+import * as $22 from "./routes/params.tsx";
+import * as $23 from "./routes/props/[id].tsx";
+import * as $24 from "./routes/static.tsx";
+import * as $25 from "./routes/wildcard.tsx";
 import * as $$0 from "./islands/Counter.tsx";
 import * as $$1 from "./islands/Test.tsx";
 
@@ -50,13 +51,14 @@ const manifest = {
     "./routes/layeredMdw/layer2-no-mw/without_mw.ts": $15,
     "./routes/layeredMdw/layer2/_middleware.ts": $16,
     "./routes/layeredMdw/layer2/abc.ts": $17,
-    "./routes/layeredMdw/layer2/layer3/[id].ts": $18,
-    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $19,
-    "./routes/middleware_root.ts": $20,
-    "./routes/params.tsx": $21,
-    "./routes/props/[id].tsx": $22,
-    "./routes/static.tsx": $23,
-    "./routes/wildcard.tsx": $24,
+    "./routes/layeredMdw/layer2/index.ts": $18,
+    "./routes/layeredMdw/layer2/layer3/[id].ts": $19,
+    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $20,
+    "./routes/middleware_root.ts": $21,
+    "./routes/params.tsx": $22,
+    "./routes/props/[id].tsx": $23,
+    "./routes/static.tsx": $24,
+    "./routes/wildcard.tsx": $25,
   },
   islands: {
     "./islands/Counter.tsx": $$0,

--- a/tests/fixture/routes/layeredMdw/layer2/index.ts
+++ b/tests/fixture/routes/layeredMdw/layer2/index.ts
@@ -1,0 +1,13 @@
+import { Handlers } from "../../../../../server.ts";
+
+interface State {
+  root: string;
+  layer1: string;
+  layer2: string;
+}
+
+export const handler: Handlers<undefined, State> = {
+  GET(_req: Request, { state }) {
+    return new Response(JSON.stringify(state));
+  },
+};

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -321,6 +321,37 @@ Deno.test({
     assert(resp);
     assertEquals(resp.status, 200);
     const body = await resp.text();
+    console.log(body);
+    assertStringIncludes(body, "root_mw");
+    assertStringIncludes(body, "layer1_mw");
+    assertStringIncludes(body, "layer2_mw");
+    // layered 2 should not run layer 3 middleware
+    assert(!body.includes("layer3_mw"));
+
+    const resp1 = await router(
+      new Request("https://fresh.deno.dev/layeredMdw/layer2-no-mw/without_mw"),
+    );
+    assert(resp1);
+    assertEquals(resp1.status, 200);
+    const body1 = await resp1.text();
+    assertStringIncludes(body1, "root_mw");
+    assertStringIncludes(body1, "layer1_mw");
+    // layered 2 should not run layer 2 or 3 middleware
+    assert(!body1.includes("layer2_mw"));
+    assert(!body1.includes("layer3_mw"));
+  },
+});
+
+Deno.test({
+  name: "/middleware - layer 2 middleware at index",
+  fn: async () => {
+    const resp = await router(
+      new Request("https://fresh.deno.dev/layeredMdw/layer2"),
+    );
+    assert(resp);
+    assertEquals(resp.status, 200);
+    const body = await resp.text();
+    console.log(body);
     assertStringIncludes(body, "root_mw");
     assertStringIncludes(body, "layer1_mw");
     assertStringIncludes(body, "layer2_mw");


### PR DESCRIPTION
This commit fixes layered middleware not being invoked for the the index
page of the layer.

For example: routes/api/_middleware.ts was not being invoked for /api,
only /api/foobar

Fixes #343.