### PR TITLE
feat: add update.ts script

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -1,6 +1,7 @@
 import { join, parse, resolve } from "./src/dev/deps.ts";
 import { error } from "./src/dev/error.ts";
 import { collect, ensureMinDenoVersion, generate } from "./src/dev/mod.ts";
+import { freshImports, twindImports } from "./src/dev/imports.ts";
 
 ensureMinDenoVersion();
 
@@ -76,19 +77,9 @@ if (useVSCode) {
   await Deno.mkdir(join(resolvedDirectory, ".vscode"), { recursive: true });
 }
 
-const importMap = {
-  "imports": {
-    "$fresh/": new URL("./", import.meta.url).href,
-    "preact": "https://esm.sh/preact@10.10.6",
-    "preact/": "https://esm.sh/preact@10.10.6/",
-    "preact-render-to-string":
-      "https://esm.sh/preact-render-to-string@5.2.2?external=preact",
-  } as Record<string, string>,
-};
-if (useTwind) {
-  importMap.imports["twind"] = "https://esm.sh/twind@0.16.17";
-  importMap.imports["twind/"] = "https://esm.sh/twind@0.16.17/";
-}
+const importMap = { imports: {} as Record<string, string> };
+freshImports(importMap.imports);
+if (useTwind) twindImports(importMap.imports);
 const IMPORT_MAP_JSON = JSON.stringify(importMap, null, 2) + "\n";
 await Deno.writeTextFile(
   join(resolvedDirectory, "import_map.json"),

--- a/src/dev/deps.ts
+++ b/src/dev/deps.ts
@@ -10,3 +10,6 @@ export {
 export { walk } from "https://deno.land/std@0.150.0/fs/walk.ts";
 export { parse } from "https://deno.land/std@0.150.0/flags/mod.ts";
 export { gte } from "https://deno.land/std@0.150.0/semver/mod.ts";
+
+// ts-morph
+export { Node, Project } from "https://deno.land/x/ts_morph@16.0.0/mod.ts";

--- a/src/dev/imports.ts
+++ b/src/dev/imports.ts
@@ -1,0 +1,16 @@
+export const RECOMMENDED_PREACT_VERSION = "10.10.6";
+export const RECOMMENDED_PREACT_RTS_VERSION = "5.2.2";
+export const RECOMMENDED_TWIND_VERSION = "0.16.17";
+
+export function freshImports(imports: Record<string, string>) {
+  imports["$fresh/"] = new URL("../../", import.meta.url).href;
+  imports["preact"] = `https://esm.sh/preact@${RECOMMENDED_PREACT_VERSION}`;
+  imports["preact/"] = `https://esm.sh/preact@${RECOMMENDED_PREACT_VERSION}/`;
+  imports["preact-render-to-string"] =
+    `https://esm.sh/*preact-render-to-string@${RECOMMENDED_PREACT_RTS_VERSION}/`;
+}
+
+export function twindImports(imports: Record<string, string>) {
+  imports["twind"] = `https://esm.sh/twind@${RECOMMENDED_TWIND_VERSION}`;
+  imports["twind/"] = `https://esm.sh/twind@${RECOMMENDED_TWIND_VERSION}/`;
+}

--- a/update.ts
+++ b/update.ts
@@ -1,0 +1,180 @@
+import { join, Node, parse, Project, resolve } from "./src/dev/deps.ts";
+import { error } from "./src/dev/error.ts";
+import { freshImports, twindImports } from "./src/dev/imports.ts";
+import { collect, ensureMinDenoVersion, generate } from "./src/dev/mod.ts";
+
+ensureMinDenoVersion();
+
+const help = `fresh-update
+
+Update a Fresh project. This updates dependencies and optionally performs code
+mods to update a project's source code to the latest recommended patterns.
+
+To upgrade a projecct in the current directory, run:
+  fresh-update .
+
+USAGE:
+    fresh-update <DIRECTORY>
+`;
+
+const flags = parse(Deno.args, {});
+
+if (flags._.length !== 1) {
+  error(help);
+}
+
+const unresolvedDirectory = Deno.args[0];
+const resolvedDirectory = resolve(unresolvedDirectory);
+
+// Update dependencies in the import map.
+const IMPORT_MAP_PATH = join(resolvedDirectory, "import_map.json");
+let importMapText = await Deno.readTextFile(IMPORT_MAP_PATH);
+const importMap = JSON.parse(importMapText);
+freshImports(importMap.imports);
+if (importMap.imports["twind"]) {
+  twindImports(importMap.imports);
+}
+importMapText = JSON.stringify(importMap, null, 2);
+await Deno.writeTextFile(IMPORT_MAP_PATH, importMapText);
+
+// Code mod for classic JSX -> automatic JSX.
+const JSX_CODEMOD =
+  `This project is using the classic JSX transform. Would you like to update to the
+automatic JSX transform? This will remove the /** @jsx h */ pragma from your
+source code and add the jsx: "react-jsx" compiler option to your deno.json file.`;
+const DENO_JSON_PATH = join(resolvedDirectory, "deno.json");
+let denoJsonText = await Deno.readTextFile(DENO_JSON_PATH);
+const denoJson = JSON.parse(denoJsonText);
+if (denoJson.compilerOptions?.jsx !== "react-jsx" && confirm(JSX_CODEMOD)) {
+  console.log("Updating config file...");
+  denoJson.compilerOptions = denoJson.compilerOptions || {};
+  denoJson.compilerOptions.jsx = "react-jsx";
+  denoJson.compilerOptions.jsxImportSource = "preact";
+  denoJsonText = JSON.stringify(denoJson, null, 2);
+  await Deno.writeTextFile(DENO_JSON_PATH, denoJsonText);
+
+  const project = new Project();
+  const sfs = project.addSourceFilesAtPaths(
+    join(resolvedDirectory, "**", "*.{js,jsx,ts,tsx}"),
+  );
+
+  for (const sf of sfs) {
+    for (const d of sf.getImportDeclarations()) {
+      if (d.getModuleSpecifierValue() !== "preact") continue;
+      for (const n of d.getNamedImports()) {
+        const name = n.getName();
+        if (name === "h" || name === "Fragment") n.remove();
+      }
+      if (
+        d.getNamedImports().length === 0 &&
+        d.getNamespaceImport() === undefined &&
+        d.getDefaultImport() === undefined
+      ) {
+        d.remove();
+      }
+    }
+
+    let text = sf.getFullText();
+    text = text.replaceAll("/** @jsx h */\n", "");
+    text = text.replaceAll("/** @jsxFrag Fragment */\n", "");
+    sf.replaceWithText(text);
+
+    await sf.save();
+  }
+}
+
+// Code mod for class={tw`border`} to class="border".
+const TWIND_CODEMOD =
+  `This project is using an old version of the twind integration. Would you like to
+update to the new twind plugin? This will remove the 'class={tw\`border\`}'
+boilerplate from your source code replace it with the simpler 'class="border"'.`;
+if (importMap.imports["@twind"] && confirm(TWIND_CODEMOD)) {
+  await Deno.remove(join(resolvedDirectory, importMap.imports["@twind"]));
+
+  delete importMap.imports["@twind"];
+  importMapText = JSON.stringify(importMap, null, 2);
+  await Deno.writeTextFile(IMPORT_MAP_PATH, importMapText);
+
+  const MAIN_TS = `/// <reference no-default-lib="true" />
+/// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
+/// <reference lib="dom.asynciterable" />
+/// <reference lib="deno.ns" />
+
+import { start } from "$fresh/server.ts";
+import manifest from "./fresh.gen.ts";
+
+import twindPlugin from "$fresh/plugins/twind.ts";
+import twindConfig from "./twind.config.ts";
+
+await start(manifest, { plugins: [twindPlugin(twindConfig)] });\n`;
+  const MAIN_TS_PATH = join(resolvedDirectory, "main.ts");
+  await Deno.writeTextFile(MAIN_TS_PATH, MAIN_TS);
+
+  const TWIND_CONFIG_TS = `import { Options } from "$fresh/plugins/twind.ts";
+
+  export default {
+    selfURL: import.meta.url,
+  } as Options;
+  `;
+  await Deno.writeTextFile(
+    join(resolvedDirectory, "twind.config.ts"),
+    TWIND_CONFIG_TS,
+  );
+
+  const project = new Project();
+  const sfs = project.addSourceFilesAtPaths(
+    join(resolvedDirectory, "**", "*.{js,jsx,ts,tsx}"),
+  );
+
+  for (const sf of sfs) {
+    const nodes = sf.forEachDescendantAsArray();
+    for (const n of nodes) {
+      if (!n.wasForgotten() && Node.isJsxAttribute(n)) {
+        const init = n.getInitializer();
+        const name = n.getName();
+        if (
+          Node.isJsxExpression(init) &&
+          (name === "class" || name === "className")
+        ) {
+          const expr = init.getExpression();
+          if (Node.isTaggedTemplateExpression(expr)) {
+            const tag = expr.getTag();
+            if (Node.isIdentifier(tag) && tag.getText() === "tw") {
+              const template = expr.getTemplate();
+              if (Node.isNoSubstitutionTemplateLiteral(template)) {
+                n.setInitializer(`"${template.getLiteralValue()}"`);
+              }
+            }
+          } else if (expr?.getFullText() === `tw(props.class ?? "")`) {
+            n.setInitializer(`{props.class}`);
+          }
+        }
+      }
+    }
+
+    const text = sf.getFullText();
+    const removeTw = [...text.matchAll(/tw[,\s`(]/g)].length === 1;
+
+    for (const d of sf.getImportDeclarations()) {
+      if (d.getModuleSpecifierValue() !== "@twind") continue;
+      for (const n of d.getNamedImports()) {
+        const name = n.getName();
+        if (name === "tw" && removeTw) n.remove();
+      }
+      d.setModuleSpecifier("twind");
+      if (
+        d.getNamedImports().length === 0 &&
+        d.getNamespaceImport() === undefined &&
+        d.getDefaultImport() === undefined
+      ) {
+        d.remove();
+      }
+    }
+
+    await sf.save();
+  }
+}
+
+const manifest = await collect(resolvedDirectory);
+await generate(resolvedDirectory, manifest);

--- a/www/routes/update.tsx
+++ b/www/routes/update.tsx
@@ -1,0 +1,288 @@
+import { asset, Head } from "$fresh/runtime.ts";
+import { Handlers, PageProps } from "$fresh/server.ts";
+import Counter from "../islands/Counter.tsx";
+import LemonDrop from "../islands/LemonDrop.tsx";
+import Footer from "../components/Footer.tsx";
+import VERSIONS from "../../versions.json" assert { type: "json" };
+import * as FeatureIcons from "../components/FeatureIcons.tsx";
+import CopyArea from "../islands/CopyArea.tsx";
+import * as Icons from "../components/Icons.tsx";
+import Projects from "../components/Projects.tsx";
+import projects from "../data/showcase.json" assert { type: "json" };
+
+export const handler: Handlers = {
+  GET(req) {
+    const accept = req.headers.get("accept");
+    let path = "/docs/concepts/updating";
+    if (accept && !accept.includes("text/html")) {
+      path = `https://deno.land/x/fresh@${VERSIONS[0]}/update.ts`;
+    }
+    return new Response(`Redirecting to ${path}`, {
+      headers: { "Location": path },
+      status: 307,
+    });
+  },
+};
+
+const TITLE = "fresh - The next-gen web framework.";
+const DESCRIPTION =
+  "Just in time edge rendering, island based interactivity, and no configuration TypeScript support using Deno.";
+
+export default function MainPage(props: PageProps) {
+  const ogImageUrl = new URL(asset("/home-og.png"), props.url).href;
+  const origin = `${props.url.protocol}//${props.url.host}`;
+
+  return (
+    <>
+      <Head>
+        <title>{TITLE}</title>
+        <meta name="description" content={DESCRIPTION} />
+        <meta property="og:title" content={TITLE} />
+        <meta property="og:description" content={DESCRIPTION} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={props.url.href} />
+        <meta property="og:image" content={ogImageUrl} />
+      </Head>
+      <div class="flex flex-col min-h-screen">
+        <Hero />
+        <div class="flex-1">
+          <Intro />
+          <GettingStarted origin={origin} />
+          <Example />
+          <Showcase />
+        </div>
+        <Footer />
+      </div>
+    </>
+  );
+}
+
+function Hero() {
+  return (
+    <>
+      <div class="flex justify-end items-center bg-green-300">
+        <a
+          href="/docs"
+          class="border(1 black) inline-flex items-center h-10 px-4 m-4 text-black bg-transparent rounded hover:bg-white"
+        >
+          Documentation
+        </a>
+      </div>
+      <section class="w-full flex justify-center items-center flex-col bg-green-300">
+        <LemonDrop />
+      </section>
+    </>
+  );
+}
+
+function Features() {
+  const item = "flex md:flex-col items-center gap-5";
+  const desc = "flex-1 md:text-center";
+
+  return (
+    <div class="grid md:grid-cols-3 gap-6 md:gap-14">
+      <div class={item}>
+        <FeatureIcons.Globe />
+        <div class={desc}>
+          <b>Just-in-time rendering</b> on the edge.
+        </div>
+      </div>
+
+      <div class={item}>
+        <FeatureIcons.Island />
+        <div class={desc}>
+          <b>Island based client hydration</b> for maximum interactivity.
+        </div>
+      </div>
+
+      <div class={item}>
+        <FeatureIcons.LightWeight />
+        <div class={desc}>
+          <b>Zero runtime overhead</b>: no JS is shipped to the client by
+          default.
+        </div>
+      </div>
+
+      <div class={item}>
+        <FeatureIcons.NoBuild />
+        <div class={desc}>
+          <b>No build step</b>.
+        </div>
+      </div>
+
+      <div class={item}>
+        <FeatureIcons.Gabage />
+        <div class={desc}>
+          <b>No configuration</b> necessary.
+        </div>
+      </div>
+
+      <div class={item}>
+        <FeatureIcons.TypeScript />
+        <div class={desc}>
+          <b>TypeScript support</b> out of the box.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Intro() {
+  return (
+    <section class="max-w-screen-md mx-auto my-16 px(4 sm:6 md:8) space-y-12">
+      <div class="md:flex items-center">
+        <div class="flex-1 text-center md:text-left">
+          <h2 class="py-2 text(5xl sm:5xl lg:5xl gray-900) sm:tracking-tight sm:leading-[1.1]! font-extrabold">
+            The <span class="text-green-500">next-gen</span> web framework.
+          </h2>
+
+          <p class="mt-4 text-gray-600">
+            Built for speed, reliability, and simplicity.
+          </p>
+        </div>
+
+        <picture class="block mt-4 md:mt-0">
+          <img
+            src="/illustration/lemon-squash.svg"
+            class="w-80 mx-auto"
+            width={800}
+            height={678}
+            alt="deno is drinking fresh lemon squash"
+          />
+        </picture>
+      </div>
+
+      <Features />
+
+      <p class="text-gray-600">
+        Fresh embraces the tried and true design of server side rendering and
+        progressive enhancement on the client side.
+      </p>
+    </section>
+  );
+}
+
+function GettingStarted(props: { origin: string }) {
+  return (
+    <section class="max-w-screen-md mx-auto my-16 px(4 sm:6 md:8) space-y-4">
+      <h2 id="getting-started" class="text(3xl gray-600) font-bold">
+        <a href="#getting-started" class="hover:underline">
+          Getting Started
+        </a>
+      </h2>
+      <div class="text-gray-600 flex gap-1 mb-4 bg-gray-100 p-2 rounded">
+        <div class="text-gray-400">
+          <Icons.Info />
+        </div>
+        <p>
+          <a href="https://deno.land" class="text-blue-600 hover:underline">
+            Deno CLI
+          </a>{" "}
+          version 1.23.0 or higher is required.{" "}
+          <a
+            href="https://deno.land/manual/getting_started/installation"
+            class="text-blue-600 hover:underline"
+          >
+            Install
+          </a>{" "}
+          or{" "}
+          <a
+            href="https://deno.land/manual/getting_started/installation#updating"
+            class="text-blue-600 hover:underline"
+          >
+            update
+          </a>.
+        </p>
+      </div>
+      <p class="text-gray-600">
+        To bootstrap a new project:
+      </p>
+
+      <CopyArea>
+        {`deno run -A -r ${props.origin} my-project`}
+      </CopyArea>
+
+      <p class="text-gray-600">
+        Enter the newly created project directory and run the following command
+        to start the development server:
+      </p>
+
+      <CopyArea>{`deno task start`}</CopyArea>
+
+      <p class="text-gray-600">
+        You can now open{" "}
+        <a
+          href="http://localhost:8000"
+          class="text-blue-600 hover:underline"
+        >
+          http://localhost:8000
+        </a>{" "}
+        in your browser to view the page.
+      </p>
+      <p class="text-gray-600">
+        A more in-depth{" "}
+        <a
+          href="/docs/getting-started"
+          class="text-blue-600 hover:underline"
+        >
+          <i>Getting Started</i>
+        </a>{" "}
+        guide is available in{" "}
+        <a href="/docs" class="text-blue-600 hover:underline">the docs</a>.
+      </p>
+    </section>
+  );
+}
+
+const timeFmt = new Intl.DateTimeFormat("en-US", {
+  timeStyle: "long",
+  hour12: false,
+});
+
+function Example() {
+  return (
+    <section class="max-w-screen-md mx-auto my-16 px(4 sm:6 md:8) space-y-4">
+      <h2 id="example" class="text(3xl gray-600) font-bold">
+        <a href="#example" class="hover:underline">
+          Example
+        </a>
+      </h2>
+      <p class="text-gray-600">
+        This text is being server side rendered on the fly. It was rendered at
+        {" "}
+        {timeFmt.format(new Date())}.
+      </p>
+      <p class="text-gray-600">
+        The counter below was rendered on the server with a starting value of 3,
+        and was then hydrated on the client to provide interactivity. Try out
+        the buttons!
+      </p>
+      <Counter start={3} />
+      <p class="text-gray-600">
+        Only the JS required to render that counter is sent to the client.
+      </p>
+    </section>
+  );
+}
+
+function Showcase() {
+  return (
+    <section class="max-w-screen-md mx-auto my-16 px(4 sm:6 md:8) space-y-4">
+      <h2 id="showcase" class="text(3xl gray-600) font-bold">
+        <a href="#showcase" class="hover:underline">
+          Showcase
+        </a>
+      </h2>
+      <p class="text-gray-600">
+        Below is a selection of projects that have been built with Fresh.
+      </p>
+      <Projects items={projects.slice(0, 3)} class="gap-8" />
+      <div class="flex gap-2 items-center justify-end text-blue-600">
+        <Icons.ArrowRight />
+        <a href="./showcase" class="hover:underline focus:underline">
+          View more
+        </a>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
This commit adds an update.ts tool that makes it easy to upgrade
existing Fresh projects to the latest version of Fresh. This tool
updates dependency versions in the import map, and includes some code
mods:

1. update projects from classic JSX to automatic JSX
2. update projects from legacy twind integration to twind plugin

Both of these code mods get you about 95% of the way there most of the
time. Users might still need to do some manual work to get their
projects fully updated.
