### PR TITLE
Remove `deno.unstable` references

### DIFF
--- a/examples/counter/main.ts
+++ b/examples/counter/main.ts
@@ -2,7 +2,6 @@
 /// <reference lib="dom" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
-/// <reference lib="deno.unstable" />
 
 import { start } from "$fresh/server.ts";
 import manifest from "./fresh.gen.ts";

--- a/init.ts
+++ b/init.ts
@@ -276,7 +276,6 @@ let MAIN_TS = `/// <reference no-default-lib="true" />
 /// <reference lib="dom" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
-/// <reference lib="deno.unstable" />
 
 import { ${
   useTwind ? "InnerRenderFunction, RenderContext, " : ""

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -2,7 +2,6 @@
 /// <reference lib="dom" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
-/// <reference lib="deno.unstable" />
 
 export {
   assert,

--- a/tests/fixture/main.ts
+++ b/tests/fixture/main.ts
@@ -2,7 +2,6 @@
 /// <reference lib="dom" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
-/// <reference lib="deno.unstable" />
 
 import { start } from "$fresh/server.ts";
 import routes from "./fresh.gen.ts";

--- a/tests/fixture_error/main.ts
+++ b/tests/fixture_error/main.ts
@@ -2,7 +2,6 @@
 /// <reference lib="dom" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
-/// <reference lib="deno.unstable" />
 
 import { start } from "$fresh/server.ts";
 import manifest from "./fresh.gen.ts";

--- a/www/main.ts
+++ b/www/main.ts
@@ -2,7 +2,6 @@
 /// <reference lib="dom" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
-/// <reference lib="deno.unstable" />
 
 import { start } from "$fresh/server.ts";
 import { virtualSheet } from "twind/sheets";


### PR DESCRIPTION
Now that Fresh hit 1.0, I feel the `deno.unstable` references seems unnecessary (and does more harm than good to end users).