### PR TITLE
Add-directions-for-running-tests-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ deno run -A -r https://fresh.deno.dev deno-fresh-demo
 
 Then navigate to the newly created project folder:
 
-```
+```sh
 cd deno-fresh-demo
 ```
 
 From within your project folder, start the development server using the
 `deno task` command:
 
-```
+```sh
 deno task start
 ```
 
@@ -71,7 +71,7 @@ browsers if you've not tried it before!
 
 Run the Fresh tests with this command:
 
-```
+```sh
 deno task test
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ For a more in-depth getting started guide, visit the
 [Getting Started](https://fresh.deno.dev/docs/getting-started) page in the Fresh
 docs.
 
+## ✅ Running tests
+
+Once you've installed Deno and Fresh, you'll also
+[need to install deno-puppeteer](https://github.com/lucacasonato/deno-puppeteer#installation)
+as this is used by some of the tests. It's also a great tool for automating your
+browsers if you've not tried it before!
+
+Run the Fresh tests with this command:
+
+```
+deno task test
+```
+
+If you're seeing failing tests on the `main` branch, then
+[check that deno-puppeteer is working properly](https://github.com/lucacasonato/deno-puppeteer#usage)
+and you are running Deno version 1.23.0 or higher.
+
 ## Badges
 
 ![Made with Fresh](./www/static/fresh-badge.svg)


### PR DESCRIPTION
I was trying to get the tests passing so I can start contributing to Fresh, but ran into an issue as [deno-puppeteer](https://github.com/lucacasonato/deno-puppeteer) wasn't installed. I figured I wasn't the only person who might have missed this so I added some notes explaining how to do that.