### PR TITLE
fix(init): add import map to vscode config

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -351,6 +351,7 @@ await Deno.writeTextFile(
 
 const vscodeSettings = {
   "deno.enable": true,
+  "deno.importMap": "./import_map.json"
 };
 
 const VSCODE_SETTINGS = JSON.stringify(vscodeSettings, null, 2) + "\n";


### PR DESCRIPTION
Without it, you're met with a bunch of errors on first opening the project