### PR TITLE
docs: correct required Deno version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The [documentation](https://fresh.deno.dev/docs/) is available on
 
 ## 🚀 Getting started
 
-Install [Deno CLI](https://deno.land/) version 1.23.0 or higher.
+Install [Deno CLI](https://deno.land/) version 1.25.0 or higher.
 
 You can scaffold a new project by running the Fresh init script. To scaffold a
 project in the `deno-fresh-demo` folder, run the following:

--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -193,7 +193,7 @@ function GettingStarted(props: { origin: string }) {
           <a href="https://deno.land" class="text-blue-600 hover:underline">
             Deno CLI
           </a>{" "}
-          version 1.23.0 or higher is required.{" "}
+          version 1.25.0 or higher is required.{" "}
           <a
             href="https://deno.land/manual/getting_started/installation"
             class="text-blue-600 hover:underline"

--- a/www/routes/update.tsx
+++ b/www/routes/update.tsx
@@ -178,7 +178,7 @@ function GettingStarted(props: { origin: string }) {
           <a href="https://deno.land" class="text-blue-600 hover:underline">
             Deno CLI
           </a>{" "}
-          version 1.23.0 or higher is required.{" "}
+          version 1.25.0 or higher is required.{" "}
           <a
             href="https://deno.land/manual/getting_started/installation"
             class="text-blue-600 hover:underline"


### PR DESCRIPTION
This pull request applies the changed `MIN_DENO_VERSION` to the document.

---

When I had tried to install `fresh`, I met `error: Deno version 1.25.0 or higher is required. Please update Deno.` error message.

Since `1.1.0`, Deno became to require (see https://github.com/denoland/fresh/pull/610). And https://github.com/denoland/fresh/pull/718 updates some docs but something was missed.