### PR TITLE
fix: upgrade preact and preact-render-to-string

### DIFF
--- a/www/import_map.json
+++ b/www/import_map.json
@@ -6,9 +6,9 @@
     "twind": "https://esm.sh/twind@0.16.17",
     "twind/": "https://esm.sh/twind@0.16.17/",
 
-    "preact": "https://esm.sh/preact@10.8.2",
-    "preact/": "https://esm.sh/preact@10.8.2/",
-    "preact-render-to-string": "https://esm.sh/preact-render-to-string@5.2.0?external=preact",
+    "preact": "https://esm.sh/preact@10.10.0",
+    "preact/": "https://esm.sh/preact@10.10.0/",
+    "preact-render-to-string": "https://esm.sh/preact-render-to-string@5.2.1?external=preact",
 
     "$semver/": "https://deno.land/x/semver@v1.4.0/"
   }


### PR DESCRIPTION
Preact@10.8.2 throws an exception (I also upgraded to Deno v1.24 but it does not seems to be related with Deno version)

```
An error occured during route handling or page rendering. TypeError: Cannot read properties of undefined (reading '__H')
```

Upgrading Preact fixed this problem.
This commit and merge might be urgent because I just created a new Fresh app and faced this issue.