### PR TITLE
Fix component gallery layout

### DIFF
--- a/www/components/gallery/Background.tsx
+++ b/www/components/gallery/Background.tsx
@@ -4,7 +4,7 @@ export default function Background(props: JSX.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
       {...props}
-      class="bg-gray-200 py-16 px-8 flex items-center justify-center rounded"
+      class="bg-gray-200 py-16 px-8 flex gap-4 items-center justify-center rounded flex-wrap"
       style="background-image: url(/gallery/grid.svg)"
     />
   );

--- a/www/components/gallery/CodeBox.tsx
+++ b/www/components/gallery/CodeBox.tsx
@@ -25,18 +25,19 @@ export default function CodeBox(props: CodeBoxProps) {
         <summary class="text-center cursor-pointer bg-gray-50 select-none text-gray-600 hover:text-gray-800 hover:bg-gray-100 py-2 rounded-b">
           Code
         </summary>
-        <code class="relative">
-          <pre
-            class="bg-gray-800 text-blue-300 p-2 text-sm rounded whitespace-pre-wrap"
-            dangerouslySetInnerHTML={{ __html: highlighted }}
-          />
+        <div class="relative">
+          <pre class="bg-gray-800 text-blue-300 p-2 text-sm rounded whitespace-pre-wrap">
+            <code
+              dangerouslySetInnerHTML={{ __html: highlighted }}
+            />
+          </pre>
           <button
             onClick={onCopy}
-            class="absolute top-2 right-2 px-3 py-2 border border-gray-400 rounded text-white"
+            class="absolute top-2 right-2 px-3 py-2 border border-gray-400 rounded text-white bg-gray-800"
           >
             {copied ? "Copied!" : "Copy"}
           </button>
-        </code>
+        </div>
       </details>
     </div>
   );

--- a/www/components/gallery/Footer.tsx
+++ b/www/components/gallery/Footer.tsx
@@ -27,7 +27,7 @@ export default function Footer({ children }: Props) {
   ];
 
   return (
-    <div class="bg-white flex w-full max-w-screen-lg gap-16 px-8 py-8 text-sm">
+    <div class="bg-white flex flex-col md:flex-row w-full max-w-screen-lg gap-8 md:gap-16 px-8 py-8 text-sm">
       <div class="flex-1">
         <div class="flex items-center gap-1">
           <LemonIcon class="inline-block" />

--- a/www/components/gallery/Header.tsx
+++ b/www/components/gallery/Header.tsx
@@ -12,10 +12,12 @@ export default function Header({ active }: Props) {
   ];
 
   return (
-    <div class="bg-white w-full max-w-screen-lg py-6 px-8 flex items-center justify-center">
-      <LemonIcon />
-      <div class="text-2xl flex-1 ml-1 font-bold">
-        Fresh
+    <div class="bg-white w-full max-w-screen-lg py-6 px-8 flex flex-col md:flex-row gap-4">
+      <div class="flex items-center flex-1">
+        <LemonIcon />
+        <div class="text-2xl  ml-1 font-bold">
+          Fresh
+        </div>
       </div>
       <ul class="flex items-center gap-6">
         {menus.map((menu) => (

--- a/www/islands/ComponentGallery.tsx
+++ b/www/islands/ComponentGallery.tsx
@@ -53,13 +53,13 @@ export default function ComponentGallery(props: ComponentGalleryProps) {
         <Button>
           Click me
         </Button>
-        <Button class="flex gap-1 ml-2">
+        <Button class="flex gap-1">
           <IconHappy class="w-6 h-6 inline-block text-gray-500" />
           <div>
             With an Icon
           </div>
         </Button>
-        <Button disabled class="ml-2">
+        <Button disabled>
           Disabled
         </Button>
       </Section>
@@ -89,7 +89,7 @@ export default function ComponentGallery(props: ComponentGalleryProps) {
         source={props.sources.Input}
       >
         <Input placeholder="Placeholder" />
-        <Input class="ml-2" placeholder="Disabled" disabled />
+        <Input placeholder="Disabled" disabled />
       </Section>
 
       <Section title="Header" source={props.sources.Header}>


### PR DESCRIPTION
# Copy button layout broken on FF / Safari

<img width="433" alt="image" src="https://user-images.githubusercontent.com/3132889/200379283-720686ee-4200-4262-8773-4bc8ed3da5d5.png">

fixed: 

<img width="385" alt="image" src="https://user-images.githubusercontent.com/3132889/200379350-c20dbb28-8136-4e59-aa06-a3f0ffd12cd5.png">

# Mobile layout

<img width="430" alt="image" src="https://user-images.githubusercontent.com/3132889/200379879-5a05866a-a9f4-4b87-b2a9-35543d3bbc7b.png">

<img width="416" alt="image" src="https://user-images.githubusercontent.com/3132889/200379921-51b47470-910e-446b-8864-678158b9ab87.png">

<img width="421" alt="image" src="https://user-images.githubusercontent.com/3132889/200379965-a293df50-bfec-4a9c-b7c3-fa7a5ae7ce0a.png">

fixed: 

<img width="419" alt="image" src="https://user-images.githubusercontent.com/3132889/200380042-29f74d79-4609-4c28-96af-7a0cbb7825b8.png">

<img width="423" alt="image" src="https://user-images.githubusercontent.com/3132889/200380089-3e322a1a-bafd-4013-95a4-0bb591627cc8.png">

<img width="425" alt="image" src="https://user-images.githubusercontent.com/3132889/200380150-b07fca8b-4dc6-47a0-91a4-5d60719dd629.png">

Still header is not perfect, hopefully humberger menu with checkbox hack, but I think it's better for now.
