### PR TITLE
docs: grammar fix

### DIFF
--- a/docs/getting-started/dynamic-routes.md
+++ b/docs/getting-started/dynamic-routes.md
@@ -22,7 +22,7 @@ the file name. For example the `/greet/:name` route maps to the file name
 Just like the static `/about` route, the dynamic `/greet/:name` route will
 render a page. The module must once again expose a component as a default
 export. This time the component will receive the matched path segment properties
-as arguments in it's `props` object though.
+as arguments in its `props` object though.
 
 ```tsx
 // routes/greet/[name].tsx


### PR DESCRIPTION
Changed "it's props" to "its props" to indicate possession instead of a contraction.