### PR TITLE
[wip] feat: add entrypoint for server-side bodyClass param

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -29,7 +29,7 @@ import {
   UnknownPage,
   UnknownPageModule,
 } from "./types.ts";
-import { render as internalRender } from "./render.tsx";
+import { render as internalRender, RenderContext } from "./render.tsx";
 import { ContentSecurityPolicyDirectives, SELF } from "../runtime/csp.ts";
 import { ASSET_CACHE_BUST_KEY, INTERNAL_PREFIX } from "../runtime/utils.ts";
 
@@ -455,7 +455,7 @@ export class ServerContext {
           (route.handler as Handler)(req, {
             ...ctx,
             params,
-            render: createRender(req, params),
+            render: createRender(req, { ...params, ...extractContextParams(ctx) }),
           });
       } else {
         for (const [method, handler] of Object.entries(route.handler)) {
@@ -463,7 +463,7 @@ export class ServerContext {
             handler(req, {
               ...ctx,
               params,
-              render: createRender(req, params),
+              render: createRender(req, { ...params, ...extractContextParams(ctx) }),
             });
         }
       }
@@ -718,4 +718,12 @@ export function middlewarePathToPattern(baseRoute: string) {
   }
   const compiledPattern = new URLPattern({ pathname: pattern });
   return { pattern, compiledPattern };
+}
+
+// Allowed options that can be set from middleware
+function extractContextParams(ctx: RenderContext) {
+  return {
+    bodyClass: ctx.bodyClass || "",
+    lang: ctx.lang || "en",
+  };
 }

--- a/src/server/render.tsx
+++ b/src/server/render.tsx
@@ -27,6 +27,7 @@ export interface RenderOptions<Data> {
   data?: Data;
   error?: unknown;
   lang?: string;
+  bodyClass?: string;
 }
 
 export type InnerRenderFunction = () => string;
@@ -38,12 +39,14 @@ export class RenderContext {
   #url: URL;
   #route: string;
   #lang: string;
+  #bodyClass: string;
 
-  constructor(id: string, url: URL, route: string, lang: string) {
+  constructor(id: string, url: URL, route: string, lang: string, bodyClass: string) {
     this.#id = id;
     this.#url = url;
     this.#route = route;
     this.#lang = lang;
+    this.#bodyClass = bodyClass;
   }
 
   /** A unique ID for this logical JIT render. */
@@ -87,6 +90,14 @@ export class RenderContext {
   }
   set lang(lang: string) {
     this.#lang = lang;
+  }
+
+  /** The class to add to the body tag, useful for applying a dark theme. */
+  get bodyClass(): string {
+    return this.#bodyClass;
+  }
+  set bodyClass(bodyClass: string) {
+    this.#bodyClass = bodyClass;
   }
 }
 
@@ -153,7 +164,8 @@ export async function render<Data>(
     crypto.randomUUID(),
     opts.url,
     opts.route.pattern,
-    opts.lang ?? "en",
+    opts.params.lang,
+    opts.params.bodyClass,
   );
 
   if (csp) {
@@ -253,6 +265,7 @@ export async function render<Data>(
     preloads: opts.preloads,
     styles: ctx.styles,
     lang: ctx.lang,
+    bodyClass: ctx.bodyClass,
   });
 
   return [html, csp];
@@ -265,9 +278,12 @@ export interface TemplateOptions {
   styles: string[];
   preloads: string[];
   lang: string;
+  bodyClass: string;
 }
 
 export function template(opts: TemplateOptions): string {
+  const optionalBodyClass = opts.bodyClass !== "" ? { class: opts.bodyClass } : {};
+
   const page = (
     <html lang={opts.lang}>
       <head>
@@ -284,7 +300,7 @@ export function template(opts: TemplateOptions): string {
         />
         {opts.headComponents}
       </head>
-      <body dangerouslySetInnerHTML={{ __html: opts.bodyHtml }} />
+      <body {...optionalBodyClass} dangerouslySetInnerHTML={{ __html: opts.bodyHtml }} />
     </html>
   );
 

--- a/src/server/render_test.ts
+++ b/src/server/render_test.ts
@@ -8,7 +8,20 @@ Deno.test("check lang", () => {
     imports: [],
     preloads: [],
     styles: [],
-    lang: lang,
+    lang,
   });
   assertStringIncludes(body, `<html lang="${lang}">`);
+});
+Deno.test("check bodyClass", () => {
+  const bodyClass = "dark";
+  const body = template({
+    bodyHtml: "",
+    headComponents: [],
+    imports: [],
+    preloads: [],
+    styles: [],
+    lang: "",
+    bodyClass,
+  });
+  assertStringIncludes(body, `<body class="${bodyClass}">`);
 });


### PR DESCRIPTION
Hello! 👋  First of all, love the framework. I'm using it for a project and it's a joy to work with.

I'm running into an issue with SSR & dark mode though, as there's currently no way to modify the server-rendered HTML to send the correctly themed content down to the client (by adding a class, re: #473). Adding this (optional) parameter to `TemplateOptions` in conjunction with [client hints headers](https://web.dev/user-preference-media-features-headers/) would enable correct theme preference on the server and avoid an annoying screen flicker on the client on pageload.

Let me know if this is something that could be added & if you have other suggestions! Thanks.