### PR TITLE
add middleware-like layouts in routes using HOCs

### DIFF
--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -5,6 +5,7 @@ import {
   AppModule,
   ErrorPageModule,
   IslandModule,
+  LayoutModule,
   MiddlewareModule,
   RouteModule,
   StartOptions,
@@ -41,6 +42,7 @@ export interface Manifest {
     string,
     | RouteModule
     | MiddlewareModule
+    | LayoutModule
     | AppModule
     | ErrorPageModule
     | UnknownPageModule

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -227,6 +227,26 @@ export interface Middleware<State = Record<string, unknown>> {
   handler: MiddlewareHandler<State> | MiddlewareHandler<State>[];
 }
 
+// --- LAYOUTS ---
+
+export interface LayoutModule {
+  default: (component: ComponentType<PageProps>) => ComponentType<PageProps>;
+  top?: boolean;
+}
+
+export interface LayoutRoute extends LayoutModule {
+  /**
+   * path-to-regexp style url path
+   */
+  pattern: string;
+  /**
+   * URLPattern of the route
+   */
+  compiledPattern: URLPattern;
+
+  top: boolean;
+}
+
 // --- ISLANDS ---
 
 export interface IslandModule {


### PR DESCRIPTION
This pr implements layouts as described in #403.

There doesn't seem to have been any productive discussion about this since https://github.com/denoland/fresh/issues/403#issuecomment-1176089873, so I took some inspiration from [QuikCity's layouts](https://qwik.builder.io/qwikcity/layout/overview/).

It works very similarily to QwikCity, except for the usage of [higher-order components](https://reactjs.org/docs/higher-order-components.html) instead of a special `<Slot />` component. Alternatively to HOCs, layouts could be a normal component that only takes children as a prop.

There's a little bit more boilerplate with HOCs, but in return, layouts will have access to `PageProps` and also the ability to transform props before passing them to the child component, which makes them the more powerful option, IMO.

A quick example:

```
# ./routes/any/sub/path/_layout.tsx

export default <P extends PageProps>(Component: ComponentType<P>) => {
  return (props: P) => {
    return <div>hello <Component {...props} someExtraProp="foo" />! We're on {props.url.toString()}!</div>;
  };
};
```

In comparison to a children prop.

```
# ./routes/any/sub/path/_layout.tsx

export default ({ children }: LayoutProps) => {
  return <div>hello {children}! I'm lost :(</div>;
};
```
