### PR TITLE
Fixed minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ deno run -A -r https://fresh.deno.dev deno-fresh-demo
 Then navigate to the newly created project folder:
 
 ```
-cd my-project
+cd deno-fresh-demo
 ```
 
 From within your project folder, start the development server using the


### PR DESCRIPTION
In the documentation, the command is listed as `deno run -A -r https://fresh.deno.dev my-project`, making the subsequent `cd my-project` appropriate. Here, however, the command arg is `deno-fresh-demo`, making this the correct follow up command.