### PR TITLE
Add padding to docs content

### DIFF
--- a/www/routes/docs/[...slug].tsx
+++ b/www/routes/docs/[...slug].tsx
@@ -153,7 +153,7 @@ function Content(props: { page: Page }) {
         {props.page.title}
       </h1>
       <div
-        class="mt-6 markdown-body"
+        class="mt-6 markdown-body p-2 rounded"
         dangerouslySetInnerHTML={{ __html: html }}
       />
       <ForwardBackButtons slug={props.page.slug} />


### PR DESCRIPTION
The docs content don't look good on desktop. Text is too close to the edge:

![Screenshot_20230220_204106](https://user-images.githubusercontent.com/10688496/220215944-b5ef2afc-f62d-470c-bd69-f92ccf9674fc.png)

This patch makes it a bit better:
![Screenshot_20230220_204200](https://user-images.githubusercontent.com/10688496/220216014-f697045a-5208-488f-ad38-23e6dde2c602.png)
