### PR TITLE
feat: allow custom charset/viewport

### DIFF
--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -328,35 +328,31 @@ export interface TemplateOptions {
   lang: string;
 }
 
-/**
- * Splices and returns the first child VNode that satisfies the predicate, if
- * any. The children array is modified in place if a matching VNode is found.
- */
-function extractVNode(
-  children: ComponentChildren[],
-  predicate: (vnode: VNode<Record<string, unknown>>) => boolean,
-): VNode | null {
-  for (let i = 0; i < children.length; i++) {
-    const child = children[i];
-    if (!child || typeof child !== "object") {
-      continue;
-    }
-    if (Array.isArray(child)) {
-      const vnode = extractVNode(child, predicate);
-      if (vnode) {
-        return vnode;
-      }
-      continue;
-    }
-    if ("type" in child && predicate(child)) {
-      children.splice(i, 1);
-      return child;
-    }
-  }
-  return null;
-}
-
 export function template(opts: TemplateOptions): string {
+  function extractVNode(
+    children: ComponentChildren[],
+    predicate: (vnode: VNode<Record<string, unknown>>) => boolean,
+  ): VNode | null {
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      if (!child || typeof child !== "object") {
+        continue;
+      }
+      if (Array.isArray(child)) {
+        const vnode = extractVNode(child, predicate);
+        if (vnode) {
+          return vnode;
+        }
+        continue;
+      }
+      if ("type" in child && predicate(child)) {
+        children.splice(i, 1);
+        return child;
+      }
+    }
+    return null;
+  }
+  
   const charSet = extractVNode(opts.headComponents, vnode => (
     vnode.type === "meta" && "charSet" in vnode.props
   ));

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -1,5 +1,5 @@
 import { renderToString } from "preact-render-to-string";
-import { VNode, ComponentChildren, ComponentType, h, options } from "preact";
+import { ComponentChildren, ComponentType, h, options, VNode } from "preact";
 import {
   AppModule,
   ErrorPage,
@@ -352,11 +352,11 @@ export function template(opts: TemplateOptions): string {
     }
     return null;
   }
-  
-  const charSet = extractVNode(opts.headComponents, vnode => (
+
+  const charSet = extractVNode(opts.headComponents, (vnode) => (
     vnode.type === "meta" && "charSet" in vnode.props
   ));
-  const viewport = extractVNode(opts.headComponents, vnode => (
+  const viewport = extractVNode(opts.headComponents, (vnode) => (
     vnode.type === "meta" && vnode.props.name === "viewport"
   ));
 

--- a/src/server/render_test.ts
+++ b/src/server/render_test.ts
@@ -1,5 +1,6 @@
+import { h } from "preact";
 import { template } from "./render.ts";
-import { assertStringIncludes } from "../../tests/deps.ts";
+import { assertEquals, assertStringIncludes } from "../../tests/deps.ts";
 
 Deno.test("check lang", () => {
   const lang = "fr";
@@ -11,4 +12,33 @@ Deno.test("check lang", () => {
     lang,
   });
   assertStringIncludes(body, `<html lang="${lang}">`);
+});
+
+Deno.test("charset/viewport set by default", () => {
+  const body = template({
+    bodyHtml: "",
+    headComponents: [],
+    imports: [],
+    preloads: [],
+    lang: "en",
+  });
+  assertStringIncludes(body, `<meta charSet="`);
+  assertStringIncludes(body, `<meta name="viewport"`);
+});
+
+Deno.test("no default charset/viewport if manually specified", () => {
+  const body = template({
+    bodyHtml: "",
+    headComponents: [
+      h("meta", { charSet: "foo" }),
+      [h("meta", { name: "viewport", content: "bar" })],
+    ],
+    imports: [],
+    preloads: [],
+    lang: "en",
+  });
+  assertStringIncludes(body, `<meta charSet="foo" />`);
+  assertStringIncludes(body, `<meta name="viewport" content="bar" />`);
+  assertEquals(body.split(`<meta charSet="`).length - 1, 1);
+  assertEquals(body.split(`<meta name="viewport"`).length - 1, 1);
 });


### PR DESCRIPTION
This PR is an attempt to fix the issue reported by @hbsion in #779.

When setting a custom viewport or charset meta tag, Fresh renders both the default and the custom versions. This fixes that problem by looking for custom charset/viewport VNodes in the `headComponents` during rendering. If found, they're extracted from the `headComponents` children and rendered instead of the defaults at the top of the `<head>`.

I originally was doing a simple loop of the `headComponents` that didn't extract the VNodes but just returned true if they were in there. If they were, the defaults weren't rendered and the custom versions were left alone, rendered further down in the `<head>` of the html. But after reading through https://github.com/vercel/next.js/issues/9794, I felt this wasn't the best solution because of the issues with W3 validation described in that thread. (The charset meta could end up too far down in the `<head>` to pass validation.) By extracting them and placing them at the top of the `<head>` where the defaults would've been, that problem is avoided.

I didn't benchmark anything, but I don't think I increased the complexity of the render process. The `extractVNode()` helper I added loops through each child of the `headComponents`, which already happens during `renderToString()`.