### PR TITLE
fix: typo in default error page "occured" -> "occurred"

### DIFF
--- a/src/server/default_error_page.ts
+++ b/src/server/default_error_page.ts
@@ -42,7 +42,7 @@ export default function DefaultErrorPage(props: ErrorPageProps) {
           padding: 16,
           fontFamily: "sans-serif",
         },
-      }, "An error occured during route handling or page rendering."),
+      }, "An error occurred during route handling or page rendering."),
       message && h("pre", {
         style: {
           margin: 0,

--- a/tests/error_test.ts
+++ b/tests/error_test.ts
@@ -28,7 +28,7 @@ Deno.test("error page rendered", async () => {
   const body = await resp.text();
   assertStringIncludes(
     body,
-    `An error occured during route handling or page rendering.`,
+    `An error occurred during route handling or page rendering.`,
   );
   assertStringIncludes(body, `Error: boom!`);
   assertStringIncludes(body, `at render`);


### PR DESCRIPTION
Hi, I've found a typo in the error page. The word "occured" does not exist. It is spelled with two "r", "occurred".

Same as #533 

I fixed the error page and the corresponding test.

Sources:
 - ["occured" in Merriam Webster](https://www.merriam-webster.com/dictionary/occured)
 - [Is it occurred or occured? on writer.com](https://writer.com/blog/occurred-occured/)
 - [Occurred, Occured, or Ocurred—Which Spelling Is Right? on grammarly.com](https://www.grammarly.com/blog/occurred-occured-ocurred/)
