### PR TITLE
Add a function to get a server class instance.

### DIFF
--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -5,7 +5,7 @@ export {
   toFileUrl,
 } from "https://deno.land/std@0.128.0/path/mod.ts";
 export { walk } from "https://deno.land/std@0.128.0/fs/walk.ts";
-export { serve } from "https://deno.land/std@0.128.0/http/server.ts";
+export { Server } from "https://deno.land/std@0.128.0/http/server.ts";
 export type {
   ConnInfo,
   Handler as RequestHandler,


### PR DESCRIPTION
I cut out the function that gets an instance of the server from the start function.

The purpose is to prepare you to create tests for your application.
The introduction of this feature does not affect fresh.

Example:

```typescript
// main_test.ts

/// <reference no-default-lib="true" />
/// <reference lib="dom" />
/// <reference lib="dom.asynciterable" />
/// <reference lib="deno.ns" />
/// <reference lib="deno.unstable" />

import { getServer } from "$fresh/server.ts";
import manifest from "./fresh.gen.ts";

import { superdeno } from "https://deno.land/x/superdeno/mod.ts";
import { assertEquals } from "https://deno.land/std@0.148.0/testing/asserts.ts";
import {
  Document,
  DOMParser,
} from "https://deno.land/x/deno_dom/deno-dom-wasm.ts";

Deno.test("HTTP assert test.", async (t) => {
  await t.step("#1 GET /", async () => {
    const server = await getServer(manifest);

    await superdeno(server)
      .get("/")
      .expect(200);
  });

  await t.step("#2 GET /Foo", async () => {
    const server = await getServer(manifest);

    const r = await superdeno(server)
      .get("/Foo")
      .expect(200);

    const document: Document = new DOMParser().parseFromString(
      r.text,
      "text/html",
    )!;

    assertEquals(document.querySelector("div")?.innerText, "Hello Foo");
  });

  await t.step("#3 GET /Foo/Bar", async () => {
    const server = await getServer(manifest);

    await superdeno(server)
      .get("/Foo/Bar")
      .expect(404);
  });
});
```

```sh
$ deno test --allow-net --allow-env --allow-read main_test.ts
Checked 11 files
running 1 test from ./main_test.ts
HTTP assert test. ...
  #1 GET / ... ok (58ms)
  #2 GET /Foo ... ok (56ms)
  #3 GET /Foo/Bar ... ok (42ms)
HTTP assert test. ... ok (162ms)

ok | 1 passed (3 steps) | 0 failed (295ms)
```
