### PR TITLE
Add RenderContext and vnode to PluginRenderContext

### DIFF
--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -174,7 +174,11 @@ export async function render<Data>(
   function render(): PluginRenderFunctionResult {
     const plugin = plugins.shift();
     if (plugin) {
-      const res = plugin.render!({ render });
+      const res = plugin.render!({
+          context: ctx,
+          render,
+          vnode,
+        });
       if (res === undefined) {
         throw new Error(
           `${plugin?.name}'s render hook did not return a PluginRenderResult object.`,

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from "preact";
+import { ComponentType, VNode } from "preact";
 import { ConnInfo, rutt, ServeInit } from "./deps.ts";
 import { InnerRenderFunction, RenderContext } from "./render.ts";
 
@@ -260,18 +260,20 @@ export interface Plugin {
    * The hook can return a `PluginRenderResult` object that can do things like
    * inject CSS into the page, or load additional JS files on the client.
    */
-  render?(ctx: PluginRenderContext): PluginRenderResult;
+  render?<V extends VNode<P>, P, T = unknown>(ctx: PluginRenderContext<V, P>): PluginRenderResult<T>;
 }
 
-export interface PluginRenderContext {
+export interface PluginRenderContext<V extends VNode<P>, P> {
   render: PluginRenderFunction;
+  vnode: V;
+  context: RenderContext;
 }
 
-export interface PluginRenderResult {
+export interface PluginRenderResult<T = unknown> {
   /** CSS styles to be injected into the page. */
   styles?: PluginRenderStyleTag[];
   /** JS scripts to ship to the client. */
-  scripts?: PluginRenderScripts[];
+  scripts?: PluginRenderScripts<T>[];
 }
 
 export interface PluginRenderStyleTag {
@@ -280,7 +282,7 @@ export interface PluginRenderStyleTag {
   id?: string;
 }
 
-export interface PluginRenderScripts {
+export interface PluginRenderScripts<T = unknown> {
   /** The "key" of the entrypoint (as specified in `Plugin.entrypoints`) for the
    * script that should be loaded. The script must be an ES module that exports
    * a default function.
@@ -291,7 +293,7 @@ export interface PluginRenderScripts {
   /** The state argument that is passed to the default export invocation of the
    * entrypoint's default export. The state must be JSON-serializable.
    */
-  state: unknown;
+  state: T;
 }
 
 export type PluginRenderFunction = () => PluginRenderFunctionResult;

--- a/tests/fixture_plugin/utils/js-inject-plugin.ts
+++ b/tests/fixture_plugin/utils/js-inject-plugin.ts
@@ -8,7 +8,12 @@ export default {
   render(ctx) {
     const res = ctx.render();
     if (res.requiresHydration) {
-      return { scripts: [{ entrypoint: "main", state: "JS injected!" }] };
+      return { 
+        scripts: [{ 
+          entrypoint: "main", 
+          state: "JS injected!" + " type:" + typeof(ctx.vnode.type) + " url:" + ctx.context.url 
+        }] 
+      };
     }
     return {};
   },

--- a/tests/plugin_test.ts
+++ b/tests/plugin_test.ts
@@ -38,7 +38,8 @@ Deno.test("/static page prerender", async () => {
 });
 
 Deno.test("/with-island prerender", async () => {
-  const resp = await router(new Request("https://fresh.deno.dev/with-island"));
+  const url = "https://fresh.deno.dev/with-island"
+  const resp = await router(new Request(url));
   assert(resp);
   assertEquals(resp.status, Status.OK);
   const body = await resp.text();
@@ -46,7 +47,7 @@ Deno.test("/with-island prerender", async () => {
     body,
     '<style id="abc">body { color: red; } h1 { color: blue; }</style>',
   );
-  assertStringIncludes(body, `>[[{}],["JS injected!"]]</script>`);
+  assertStringIncludes(body, `>[[{}],["JS injected! type:function url:${url}"]]</script>`);
   assertStringIncludes(body, `/plugin-js-inject-main.js"`);
 });
 
@@ -80,8 +81,8 @@ Deno.test({
 
     const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
     const page = await browser.newPage();
-
-    await page.goto("http://localhost:8000/with-island", {
+    const url = "http://localhost:8000/with-island"
+    await page.goto(url, {
       waitUntil: "networkidle2",
     });
 
@@ -91,7 +92,7 @@ Deno.test({
 
     await t.step("title was updated", async () => {
       const title = await page.title();
-      assertEquals(title, "JS injected!");
+      assertEquals(title, `JS injected! type:function url:${url}`);
     });
 
     await browser.close();


### PR DESCRIPTION
I am unsure if there is any reason not to expose the whole RenderContext to the pluginContext, but I think getting the vnode or at least the type and other context properties would be really helpful for plugin development.

For example for something like styled-components e.g. #927


