### PR TITLE
Async plugin rendering (addresses #728)

### DIFF
--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -99,3 +99,29 @@ serializable JavaScript value.
 
 For an example of a plugin that uses the `render` hook, see the first-party
 [Twind plugin](https://github.com/denoland/fresh/blob/main/plugins/twind.ts).
+
+### Hook: `renderAsync`
+
+This hook is largely the same as the `render` hook, with a couple of key
+differences to make asynchronous style and script generation possible. It must
+asynchronously return its
+[`PluginRenderResult`](https://deno.land/x/fresh/server.ts?s=PluginRenderResult),
+either from an `async/await` function or wrapped within a promise.
+
+The render hook is called with the
+[`AsyncPluginRenderContext`](https://deno.land/x/fresh/server.ts?s=AsyncPluginRenderContext)
+object, which contains a `renderAsync()` method. This method must be invoked
+during the render hook to actually render the page. It is a terminal error to
+not call the `renderAsync()` method during the render hook.
+
+This is useful for when plugins are generating styles and scripts with
+asynchronous dependencies based on the `htmlText`. Unlike the synchronous render
+hook, async render hooks for multiple pages can be running at the same time.
+This means that unlike the synchronous render hook, you can not use global
+variables to propagate state between the render hook and the renderer.
+
+The `renderAsync` hooks start before any page rendering occurs, and finish after
+all rendering is complete -- they wrap around the underlying JSX->string
+rendering, plugin `render` hooks, and the
+[`RenderFunction`](https://deno.land/x/fresh/server.ts?s=RenderFunction) that
+may be provided to Fresh's `start` entrypoint in the `main.ts` file.

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -269,10 +269,26 @@ export interface Plugin {
    * inject CSS into the page, or load additional JS files on the client.
    */
   render?(ctx: PluginRenderContext): PluginRenderResult;
+
+  /** The asynchronous render hook is called on the server every time some
+   * JSX needs to be turned into HTML, wrapped around all synchronous render
+   * hooks. The render hook needs to call the `ctx.renderAsync` function
+   * exactly once, and await the result.
+   *
+   * This is useful for when plugins are generating styles and scripts with
+   * asynchronous dependencies. Unlike the synchronous render hook, async render
+   * hooks for multiple pages can be running at the same time. This means that
+   * unlike the synchronous render hook, you can not use global variables to
+   * propagate state between the render hook and the renderer.
+   */
+  renderAsync?(ctx: PluginAsyncRenderContext): Promise<PluginRenderResult>;
 }
 
 export interface PluginRenderContext {
   render: PluginRenderFunction;
+}
+export interface PluginAsyncRenderContext {
+  renderAsync: PluginAsyncRenderFunction;
 }
 
 export interface PluginRenderResult {
@@ -303,12 +319,14 @@ export interface PluginRenderScripts {
 }
 
 export type PluginRenderFunction = () => PluginRenderFunctionResult;
+export type PluginAsyncRenderFunction = () =>
+  | PluginRenderFunctionResult
+  | Promise<PluginRenderFunctionResult>;
 
 export interface PluginRenderFunctionResult {
   /** The HTML text that was rendered. */
   htmlText: string;
   /** If the renderer encountered any islands that require hydration on the
-   * client.
-   */
+   * client. */
   requiresHydration: boolean;
 }

--- a/tests/fixture_plugin/options.ts
+++ b/tests/fixture_plugin/options.ts
@@ -1,5 +1,12 @@
 import { FreshOptions } from "$fresh/server.ts";
 import cssInjectPlugin from "./utils/css-inject-plugin.ts";
 import jsInjectPlugin from "./utils/js-inject-plugin.ts";
+import cssInjectPluginAsync from "./utils/css-inject-plugin-async.ts";
 
-export default { plugins: [cssInjectPlugin, jsInjectPlugin] } as FreshOptions;
+export default {
+  plugins: [
+    cssInjectPlugin,
+    jsInjectPlugin,
+    cssInjectPluginAsync,
+  ],
+} as FreshOptions;

--- a/tests/fixture_plugin/utils/css-inject-plugin-async.ts
+++ b/tests/fixture_plugin/utils/css-inject-plugin-async.ts
@@ -1,0 +1,15 @@
+import { Plugin } from "$fresh/server.ts";
+
+let CSS_TO_INJECT = "h1 { text-decoration: underline; }";
+
+export default {
+  name: "css-inject-async",
+  async renderAsync(ctx) {
+    await new Promise((res) => setTimeout(res, 50));
+    const res = await ctx.renderAsync();
+    if (res.requiresHydration) {
+      CSS_TO_INJECT += " h1 { font-style: italic; }";
+    }
+    return { styles: [{ cssText: CSS_TO_INJECT, id: "def" }] };
+  },
+} as Plugin;

--- a/tests/plugin_test.ts
+++ b/tests/plugin_test.ts
@@ -35,6 +35,10 @@ Deno.test("/static page prerender", async () => {
   assertStringIncludes(body, '<style id="abc">body { color: red; }</style>');
   assert(!body.includes(`>{"v":[[],[]]}</script>`));
   assert(!body.includes(`import`));
+  assertStringIncludes(
+    body,
+    '<style id="def">h1 { text-decoration: underline; }</style>',
+  );
 });
 
 Deno.test("/with-island prerender", async () => {
@@ -48,6 +52,10 @@ Deno.test("/with-island prerender", async () => {
   );
   assertStringIncludes(body, `>{"v":[[{}],["JS injected!"]]}</script>`);
   assertStringIncludes(body, `/plugin-js-inject-main.js"`);
+  assertStringIncludes(
+    body,
+    '<style id="def">h1 { text-decoration: underline; } h1 { font-style: italic; }</style>',
+  );
 });
 
 Deno.test({


### PR DESCRIPTION
Closes #728

For now, it's added as an extra hook that runs after all other render functions are called. I'm assuming it's alright that the async plugin render functions would be called after `opts.renderFn`, since none of the plugins modify the page's content, only add scripts/styles, and this way the thread local state will be preserved everywhere except in the renderAsync hooks.

If this looks good to you, I'll see if I can start building a couple of plugins.