### PR TITLE
chore: use rutt instead of crux.land/router

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -3,7 +3,7 @@ import {
   extname,
   fromFileUrl,
   RequestHandler,
-  router,
+  rutt,
   Status,
   toFileUrl,
   typeByExtension,
@@ -171,7 +171,7 @@ export class ServerContext {
           url,
           name,
           component,
-          handler: handler ?? ((req) => router.defaultOtherHandler(req)),
+          handler: handler ?? ((req) => rutt.defaultOtherHandler(req)),
           csp: Boolean(config?.csp ?? false),
         };
       } else if (
@@ -190,7 +190,7 @@ export class ServerContext {
           name,
           component,
           handler: handler ??
-            ((req, ctx) => router.defaultErrorHandler(req, ctx, ctx.error)),
+            ((req, ctx) => rutt.defaultErrorHandler(req, ctx, ctx.error)),
           csp: Boolean(config?.csp ?? false),
         };
       }
@@ -279,7 +279,7 @@ export class ServerContext {
    * by fresh, including static files.
    */
   handler(): RequestHandler {
-    const inner = router.router<RouterState>(...this.#handlers());
+    const inner = rutt.router<RouterState>(...this.#handlers());
     const withMiddlewares = this.#composeMiddlewares(this.#middlewares);
     return function handler(req: Request, connInfo: ConnInfo) {
       // Redirect requests that end with a trailing slash
@@ -302,7 +302,7 @@ export class ServerContext {
     return (
       req: Request,
       connInfo: ConnInfo,
-      inner: router.Handler<RouterState>,
+      inner: rutt.Handler<RouterState>,
     ) => {
       // identify middlewares to apply, if any.
       // middlewares should be already sorted from deepest to shallow layer
@@ -335,11 +335,11 @@ export class ServerContext {
    * path-to-regex, to handler mapping.
    */
   #handlers(): [
-    router.Routes<RouterState>,
-    router.Handler<RouterState>,
-    router.ErrorHandler<RouterState>,
+    rutt.Routes<RouterState>,
+    rutt.Handler<RouterState>,
+    rutt.ErrorHandler<RouterState>,
   ] {
-    const routes: router.Routes<RouterState> = {};
+    const routes: rutt.Routes<RouterState> = {};
 
     routes[`${INTERNAL_PREFIX}${JS_PREFIX}/${BUILD_ID}/:path*`] = this
       .#bundleAssetRoute();
@@ -484,7 +484,7 @@ export class ServerContext {
       }
     }
 
-    const unknownHandler: router.Handler<RouterState> = (
+    const unknownHandler: rutt.Handler<RouterState> = (
       req,
       ctx,
     ) =>
@@ -500,7 +500,7 @@ export class ServerContext {
       this.#error,
       Status.InternalServerError,
     );
-    const errorHandler: router.ErrorHandler<RouterState> = (
+    const errorHandler: rutt.ErrorHandler<RouterState> = (
       req,
       ctx,
       error,
@@ -528,7 +528,7 @@ export class ServerContext {
     size: number,
     contentType: string,
     etag: string,
-  ): router.MatchHandler {
+  ): rutt.MatchHandler {
     return async (req: Request) => {
       const url = new URL(req.url);
       const key = url.searchParams.get(ASSET_CACHE_BUST_KEY);
@@ -566,7 +566,7 @@ export class ServerContext {
    * Returns a router that contains all fresh routes. Should be mounted at
    * constants.INTERNAL_PREFIX
    */
-  #bundleAssetRoute = (): router.MatchHandler => {
+  #bundleAssetRoute = (): rutt.MatchHandler => {
     return async (_req, _ctx, params) => {
       const path = `/${params.path}`;
       const file = await this.#bundler.get(path);
@@ -606,7 +606,7 @@ const DEFAULT_NOT_FOUND: UnknownPage = {
   pattern: "",
   url: "",
   name: "_404",
-  handler: (req) => router.defaultOtherHandler(req),
+  handler: (req) => rutt.defaultOtherHandler(req),
   csp: false,
 };
 

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -16,8 +16,8 @@ export {
   typeByExtension,
 } from "https://deno.land/std@0.150.0/media_types/mod.ts";
 
-// -- router --
-export * as router from "https://deno.land/x/rutt@0.0.13/mod.ts";
+// -- rutt --
+export * as rutt from "https://deno.land/x/rutt@0.0.13/mod.ts";
 
 // -- esbuild --
 // @deno-types="https://deno.land/x/esbuild@v0.14.51/mod.d.ts"

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -17,7 +17,7 @@ export {
 } from "https://deno.land/std@0.150.0/media_types/mod.ts";
 
 // -- router --
-export * as router from "https://crux.land/router@0.0.11";
+export * as router from "https://deno.land/x/rutt@0.0.13";
 
 // -- esbuild --
 // @deno-types="https://deno.land/x/esbuild@v0.14.51/mod.d.ts"

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -17,7 +17,7 @@ export {
 } from "https://deno.land/std@0.150.0/media_types/mod.ts";
 
 // -- router --
-export * as router from "https://deno.land/x/rutt@0.0.13";
+export * as router from "https://deno.land/x/rutt@0.0.13/mod.ts";
 
 // -- esbuild --
 // @deno-types="https://deno.land/x/esbuild@v0.14.51/mod.d.ts"

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,5 +1,5 @@
 import { ComponentType } from "preact";
-import { ConnInfo, router, ServeInit } from "./deps.ts";
+import { ConnInfo, rutt, ServeInit } from "./deps.ts";
 import { InnerRenderFunction, RenderContext } from "./render.tsx";
 
 // --- APPLICATION CONFIGURATION ---
@@ -78,7 +78,7 @@ export type Handler<T = any, State = Record<string, unknown>> = (
 
 // deno-lint-ignore no-explicit-any
 export type Handlers<T = any, State = Record<string, unknown>> = {
-  [K in typeof router.METHODS[number]]?: Handler<T, State>;
+  [K in typeof rutt.METHODS[number]]?: Handler<T, State>;
 };
 
 export interface RouteModule {


### PR DESCRIPTION
crux.land/router is becoming denosaurs/rutt. Functionality is the same and everything should keep on working the same!