### PR TITLE
refactor: simplified start proj logs

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -386,6 +386,6 @@ await generate(resolvedDirectory, manifest);
 // Specifically print unresolvedDirectory, rather than resolvedDirectory in order to
 // not leak personal info (e.g. `/Users/MyName`)
 console.log("\n%cProject created!", "color: green; font-weight: bold");
-console.log(`\nIn order to start the development server, type:\n`);
+console.log(`\nIn order to start the development server, run:\n`);
 console.log(`$ cd ${unresolvedDirectory}`);
 console.log("$ deno task start");

--- a/init.ts
+++ b/init.ts
@@ -386,5 +386,6 @@ await generate(resolvedDirectory, manifest);
 // Specifically print unresolvedDirectory, rather than resolvedDirectory in order to
 // not leak personal info (e.g. `/Users/MyName`)
 console.log("\n%cProject created!", "color: green; font-weight: bold");
-console.log(`\`cd ${unresolvedDirectory}\` to enter to the project directory.`);
-console.log("Run \`deno task start\` to start the development server.");
+console.log(`\nIn order to start the development server, type:\n`);
+console.log(`$ cd ${unresolvedDirectory}`);
+console.log("$ deno task start");


### PR DESCRIPTION
## Change
Improved the _how to navigate and start your project_ logs after initialization.

## Why this change?

In the previous state, it was harder for users:
1. To know that these are commands
2. To copy and paste that commands into the terminal

## Inspiration 

While creating Google Flutter's projects, it has a similar structure which makes it easier for copy-pasting in the terminal. When I came to fresh for the first time, it was a little hard for me to quickly catch them as commands.

## Comparison (Before | After)
![image](https://user-images.githubusercontent.com/47249618/178105250-766723b6-8794-4600-918a-226f61857beb.png)
