### PR TITLE
Remove twind in favor of plain tailwind extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
     "denoland.vscode-deno",
-    "sastan.twind-intellisense"
+    "bradlc.vscode-tailwindcss"
   ]
 }


### PR DESCRIPTION
As of 1.1 components invoke tailwind class names directly, the twind extension isn't needed.