### PR TITLE
prefix asset urls with a `X-Fresh-Base-Url` header if present.

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -459,6 +459,10 @@ export class ServerContext {
           }
 
           const preloads: string[] = [];
+          const base = (req.headers.get("X-Fresh-Base-Url") ?? "").replace(
+            /\/$/,
+            "",
+          );
           const resp = await internalRender({
             route,
             islands: this.#islands,
@@ -468,6 +472,7 @@ export class ServerContext {
             preloads,
             renderFn: this.#renderFn,
             url: new URL(req.url),
+            base,
             params,
             data,
             error,

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -15,7 +15,7 @@ import {
 import { HEAD_CONTEXT } from "../runtime/head.ts";
 import { CSP_CONTEXT, nonce, NONE, UNSAFE_INLINE } from "../runtime/csp.ts";
 import { ContentSecurityPolicy } from "../runtime/csp.ts";
-import { bundleAssetUrl } from "./constants.ts";
+import { bundleAssetUrl as bundleAssetUrlStatic } from "./constants.ts";
 import { assetHashingHook } from "../runtime/utils.ts";
 import { htmlEscapeJsonString } from "./htmlescape.ts";
 
@@ -27,6 +27,7 @@ export interface RenderOptions<Data> {
   imports: string[];
   preloads: string[];
   url: URL;
+  base: string;
   params: Record<string, string | string[]>;
   renderFn: RenderFunction;
   data?: Data;
@@ -118,6 +119,9 @@ export async function render<Data>(
   if (opts.error) {
     props.error = opts.error;
   }
+
+  const bundleAssetUrl = (path: string) =>
+    opts.base + bundleAssetUrlStatic(path);
 
   const csp: ContentSecurityPolicy | undefined = opts.route.csp
     ? defaultCsp()


### PR DESCRIPTION
## Motivation

See #697 #825 

In order to "mount" a Fresh website onto a path at another website, the subpath of that website needs to be prepended to all assets it serves.

For example, if I want to mount my fresh site at
`https://example.com/my-fresh`, then whenever Fresh loads the source of an island into the DOM, instead of using `/_frsh/.../island-my-island.js` as the `<script src>` of an island, it should use `/my-fresh/_frsh/.../island-my-island.js` or more fully: `https://example.com/my-fresh/_frsh/.../island-my-island.js`

## Approach

This reads a header `X-Fresh-Base-Url`, and if present, prepends it to any asset urls. This allows the mounting site to dynamically instruct Fresh to act as though it were living at the subpath. 

## Todos

- [ ] Arrive at optimal design accounting for various use-cases
- [ ] Tests
- [ ] Documentation