### PR TITLE
fix: fresh vendor dependencies

### DIFF
--- a/plugins/twind.ts
+++ b/plugins/twind.ts
@@ -4,6 +4,9 @@ import { Plugin } from "../server.ts";
 import { Options, setup, STYLE_ELEMENT_ID } from "./twind/shared.ts";
 export type { Options };
 
+// Include it on vendor since it's being included on esbuild.
+const _vendor0 = () => import('./twind/main.ts')
+
 export default function twind(options: Options): Plugin {
   const sheet = virtualSheet();
   setup(options, sheet);

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -1,3 +1,4 @@
+import './vendor.ts'
 import { BuildOptions } from "https://deno.land/x/esbuild@v0.14.51/mod.js";
 import { BUILD_ID } from "./constants.ts";
 import { denoPlugin, esbuild, toFileUrl } from "./deps.ts";

--- a/src/server/vendor.ts
+++ b/src/server/vendor.ts
@@ -1,0 +1,14 @@
+/** 
+ * Hack to make vendoreing work with fresh.
+ * 
+ * The idea is to import missing modules so deno vendor add all necessary 
+ * modules to /vendor folder.
+ * */
+// This may be removed once this is fixed: https://github.com/denoland/deno/issues/16108
+const _vendor0 = () => import("preact/jsx-runtime");
+
+// These are the fresh's entrypoints not imported by anyone else: 
+// https://github.com/denoland/fresh/blob/41befe3b382354e35ef8bacb8f8905a186920a1f/src/server/bundle.ts#L65
+const _vendor1 = () => import("$fresh/src/runtime/main_dev.ts");
+const _vendor2 = () => import("$fresh/src/runtime/main.ts");
+


### PR DESCRIPTION
## What's the purpose of this PR?
This PR solves [issues](https://github.com/denoland/fresh/issues/596) related to running `deno vendor` on a fresh project.

## How does it work?
Vendoring in fresh is a little bit more difficult than in a "normal" deno project because it uses `esbuild` and, sometimes, dependency resolution is not accessible to deno's engine. To overcome this issue, I'm using a technique of explicitly configuring deno's engine to vendor dependencies by using the dynamic import tag. The upside of this approach is not actually importing the dependency but only configuring the vendoring engine to include this dependency. 

This PR fixes both fresh's and twind's plugin missing modules.

## How to test it?
To test it, clone this version, link to a newly created fresh project and run:
```
deno vendor main.ts dev.ts
deno run -A --no-remote main.ts
```

The server should be spawned without any issues.