### PR TITLE
docs: fix syntax error on "Error Pages" page

### DIFF
--- a/docs/concepts/error-pages.md
+++ b/docs/concepts/error-pages.md
@@ -38,13 +38,13 @@ import { Handlers, PageProps } from "$fresh/server.ts";
 
 export const handler: Handlers = {
   async GET(req, ctx) {
-    const blogpost = await fetchBlogpost(ctx.params.slug)
+    const blogpost = await fetchBlogpost(ctx.params.slug);
     if (!blogpost) {
       return ctx.renderNotFound();
     }
-    return ctx.render({ blogpost })
-  }
-}
+    return ctx.render({ blogpost });
+  },
+};
 
 export default function BlogpostPage({ data }) {
   return (

--- a/docs/concepts/error-pages.md
+++ b/docs/concepts/error-pages.md
@@ -36,7 +36,7 @@ This can be achieved with `ctx.renderNotFound`.
 import { h } from "preact";
 import { Handlers, PageProps } from "$fresh/server.ts";
 
-export handler: Handlers = {
+export const handler: Handlers = {
   async GET(req, ctx) {
     const blogpost = await fetchBlogpost(ctx.params.slug)
     if (!blogpost) {


### PR DESCRIPTION
Add the missing `const` keyword in **Manually render 404 pages** snippet.