### PR TITLE
feat: support nested islands (alternative)

### DIFF
--- a/runtime.ts
+++ b/runtime.ts
@@ -1,3 +1,4 @@
 export * from "./src/runtime/utils.ts";
 export * from "./src/runtime/head.ts";
 export * from "./src/runtime/csp.ts";
+export * from "./src/runtime/island.ts";

--- a/src/runtime/island.ts
+++ b/src/runtime/island.ts
@@ -1,0 +1,16 @@
+import { createContext } from "preact";
+import { useContext } from "preact/hooks";
+
+export const ISLAND_CONTEXT = createContext<boolean>(false);
+
+export function useWithinIsland() {
+  const ctx = useContext(ISLAND_CONTEXT);
+
+  if (ctx === undefined) {
+    throw new Error(
+      "useWithinIsland must be used within an ISLAND_CONTEXT.Provider",
+    );
+  }
+
+  return ctx;
+}

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -29,8 +29,9 @@ import * as $23 from "./routes/props/[id].tsx";
 import * as $24 from "./routes/static.tsx";
 import * as $25 from "./routes/wildcard.tsx";
 import * as $$0 from "./islands/Counter.tsx";
-import * as $$1 from "./islands/Test.tsx";
-import * as $$2 from "./islands/kebab-case-counter-test.tsx";
+import * as $$1 from "./islands/Nested.tsx";
+import * as $$2 from "./islands/Test.tsx";
+import * as $$3 from "./islands/kebab-case-counter-test.tsx";
 
 const manifest = {
   routes: {
@@ -63,8 +64,9 @@ const manifest = {
   },
   islands: {
     "./islands/Counter.tsx": $$0,
-    "./islands/Test.tsx": $$1,
-    "./islands/kebab-case-counter-test.tsx": $$2,
+    "./islands/Nested.tsx": $$1,
+    "./islands/Test.tsx": $$2,
+    "./islands/kebab-case-counter-test.tsx": $$3,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/fixture/islands/Nested.tsx
+++ b/tests/fixture/islands/Nested.tsx
@@ -1,0 +1,7 @@
+/** @jsx h */
+import { h } from "preact";
+import Counter from "./Counter.tsx";
+
+export default function Nesting({ id, start }: { id: string; start: number }) {
+  return <Counter id={id} start={start} />;
+}

--- a/tests/fixture/routes/islands/index.tsx
+++ b/tests/fixture/routes/islands/index.tsx
@@ -2,6 +2,7 @@
 import { h } from "preact";
 import Counter from "../../islands/Counter.tsx";
 import KebabCaseFileNameTest from "../../islands/kebab-case-counter-test.tsx";
+import NestedCounter from "../../islands/Nested.tsx";
 import Test from "../../islands/Test.tsx";
 
 export default function Home() {
@@ -10,6 +11,7 @@ export default function Home() {
       <Counter id="counter1" start={3} />
       <Counter id="counter2" start={10} />
       <KebabCaseFileNameTest id="kebab-case-file-counter" start={5} />
+      <NestedCounter id="counter3" start={5} />
       <Test message="" />
     </div>
   );


### PR DESCRIPTION
This branch is an alternate to #459 that adds support for nested islands.  As [discussed](https://github.com/denoland/fresh/pull/459#issuecomment-1179009786), the way this change handles nested islands is to use an island context to track whether the component is within an island or not.  This should address the problems mentioned in https://github.com/denoland/fresh/issues/168 and https://github.com/denoland/fresh/issues/178.

Additionally, this change has a second commit exposing a `useWithinIsland` component which would let components detect whether they are being loaded within an island.  I'm not sure if the addition of this is a good fit for the framework long term.  I could see it being used in cases where a component library (one specifically designed for fresh) would need to do different things on render e.g. modifications to `<head>`.  Since there are likely pros and cons to this, I'm happy to split it into another PR so it can be discussed separately.

Future idea 💡 – I could also see a way that the island context could open a path to get the `<Head>` component [working  in the browser](https://github.com/denoland/fresh/blob/main/src/runtime/head.ts#L15-L18).  