### PR TITLE
fix(www): a11y issue (low-contrast)

### DIFF
--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -148,7 +148,7 @@ function Intro() {
       <div class="md:flex items-center">
         <div class="flex-1 text-center md:text-left">
           <h2 class="py-2 text(5xl sm:5xl lg:5xl gray-900) sm:tracking-tight sm:leading-[1.1]! font-extrabold">
-            The <span class="text-green-500">next-gen</span> web framework.
+            The <span class="text-green-600">next-gen</span> web framework.
           </h2>
 
           <p class="mt-4 text-gray-600">


### PR DESCRIPTION
This PR fixes accessibility issue of fresh web site.

Lighthouse reports 'next-gen' text of the landing page doesn't have enough color contrast of background and foreground.

<img width="722" alt="スクリーンショット 2022-11-30 21 22 03" src="https://user-images.githubusercontent.com/613956/204796318-cdb71c60-17d0-4eb9-a800-9d8d6b8769eb.png">

This PR changes the color of it to darker green and improves the lighthouse a11y score. (The score is now 100 on my machine with this change.)

BEFORE
<img width="431" alt="スクリーンショット 2022-11-30 21 23 28" src="https://user-images.githubusercontent.com/613956/204796588-2f4241b8-3c47-4e5b-a4e0-a233a08ead6a.png">

AFTER
<img width="415" alt="スクリーンショット 2022-11-30 21 23 38" src="https://user-images.githubusercontent.com/613956/204796612-12c6d084-84ce-4af5-8b45-b1af2cc7e08c.png">
