### PR TITLE
Fix wasm relative url

### DIFF
--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -13,7 +13,7 @@ async function ensureEsbuildInitialized() {
   if (esbuildInitialized === false) {
     if (Deno.run === undefined) {
       esbuildInitialized = esbuild.initialize({
-        wasmURL: "./esbuild_v0.14.51.wasm",
+        wasmURL: new URL("./esbuild_v0.14.51.wasm", import.meta.url).href,
         worker: false,
       });
     } else {


### PR DESCRIPTION
Islands seem not working on the latest LP. Error logs:

![image](https://user-images.githubusercontent.com/3132889/196659743-acecf9fc-4d51-4bfa-82a8-a00be4427716.png)

![image](https://user-images.githubusercontent.com/3132889/196659448-40b36e16-5476-4163-8f9d-87fc5a61cc0e.png)

I fixed wasm url to absolute path.

co-authored-by: @kt3k 

Related: 
- https://github.com/denoland/fresh/pull/850
- https://github.com/denoland/fresh/issues/851