### PR TITLE
feat: encode and decode Uint8Array props

### DIFF
--- a/src/runtime/main.ts
+++ b/src/runtime/main.ts
@@ -1,5 +1,6 @@
 import { ComponentType, h, options, render } from "preact";
 import { assetHashingHook } from "./utils.ts";
+import { decodeProps } from "../shared/prop_encoding.ts";
 
 function createRootFragment(
   parent: Element,
@@ -42,7 +43,7 @@ export function revive(islands: Record<string, ComponentType>, props: any[]) {
 
       const [id, n] = tag.split(":");
       render(
-        h(islands[id], props[Number(n)]),
+        h(islands[id], decodeProps(props[Number(n)])),
         createRootFragment(
           parent! as HTMLElement,
           children,

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -18,6 +18,7 @@ import { ContentSecurityPolicy } from "../runtime/csp.ts";
 import { bundleAssetUrl } from "./constants.ts";
 import { assetHashingHook } from "../runtime/utils.ts";
 import { htmlEscapeJsonString } from "./htmlescape.ts";
+import { encodeProps } from "../shared/prop_encoding.ts";
 
 export interface RenderOptions<Data> {
   route: Route<Data> | UnknownPage | ErrorPage;
@@ -374,7 +375,7 @@ options.vnode = (vnode) => {
       vnode.type = (props) => {
         ignoreNext = true;
         const child = h(originalType, props);
-        ISLAND_PROPS.push(props);
+        ISLAND_PROPS.push(encodeProps(props));
         return h(
           `!--frsh-${island.id}:${ISLAND_PROPS.length - 1}--`,
           null,

--- a/src/shared/prop_encoding.ts
+++ b/src/shared/prop_encoding.ts
@@ -1,0 +1,80 @@
+import {
+  decode,
+  encode,
+} from "https://deno.land/std@0.150.0/encoding/base64.ts";
+
+function replaceValues<T>(
+  obj: Record<PropertyKey, unknown>,
+  fn: (value: unknown) => NonNullable<T> | undefined,
+) {
+  const handleValue = (val: unknown): unknown => {
+    if (Array.isArray(val)) {
+      return val.map((val) => handleValue(val));
+    }
+    const newVal = fn(val);
+    if (newVal !== undefined) {
+      return newVal;
+    }
+    if (val && typeof val === "object") {
+      return handleObj({ ...val });
+    }
+    return val;
+  };
+
+  const handleObj = (obj: Record<PropertyKey, unknown>) =>
+    Object.fromEntries(
+      Object.entries(obj).map(([key, val]) => [key, handleValue(val)]),
+    );
+
+  return handleObj(obj);
+}
+
+function toHexByte(n: number) {
+  const s = n.toString(16).padStart(2, "0");
+  if (s.length > 2) {
+    throw new Error("Byte must be in range [0-255]");
+  }
+  return s;
+}
+
+const PREFIX = `__FRSH_`;
+
+enum EncodedType {
+  UNKNOWN = 0,
+  UINT8ARRAY = 1,
+  MAX = 256,
+}
+
+const pack = (type: EncodedType, data: string): string =>
+  PREFIX + toHexByte(type) + data;
+
+const unpack = (val: unknown): [EncodedType, string] => {
+  if (typeof val !== "string" || !val.startsWith(PREFIX)) {
+    return [EncodedType.UNKNOWN, ""];
+  }
+  const s = val.substring(PREFIX.length);
+  return [parseInt(s.slice(0, 2), 16), s.slice(2)];
+};
+
+export function encodeProps(props: Record<PropertyKey, unknown>) {
+  return replaceValues(props, (val) => {
+    if (val instanceof Uint8Array) {
+      return pack(EncodedType.UINT8ARRAY, encode(val));
+    }
+  });
+}
+
+export function decodeProps(props: Record<PropertyKey, unknown>) {
+  return replaceValues(props, (val) => {
+    const [type, data] = unpack(val);
+
+    switch (type) {
+      case EncodedType.UNKNOWN:
+        return undefined;
+      case EncodedType.UINT8ARRAY:
+        return decode(data);
+      default:
+        throw new Error(`Unknown type "${type}"`);
+    }
+  });
+}

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -32,8 +32,9 @@ import * as $25 from "./routes/props/[id].tsx";
 import * as $26 from "./routes/static.tsx";
 import * as $27 from "./routes/wildcard.tsx";
 import * as $$0 from "./islands/Counter.tsx";
-import * as $$1 from "./islands/Test.tsx";
-import * as $$2 from "./islands/kebab-case-counter-test.tsx";
+import * as $$1 from "./islands/Props.tsx";
+import * as $$2 from "./islands/Test.tsx";
+import * as $$3 from "./islands/kebab-case-counter-test.tsx";
 
 const manifest = {
   routes: {
@@ -68,8 +69,9 @@ const manifest = {
   },
   islands: {
     "./islands/Counter.tsx": $$0,
-    "./islands/Test.tsx": $$1,
-    "./islands/kebab-case-counter-test.tsx": $$2,
+    "./islands/Props.tsx": $$1,
+    "./islands/Test.tsx": $$2,
+    "./islands/kebab-case-counter-test.tsx": $$3,
   },
   baseUrl: import.meta.url,
   config,

--- a/tests/fixture/islands/Props.tsx
+++ b/tests/fixture/islands/Props.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "preact/hooks";
+
+interface Props {
+  u8: { single: Uint8Array; array: Uint8Array[] };
+}
+
+export default function Props({ u8 }: Props) {
+  const [u8SingleByteLength, setU8SingleByteLength] = useState(0);
+  const [u8ArrayByteLength, setU8ArrayByteLength] = useState(0);
+
+  useEffect(() => {
+    setU8SingleByteLength(u8.single.byteLength);
+    setU8ArrayByteLength(u8.array.reduce((sum, u8) => sum + u8.byteLength, 0));
+  }, []);
+
+  return (
+    <div>
+      <div id="u8-single-bytelength">{u8SingleByteLength}</div>
+      <div id="u8-array-bytelength">{u8ArrayByteLength}</div>
+    </div>
+  );
+}

--- a/tests/fixture/routes/islands/index.tsx
+++ b/tests/fixture/routes/islands/index.tsx
@@ -1,8 +1,14 @@
 import Counter from "../../islands/Counter.tsx";
 import KebabCaseFileNameTest from "../../islands/kebab-case-counter-test.tsx";
 import Test from "../../islands/Test.tsx";
+import Props from "../../islands/Props.tsx";
 
 export default function Home() {
+  const u8 = {
+    single: new Uint8Array([1, 2, 3]),
+    array: [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5])],
+  };
+
   return (
     <div>
       <Counter id="counter1" start={3} />
@@ -10,6 +16,7 @@ export default function Home() {
       <KebabCaseFileNameTest id="kebab-case-file-counter" start={5} />
       <Test message="" />
       <Test message={`</script><script>alert('test')</script>`} />
+      <Props {...{ u8 }} />
     </div>
   );
 }

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -73,6 +73,16 @@ Deno.test({
       assertStringIncludes(srcString, imgFilePath);
     });
 
+    await t.step("Ensure an island revives non-JSON props", async () => {
+      let pElem = await page.waitForSelector(`#u8-single-bytelength`);
+      let value = await pElem?.evaluate((el) => el.textContent);
+      assert(value === "3");
+
+      pElem = await page.waitForSelector(`#u8-array-bytelength`);
+      value = await pElem?.evaluate((el) => el.textContent);
+      assert(value === "5");
+    });
+
     await browser.close();
 
     await lines.cancel();


### PR DESCRIPTION
Adds a shared module (`src/shared/prop_encoding.ts`, location up for debate) that contains 2 entry points to transform the properties for an island into a JSON compatible format and back. It is used in `src/server/render.ts` to convert to JSON serializable version, and in `src/runtime/main.ts` to convert back into the original state. The initial implementation supports encoding and decoding `Uint8Array` values (nested and in arrays). More types may be added.

**Details:**
Each value in the property object tree goes through a conversion step where the value may be transformed into a [enum type number, data string] tuple which is then packed into a single string value on the form `__FRSH_<enum type 00-FF><data>`. The enum type number is declared in the module as such:
```
enum EncodedType {
  UNKNOWN = 0,
  UINT8ARRAY = 1,
  MAX = 256,
}
```
The type is parsed as a single hex byte (as 255 different types is pretty generous). Since the runtime and server dependencies are bumped together, changing the schema on the server will also change what is served to the client, which mean breaking changes would be allowed, if this needs to be expanded in the future.

The PR includes an additional step where a CRC32 for the value is added to the state, and checked at decoding.