### PR TITLE
fix(plugin/twind): load configuration as module

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -201,14 +201,16 @@ await Deno.writeTextFile(
   ROUTES_API_JOKE_TS,
 );
 
-const TWIND_CONFIG_JS =
-  `/** @type {import("$fresh/plugins/twind.ts").Options} */
-export default {};
+const TWIND_CONFIG_TS = `import { Options } from "$fresh/plugins/twind.ts";
+
+export default {
+  selfURL: import.meta.url,
+} as Options;
 `;
 if (useTwind) {
   await Deno.writeTextFile(
-    join(resolvedDirectory, "twind.config.js"),
-    TWIND_CONFIG_JS,
+    join(resolvedDirectory, "twind.config.ts"),
+    TWIND_CONFIG_TS,
   );
 }
 
@@ -249,7 +251,7 @@ import manifest from "./fresh.gen.ts";
 if (useTwind) {
   MAIN_TS += `
 import twindPlugin from "$fresh/plugins/twind.ts";
-import twindConfig from "./twind.config.js";
+import twindConfig from "./twind.config.ts";
 `;
 }
 

--- a/plugins/twind.ts
+++ b/plugins/twind.ts
@@ -7,9 +7,14 @@ export type { Options };
 export default function twind(options: Options): Plugin {
   const sheet = virtualSheet();
   setup(options, sheet);
+  const main = `data:application/javascript,import hydrate from "${
+    new URL("./twind/main.ts", import.meta.url).href
+  }";
+import options from "${options.selfURL}";
+export default function(state) { hydrate(options, state); }`;
   return {
     name: "twind",
-    entrypoints: { "main": new URL("./twind/main.ts", import.meta.url).href },
+    entrypoints: { "main": main },
     render(ctx) {
       sheet.reset(undefined);
       const res = ctx.render();
@@ -28,7 +33,7 @@ export default function twind(options: Options): Plugin {
             mappings.push([key, value]);
           }
         }
-        const state = [options, precedences, mappings];
+        const state = [precedences, mappings];
         scripts.push({ entrypoint: "main", state });
       }
       return {

--- a/plugins/twind/main.ts
+++ b/plugins/twind/main.ts
@@ -1,13 +1,13 @@
 import { Sheet } from "twind";
 import { Options, setup, STYLE_ELEMENT_ID } from "./shared.ts";
 
-type State = [Options, string[], [string, string][]];
+type State = [string[], [string, string][]];
 
-export default function hydrate(state: State) {
+export default function hydrate(options: Options, state: State) {
   const el = document.getElementById(STYLE_ELEMENT_ID) as HTMLStyleElement;
   const rules = new Set(el.innerText.split("\n"));
-  const precedences = state[1];
-  const mappings = new Map(state[2]
+  const precedences = state[0];
+  const mappings = new Map(state[1]
     .map((v) => typeof v === "string" ? [v, v] : v));
   // deno-lint-ignore no-explicit-any
   const sheetState: any[] = [precedences, rules, mappings, true];
@@ -17,5 +17,5 @@ export default function hydrate(state: State) {
     insert: (rule, index) => target.insertRule(rule, index),
     init: (cb) => cb(sheetState.shift()),
   };
-  setup(state[0], sheet);
+  setup(options, sheet);
 }

--- a/plugins/twind/shared.ts
+++ b/plugins/twind/shared.ts
@@ -1,40 +1,11 @@
 import { JSX, options as preactOptions, VNode } from "preact";
-import {
-  Configuration,
-  DarkMode,
-  setup as twSetup,
-  Sheet,
-  ThemeConfiguration,
-  tw,
-} from "twind";
+import { Configuration, setup as twSetup, Sheet, tw } from "twind";
 
 export const STYLE_ELEMENT_ID = "__FRSH_TWIND";
 
-export interface Options {
-  /**
-   * Determines the dark mode strategy (default: `"media"`).
-   */
-  darkMode?: DarkMode;
-
-  /**
-   * The twind theme to use.
-   */
-  theme?: ThemeConfiguration;
-
-  /**
-   * ```js
-   * {
-   *   ':new-variant': '& .selector',
-   * }
-   * ```
-   */
-  variants?: Record<string, string>;
-
-  /**
-   * Configure wether the class names should be emitted "as is", or if they
-   * should be hashed.
-   */
-  hash?: boolean;
+export interface Options extends Omit<Configuration, "mode" | "sheet"> {
+  /** The import.meta.url of the module defining these options. */
+  selfURL: string;
 }
 
 declare module "preact" {
@@ -48,12 +19,9 @@ declare module "preact" {
 
 export function setup(options: Options, sheet: Sheet) {
   const config: Configuration = {
-    darkMode: options.darkMode,
-    hash: options.hash,
+    ...options,
     mode: "silent",
     sheet,
-    variants: options.variants,
-    theme: options.theme,
   };
   twSetup(config);
 

--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -206,7 +206,7 @@ Deno.test({
           { "type": "file", "name": "README.md" },
           { "type": "file", "name": "import_map.json" },
           { "type": "file", "name": "fresh.gen.ts" },
-          { "type": "file", "name": "twind.config.js" },
+          { "type": "file", "name": "twind.config.ts" },
           {
             "type": "directory",
             "name": "components",

--- a/www/main.ts
+++ b/www/main.ts
@@ -8,6 +8,6 @@ import { start } from "$fresh/server.ts";
 import twindPlugin from "$fresh/plugins/twind.ts";
 
 import manifest from "./fresh.gen.ts";
-import twindConfig from "./twind.config.js";
+import twindConfig from "./twind.config.ts";
 
 await start(manifest, { plugins: [twindPlugin(twindConfig)] });

--- a/www/twind.config.ts
+++ b/www/twind.config.ts
@@ -1,7 +1,8 @@
+import { Options } from "$fresh/plugins/twind.ts";
 import * as colors from "twind/colors";
 
-/** @type {import("$fresh/plugins/twind.ts").Options} */
 export default {
+  selfURL: import.meta.url,
   theme: {
     colors: {
       blue: colors.blue,
@@ -13,4 +14,4 @@ export default {
       transparent: "transparent",
     },
   },
-};
+} as Options;


### PR DESCRIPTION
This commit loads the Twind configuration as an actual module rather
than evaluating it on the server and then serializing. This allows usage
of unserializable plugin functions.

Co-authored-by: Elias Sjögreen <eliassjogreen1@gmail.com>
