### PR TITLE
feat: enable deno lint & point editor default format to deno

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -356,6 +356,8 @@ await Deno.writeTextFile(
 
 const vscodeSettings = {
   "deno.enable": true,
+  "deno.lint": true,
+  "editor.defaultFormatter": "denoland.vscode-deno",
 };
 
 const VSCODE_SETTINGS = JSON.stringify(vscodeSettings, null, 2) + "\n";


### PR DESCRIPTION
Enable Deno lint & format on save for VSCode.

I wonder if it's better to keep those enable by default or if we should ask via a prompt to enable it.