### PR TITLE
fix: The "Made with Fresh" Badge broke

### DIFF
--- a/.github/workflows/www.yml
+++ b/.github/workflows/www.yml
@@ -30,3 +30,7 @@ jobs:
       - name: Type check website
         run: deno check main.ts dev.ts
         working-directory: www/
+
+      - name: Run tests
+        run: deno test -A
+        working-directory: www/

--- a/deno.json
+++ b/deno.json
@@ -9,5 +9,10 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "preact"
+  },
+  "test": {
+    "files": {
+      "exclude": ["www/"]
+    }
   }
 }

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -151,12 +151,12 @@ export class ServerContext {
         path.endsWith("/_middleware.ts") || path.endsWith("/_middleware.jsx") ||
         path.endsWith("/_middleware.js");
       if (!path.startsWith("/_") && !isMiddleware) {
-        const { default: component, config } = (module as RouteModule);
+        const { default: component, config } = module as RouteModule;
         let pattern = pathToPattern(baseRoute);
         if (config?.routeOverride) {
           pattern = String(config.routeOverride);
         }
-        let { handler } = (module as RouteModule);
+        let { handler } = module as RouteModule;
         handler ??= {};
         if (
           component &&
@@ -187,8 +187,8 @@ export class ServerContext {
         path === "/_404.tsx" || path === "/_404.ts" ||
         path === "/_404.jsx" || path === "/_404.js"
       ) {
-        const { default: component, config } = (module as UnknownPageModule);
-        let { handler } = (module as UnknownPageModule);
+        const { default: component, config } = module as UnknownPageModule;
+        let { handler } = module as UnknownPageModule;
         if (component && handler === undefined) {
           handler = (_req, { render }) => render();
         }
@@ -205,8 +205,8 @@ export class ServerContext {
         path === "/_500.tsx" || path === "/_500.ts" ||
         path === "/_500.jsx" || path === "/_500.js"
       ) {
-        const { default: component, config } = (module as ErrorPageModule);
-        let { handler } = (module as ErrorPageModule);
+        const { default: component, config } = module as ErrorPageModule;
+        let { handler } = module as ErrorPageModule;
         if (component && handler === undefined) {
           handler = (_req, { render }) => render();
         }

--- a/www/main_test.ts
+++ b/www/main_test.ts
@@ -4,7 +4,7 @@ import { delay } from "$std/async/delay.ts";
 
 Deno.test("CORS should not set on GET /fresh-badge.svg", {
   sanitizeResources: false,
-}, async (t) => {
+}, async () => {
   const serverProcess = Deno.run({
     cmd: ["deno", "run", "-A", "./main.ts"],
     stdin: "null",

--- a/www/main_test.ts
+++ b/www/main_test.ts
@@ -26,7 +26,6 @@ Deno.test("CORS should not set on GET /fresh-badge.svg", {
   if (!started) {
     throw new Error("Server didn't start up");
   }
-  await delay(100);
 
   const res = await fetch("http://localhost:8000/fresh-badge.svg");
   await res.body?.cancel();

--- a/www/main_test.ts
+++ b/www/main_test.ts
@@ -1,0 +1,39 @@
+import { assertEquals } from "$std/testing/asserts.ts";
+import { TextLineStream } from "$std/streams/delimiter.ts";
+import { delay } from "$std/async/delay.ts";
+
+Deno.test("CORS should not set on GET /fresh-badge.svg", {
+  sanitizeResources: false,
+}, async (t) => {
+  const serverProcess = Deno.run({
+    cmd: ["deno", "run", "-A", "./main.ts"],
+    stdin: "null",
+    stdout: "piped",
+    stderr: "inherit",
+  });
+  const decoder = new TextDecoderStream();
+  const lines = serverProcess.stdout.readable
+    .pipeThrough(decoder)
+    .pipeThrough(new TextLineStream());
+
+  let started = false;
+  for await (const line of lines) {
+    if (line.includes("Listening on http://")) {
+      started = true;
+      break;
+    }
+  }
+  if (!started) {
+    throw new Error("Server didn't start up");
+  }
+  await delay(100);
+
+  const res = await fetch("http://localhost:8000/fresh-badge.svg");
+  await res.body?.cancel();
+
+  assertEquals(res.headers.get("cross-origin-resource-policy"), null);
+
+  await lines.cancel();
+  serverProcess.kill("SIGTERM");
+  serverProcess.close();
+});

--- a/www/main_test.ts
+++ b/www/main_test.ts
@@ -1,6 +1,5 @@
 import { assertEquals } from "$std/testing/asserts.ts";
 import { TextLineStream } from "$std/streams/delimiter.ts";
-import { delay } from "$std/async/delay.ts";
 
 Deno.test("CORS should not set on GET /fresh-badge.svg", {
   sanitizeResources: false,

--- a/www/routes/_middleware.ts
+++ b/www/routes/_middleware.ts
@@ -76,15 +76,6 @@ export async function handler(
   try {
     const resp = await ctx.next();
     const headers = new Headers(resp.headers);
-    headers.set(
-      "Strict-Transport-Security",
-      "max-age=63072000; includeSubDomains; preload",
-    );
-    headers.set("X-Content-Type-Options", "nosniff");
-    headers.set("X-Frame-Options", "DENY");
-    headers.set("Cross-Origin-Resource-Policy", "same-origin");
-    headers.set("Cross-Origin-Opener-Policy", "same-origin");
-    headers.set("Cross-Origin-Embedder-Policy", "same-origin");
     res = new Response(resp.body, { status: resp.status, headers });
     return res;
   } catch (e) {


### PR DESCRIPTION
Close #969

I added a CORS header when I added the ga4 middleware, but this applied to the `static/` files as well, and it causes "Made with Fresh" badge broke.

It may be desirable to remove the CORS header from `static/` files only, but for the time being, I have revert the addition of headers including CORS.