### PR TITLE
feat: allow custom entrypoints

### DIFF
--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -45,6 +45,7 @@ export class Bundler {
   #plugins: Plugin[];
   #cache: Map<string, Uint8Array> | Promise<void> | undefined = undefined;
   #dev: boolean;
+  #mainEntryPoint: string | undefined = undefined;
 
   constructor(
     islands: Island[],
@@ -52,19 +53,27 @@ export class Bundler {
     importMapURL: URL,
     jsxConfig: JSXConfig,
     dev: boolean,
+    mainEntryPoint: string | undefined,
   ) {
     this.#islands = islands;
     this.#plugins = plugins;
     this.#importMapURL = importMapURL;
     this.#jsxConfig = jsxConfig;
     this.#dev = dev;
+    this.#mainEntryPoint = mainEntryPoint;
+  }
+
+  getMainEntrypoint() {
+    if (this.#mainEntryPoint) return this.#mainEntryPoint;
+    if (this.#dev) {
+      return new URL("../../src/runtime/main_dev.ts", import.meta.url).href
+    }
+    return new URL("../../src/runtime/main.ts", import.meta.url).href;
   }
 
   async bundle() {
     const entryPoints: Record<string, string> = {
-      main: this.#dev
-        ? new URL("../../src/runtime/main_dev.ts", import.meta.url).href
-        : new URL("../../src/runtime/main.ts", import.meta.url).href,
+      main: this.getMainEntrypoint()
     };
 
     for (const island of this.#islands) {

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -76,6 +76,7 @@ export class ServerContext {
     plugins: Plugin[],
     importMapURL: URL,
     jsxConfig: JSXConfig,
+    mainEntryPoint: string | undefined,
   ) {
     this.#routes = routes;
     this.#islands = islands;
@@ -93,6 +94,7 @@ export class ServerContext {
       importMapURL,
       jsxConfig,
       this.#dev,
+      mainEntryPoint,
     );
   }
 
@@ -302,6 +304,7 @@ export class ServerContext {
       opts.plugins ?? [],
       importMapURL,
       jsxConfig,
+      opts.mainEntryPoint,
     );
   }
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -18,6 +18,7 @@ export interface FreshOptions {
   render?: RenderFunction;
   plugins?: Plugin[];
   staticDir?: string;
+  mainEntryPoint?: string;
 }
 
 export type RenderFunction = (


### PR DESCRIPTION
Hi,
I want to have ability to customize how revive works by passing optional, custom entrypoint.
For example... we could autoinject Providers on layout level to share client side state between islands... share fetch states or trigger side-effects.
I am aware that I can use browser memory to share data between islands, but I think it would be much cleaner and easier to manage if we could just customize the entrypoint.
If it will be accepted - I will be superhappy to write tests and documentation (+an example in showcase) for this.