### PR TITLE
Add support for preact devtools in dev mode

### DIFF
--- a/src/runtime/main_dev.ts
+++ b/src/runtime/main_dev.ts
@@ -1,0 +1,2 @@
+import "preact/debug";
+export { revive } from "./main.ts";

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -25,16 +25,25 @@ export class Bundler {
   #islands: Island[];
   #plugins: Plugin[];
   #cache: Map<string, Uint8Array> | Promise<void> | undefined = undefined;
+  #dev: boolean;
 
-  constructor(islands: Island[], plugins: Plugin[], importMapURL: URL) {
+  constructor(
+    islands: Island[],
+    plugins: Plugin[],
+    importMapURL: URL,
+    dev: boolean
+  ) {
     this.#islands = islands;
     this.#plugins = plugins;
     this.#importMapURL = importMapURL;
+    this.#dev = dev;
   }
 
   async bundle() {
     const entryPoints: Record<string, string> = {
-      "main": new URL("../../src/runtime/main.ts", import.meta.url).href,
+      main: this.#dev
+        ? new URL("../../src/runtime/main_dev.ts", import.meta.url).href
+        : new URL("../../src/runtime/main.ts", import.meta.url).href,
     };
 
     for (const island of this.#islands) {

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -32,7 +32,7 @@ export class Bundler {
     islands: Island[],
     plugins: Plugin[],
     importMapURL: URL,
-    dev: boolean
+    dev: boolean,
   ) {
     this.#islands = islands;
     this.#plugins = plugins;

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -1,3 +1,4 @@
+import { BuildOptions } from "https://deno.land/x/esbuild@v0.14.51/mod.js";
 import { BUILD_ID } from "./constants.ts";
 import { denoPlugin, esbuild, toFileUrl } from "./deps.ts";
 import { Island, Plugin } from "./types.ts";
@@ -58,13 +59,18 @@ export class Bundler {
 
     const absWorkingDir = Deno.cwd();
     await ensureEsbuildInitialized();
+    // In dev-mode we skip identifier minification to be able to show proper
+    // component names in Preact DevTools instead of single characters.
+    const minifyOptions: Partial<BuildOptions> = this.#dev
+      ? { minifyIdentifiers: false, minifySyntax: true, minifyWhitespace: true }
+      : { minify: true };
     const bundle = await esbuild.build({
       bundle: true,
       define: { __FRSH_BUILD_ID: `"${BUILD_ID}"` },
       entryPoints,
       format: "esm",
       metafile: true,
-      minify: true,
+      ...minifyOptions,
       outdir: ".",
       // This is requried to ensure the format of the outputFiles path is the same
       // between windows and linux

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -86,7 +86,12 @@ export class ServerContext {
     this.#error = error;
     this.#plugins = plugins;
     this.#dev = typeof Deno.env.get("DENO_DEPLOYMENT_ID") !== "string"; // Env var is only set in prod (on Deploy).
-    this.#bundler = new Bundler(this.#islands, this.#plugins, importMapURL, this.#dev);
+    this.#bundler = new Bundler(
+      this.#islands,
+      this.#plugins,
+      importMapURL,
+      this.#dev,
+    );
   }
 
   /**

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -85,8 +85,8 @@ export class ServerContext {
     this.#notFound = notFound;
     this.#error = error;
     this.#plugins = plugins;
-    this.#bundler = new Bundler(this.#islands, this.#plugins, importMapURL);
     this.#dev = typeof Deno.env.get("DENO_DEPLOYMENT_ID") !== "string"; // Env var is only set in prod (on Deploy).
+    this.#bundler = new Bundler(this.#islands, this.#plugins, importMapURL, this.#dev);
   }
 
   /**


### PR DESCRIPTION
This PR injects `preact/debug` before the main bundle when running in `dev` mode. This enables helpful debug warnings for Preact and sets up the bridge for the DevTools browser extension.

To show the actual component names instead of the minified names, we need to disable esbuild's identifier minification option. The alternative would be to transform every file and append the `displayName` property to all component functions, but since esbuild doesn't expose its AST we'd need to fall back on babel or something similar. That would incur a significant compilation cost and I'm assuming that this wouldn't be in the spirit of this project.

Let me know what you think.

DevTools in action:

![Screenshot 2022-08-21 at 08 42 31](https://user-images.githubusercontent.com/1062408/185779068-3572292b-78b7-44d2-be40-3971b95c1531.png)


Fixes #611 
Fixes https://github.com/preactjs/preact/issues/3686