### PR TITLE
docs: mention kebab case naming for islands

### DIFF
--- a/docs/concepts/islands.md
+++ b/docs/concepts/islands.md
@@ -8,8 +8,8 @@ components that are rendered on the client. This is different from all other
 components in Fresh, as they are usually just rendered on the server.
 
 Islands are defined by creating a file in the `islands/` folder in a Fresh
-project. The name of this file must be a PascalCase name of the island. The file
-must have a default export that is a regular Preact component.
+project. The name of this file must be a PascalCase or kebab-case name of the
+island. The file must have a default export that is a regular Preact component.
 
 ```tsx
 // islands/MyIsland.tsx

--- a/docs/getting-started/adding-interactivity.md
+++ b/docs/getting-started/adding-interactivity.md
@@ -23,8 +23,8 @@ Fresh projects have a special `islands/` folder. The modules in this folder each
 encapsulate a single island component. The name of the module should be the
 [pascal case][pascal-case] or [kebab case][kebab-case] name of the island
 component. For example a counter component would be defined in the file
-`islands/Counter.tsx`. A buy now button would be defined in the file
-`islands/BuyNowButton.tsx`.
+`islands/Counter.tsx`. A buy now button could be defined in the file
+`islands/buy-now-button.tsx`.
 
 Here is an example of an island component that counts down to a specific time.
 

--- a/docs/getting-started/adding-interactivity.md
+++ b/docs/getting-started/adding-interactivity.md
@@ -21,7 +21,7 @@ Fresh embraces this model. All pages are rendered server side, but you can
 create "island components" that are _also_ rendered client side. To do this,
 Fresh projects have a special `islands/` folder. The modules in this folder each
 encapsulate a single island component. The name of the module should be the
-[pascal case][pascal-case] or [kebab case](kebab-case) name of the island
+[pascal case][pascal-case] or [kebab case][kebab-case] name of the island
 component. For example a counter component would be defined in the file
 `islands/Counter.tsx`. A buy now button would be defined in the file
 `islands/BuyNowButton.tsx`.

--- a/docs/getting-started/adding-interactivity.md
+++ b/docs/getting-started/adding-interactivity.md
@@ -21,9 +21,10 @@ Fresh embraces this model. All pages are rendered server side, but you can
 create "island components" that are _also_ rendered client side. To do this,
 Fresh projects have a special `islands/` folder. The modules in this folder each
 encapsulate a single island component. The name of the module should be the
-[pascal case][pascal-case] name of the island component. For example a counter
-component would be defined in the file `islands/Counter.tsx`. A buy now button
-would be defined in the file `islands/BuyNowButton.tsx`.
+[pascal case][pascal-case] or [kebab case](kebab-case) name of the island
+component. For example a counter component would be defined in the file
+`islands/Counter.tsx`. A buy now button would be defined in the file
+`islands/BuyNowButton.tsx`.
 
 Here is an example of an island component that counts down to a specific time.
 
@@ -94,3 +95,4 @@ The page that is rendered on the client now has an interactive countdown.
 
 [islands-architecture]: https://jasonformat.com/islands-architecture
 [pascal-case]: https://en.wiktionary.org/wiki/Pascal_case
+[kebab-case]: https://en.wiktionary.org/wiki/kebab_case


### PR DESCRIPTION
Fresh now supports kebab case naming for islands (#404)
This PR updates docs to mention that