### PR TITLE
www: use frontmatter parser from std

### DIFF
--- a/www/routes/docs/[...slug].tsx
+++ b/www/routes/docs/[...slug].tsx
@@ -40,11 +40,8 @@ export const handler: Handlers<Data> = {
     }
     const url = new URL(`../../../${entry.file}`, import.meta.url);
     const fileContent = await Deno.readTextFile(url);
-    const { content, data } = frontMatter(fileContent) as {
-      data: Record<string, string>;
-      content: string;
-    };
-    const page = { ...entry, markdown: content, data: data ?? {} };
+    const { body, attrs } = frontMatter<Record<string, unknown>>(fileContent);
+    const page = { ...entry, markdown: body, data: attrs ?? {} };
     const resp = ctx.render({ page });
     return resp;
   },

--- a/www/utils/markdown.ts
+++ b/www/utils/markdown.ts
@@ -3,4 +3,4 @@ import "https://esm.sh/prismjs@1.27.0/components/prism-jsx.js?no-check";
 import "https://esm.sh/prismjs@1.27.0/components/prism-typescript.js?no-check";
 import "https://esm.sh/prismjs@1.27.0/components/prism-tsx.js?no-check";
 
-export { parse as frontMatter } from "https://deno.land/x/frontmatter@v0.1.4/mod.ts";
+export { extract as frontMatter } from "$std/encoding/front_matter.ts";


### PR DESCRIPTION
Replace the `frontmatter` with the std version, since the package is deprecated: https://deno.land/x/frontmatter@v0.1.5