### PR TITLE
Fix HTML meta tag charset property casing

### DIFF
--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -334,7 +334,7 @@ export function template(opts: TemplateOptions): string {
     h(
       "head",
       null,
-      h("meta", { charSet: "UTF-8" }),
+      h("meta", { charset: "UTF-8" }),
       h("meta", {
         name: "viewport",
         content: "width=device-width, initial-scale=1.0",


### PR DESCRIPTION
Corrects strange casing of HTML meta tag charset property for cleaner visual appearance.