### PR TITLE
www: bump x/gfm version to aid translation software

### DIFF
--- a/www/utils/markdown.ts
+++ b/www/utils/markdown.ts
@@ -1,6 +1,6 @@
 export * as gfm from "https://deno.land/x/gfm@0.1.23/mod.ts";
-import "https://esm.sh/prismjs@1.29.0/components/prism-jsx.js?no-check";
-import "https://esm.sh/prismjs@1.29.0/components/prism-typescript.js?no-check";
-import "https://esm.sh/prismjs@1.29.0/components/prism-tsx.js?no-check";
+import "https://esm.sh/prismjs@1.27.0/components/prism-jsx.js?no-check";
+import "https://esm.sh/prismjs@1.27.0/components/prism-typescript.js?no-check";
+import "https://esm.sh/prismjs@1.27.0/components/prism-tsx.js?no-check";
 
 export { extract as frontMatter } from "$std/encoding/front_matter.ts";

--- a/www/utils/markdown.ts
+++ b/www/utils/markdown.ts
@@ -1,6 +1,6 @@
-export * as gfm from "https://deno.land/x/gfm@0.1.19/mod.ts";
-import "https://esm.sh/prismjs@1.27.0/components/prism-jsx.js?no-check";
-import "https://esm.sh/prismjs@1.27.0/components/prism-typescript.js?no-check";
-import "https://esm.sh/prismjs@1.27.0/components/prism-tsx.js?no-check";
+export * as gfm from "https://deno.land/x/gfm@0.1.23/mod.ts";
+import "https://esm.sh/prismjs@1.29.0/components/prism-jsx.js?no-check";
+import "https://esm.sh/prismjs@1.29.0/components/prism-typescript.js?no-check";
+import "https://esm.sh/prismjs@1.29.0/components/prism-tsx.js?no-check";
 
 export { extract as frontMatter } from "$std/encoding/front_matter.ts";


### PR DESCRIPTION
[This pull request](https://github.com/lucacasonato/deno-gfm/pull/16) got merged so we have to update GFM to get this fix. (I also bumped PrismJS because why not). This closes #597.

Before:
<img width="1097" alt="Screen Shot 2022-09-05 at 7 48 02 PM" src="https://user-images.githubusercontent.com/11367844/188537144-7ffc6558-32bc-4249-aef3-347abe75d746.png">

After:
<img width="1117" alt="Screen Shot 2022-09-05 at 7 47 45 PM" src="https://user-images.githubusercontent.com/11367844/188537155-a7d8b310-8be9-4a66-a1dd-4a3997f64778.png">
