### PR TITLE
fix: add reference to dom.iterable

### DIFF
--- a/examples/counter/main.ts
+++ b/examples/counter/main.ts
@@ -1,5 +1,6 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 

--- a/init.ts
+++ b/init.ts
@@ -259,6 +259,7 @@ try {
 
 let MAIN_TS = `/// <reference no-default-lib="true" />
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -1,5 +1,6 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 

--- a/tests/fixture/main.ts
+++ b/tests/fixture/main.ts
@@ -1,5 +1,6 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 

--- a/tests/fixture_error/main.ts
+++ b/tests/fixture_error/main.ts
@@ -1,5 +1,6 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 

--- a/tests/fixture_plugin/main.ts
+++ b/tests/fixture_plugin/main.ts
@@ -1,5 +1,6 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 

--- a/www/main.ts
+++ b/www/main.ts
@@ -1,5 +1,6 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 


### PR DESCRIPTION
This fixes TypeScript errors with things like `URLSearchParams.entries`.

Related: https://github.com/denoland/deno/issues/15517#issuecomment-1221521244