### PR TITLE
feat: support passing signals as island props

### DIFF
--- a/demo/import_map.json
+++ b/demo/import_map.json
@@ -3,6 +3,8 @@
     "$fresh/": "../",
     "preact": "https://esm.sh/preact@10.13.1",
     "preact/": "https://esm.sh/preact@10.13.1/",
-    "preact-render-to-string": "https://esm.sh/*preact-render-to-string@5.2.6"
+    "preact-render-to-string": "https://esm.sh/*preact-render-to-string@5.2.6",
+    "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
+    "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.2.3"
   }
 }

--- a/demo/islands/Counter.tsx
+++ b/demo/islands/Counter.tsx
@@ -1,19 +1,18 @@
-import { useState } from "preact/hooks";
+import { Signal } from "@preact/signals";
 import { IS_BROWSER } from "$fresh/runtime.ts";
 
 interface CounterProps {
-  start: number;
+  count: Signal<number>;
 }
 
-export default function Counter(props: CounterProps) {
-  const [count, setCount] = useState(props.start);
+export default function Counter({ count }: CounterProps) {
   return (
     <div>
       <p>{count}</p>
-      <button onClick={() => setCount(count - 1)} disabled={!IS_BROWSER}>
+      <button onClick={() => count.value -= 1} disabled={!IS_BROWSER}>
         -1
       </button>
-      <button onClick={() => setCount(count + 1)} disabled={!IS_BROWSER}>
+      <button onClick={() => count.value += 1} disabled={!IS_BROWSER}>
         +1
       </button>
     </div>

--- a/demo/routes/index.tsx
+++ b/demo/routes/index.tsx
@@ -1,13 +1,17 @@
+import { useSignal } from "@preact/signals";
 import Counter from "../islands/Counter.tsx";
 
 export default function Home() {
+  const count = useSignal(3);
   return (
     <div>
       <p>
         Welcome to Fresh. Try to update this message in the ./routes/index.tsx
         file, and refresh.
       </p>
-      <Counter start={3} />
+      <Counter count={count} />
+      <Counter count={count} />
+      <Counter count={count} />
     </div>
   );
 }

--- a/docs/concepts/islands.md
+++ b/docs/concepts/islands.md
@@ -39,6 +39,7 @@ Fresh can serialize the following types of values:
   `null`, and `bigint`s are not supported)
 - Plain objects with string keys and serializable values
 - Arrays containing serializable values
+- Preact Signals (if the inner value is serializable)
 
 Circular references are supported. If an object or signal is referenced multiple
 times, it is only serialized once and the references are restored upon

--- a/src/runtime/deserializer.ts
+++ b/src/runtime/deserializer.ts
@@ -3,11 +3,22 @@
 
 export const KEY = "_f";
 
-export function deserialize(str: string): unknown {
+interface Signal<T> {
+  peek(): T;
+  value: T;
+}
+
+export function deserialize(
+  str: string,
+  signal?: <T>(a: T) => Signal<T>,
+): unknown {
   function reviver(this: unknown, _key: string, value: unknown): unknown {
     if (typeof value === "object" && value && KEY in value) {
       // deno-lint-ignore no-explicit-any
       const v: any = value;
+      if (v[KEY] === "s") {
+        return signal!(v.v);
+      }
       if (v[KEY] === "l") {
         const val = v.v;
         val[KEY] = v.k;

--- a/src/runtime/entrypoints/signals.ts
+++ b/src/runtime/entrypoints/signals.ts
@@ -1,0 +1,1 @@
+export { signal } from "@preact/signals";

--- a/src/server/__snapshots__/serializer_test.ts.snap
+++ b/src/server/__snapshots__/serializer_test.ts.snap
@@ -2,6 +2,8 @@ export const snapshot = {};
 
 snapshot[`serializer - primitives & plain objects 1`] = `'{"v":{"a":1,"b":"2","c":true,"d":null,"f":[1,2,3],"g":{"a":1,"b":2,"c":3}}}'`;
 
+snapshot[`serializer - signals 1`] = `'{"v":{"a":1,"b":{"_f":"s","v":2}}}'`;
+
 snapshot[`serializer - magic key 1`] = `'{"v":{"_f":"l","k":"f","v":{"a":1}}}'`;
 
 snapshot[`serializer - circular reference objects 1`] = `'{"v":{"a":1,"b":0},"r":[[[],["b"]]]}'`;
@@ -12,4 +14,8 @@ snapshot[`serializer - circular reference array 1`] = `'{"v":[1,2,3,0],"r":[[[],
 
 snapshot[`serializer - multiple reference 1`] = `'{"v":{"a":1,"b":{"c":2},"d":0},"r":[[["b"],["d"]]]}'`;
 
+snapshot[`serializer - multiple reference signals 1`] = `'{"v":{"inner":{"_f":"l","k":"x","v":{"x":1,"y":0}},"a":{"_f":"s","v":0},"b":{"c":0}},"r":[[["inner"],["inner",null,"y"],["a","value"]],[["a"],["b","c"]]]}'`;
+
 snapshot[`serializer - multiple reference in magic key 1`] = `'{"v":{"literal":{"_f":"l","k":"x","v":{"inner":{"foo":"bar"}}},"inner":0},"r":[[["literal",null,"inner"],["inner"]]]}'`;
+
+snapshot[`serializer - multiple reference in signal 1`] = `'{"v":{"s":{"_f":"s","v":{"foo":"bar"}},"inner":0},"r":[[["s","value"],["inner"]]]}'`;

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -76,6 +76,13 @@ export class Bundler {
       deserializer: import.meta.resolve(`${entrypointBase}/deserializer.ts`),
     };
 
+    try {
+      import.meta.resolve("@preact/signals");
+      entryPoints.signals = import.meta.resolve(`${entrypointBase}/signals.ts`);
+    } catch {
+      // @preact/signals is not in the import map
+    }
+
     for (const island of this.#islands) {
       entryPoints[`island-${island.id}`] = island.url;
     }

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -257,10 +257,18 @@ export async function render<Data>(
       const url = addImport("/deserializer.js");
       script += `import { deserialize } from "${url}";`;
     }
+    if (res.hasSignals) {
+      const url = addImport("/signals.js");
+      script += `import { signal } from "${url}";`;
+    }
     script += `const ST = document.getElementById("__FRSH_STATE").textContent;`;
     script += `const STATE = `;
     if (res.requiresDeserializer) {
-      script += `deserialize(ST);`;
+      if (res.hasSignals) {
+        script += `deserialize(ST, signal);`;
+      } else {
+        script += `deserialize(ST);`;
+      }
     } else {
       script += `JSON.parse(ST).v;`;
     }


### PR DESCRIPTION
This commit adds support for passing signals to islands in component
props. This is useful for passing around mutable state between islands.
The signal's value needs to be serializable for this to work.

Closes #749

Depends on #1224 