### PR TITLE
fix: revert "chore: bump dependencies and license year (#986)"

### DIFF
--- a/.vscode/import_map.json
+++ b/.vscode/import_map.json
@@ -14,6 +14,6 @@
     "@preact/signals": "https://esm.sh/*@preact/signals@1.0.3",
     "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.0.1",
 
-    "$std/": "https://deno.land/std@0.177.0/"
+    "$std/": "https://deno.land/std@0.150.0/"
   }
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2023 Luca Casonato
+Copyright (c) 2021 Luca Casonato
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/dev/deps.ts
+++ b/src/dev/deps.ts
@@ -6,10 +6,10 @@ export {
   join,
   resolve,
   toFileUrl,
-} from "https://deno.land/std@0.177.0/path/mod.ts";
-export { walk } from "https://deno.land/std@0.177.0/fs/walk.ts";
-export { parse } from "https://deno.land/std@0.177.0/flags/mod.ts";
-export { gte } from "https://deno.land/std@0.177.0/semver/mod.ts";
+} from "https://deno.land/std@0.150.0/path/mod.ts";
+export { walk } from "https://deno.land/std@0.150.0/fs/walk.ts";
+export { parse } from "https://deno.land/std@0.150.0/flags/mod.ts";
+export { gte } from "https://deno.land/std@0.150.0/semver/mod.ts";
 
 // ts-morph
-export { Node, Project } from "https://deno.land/x/ts_morph@17.0.1/mod.ts";
+export { Node, Project } from "https://deno.land/x/ts_morph@16.0.0/mod.ts";

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -20,7 +20,6 @@ export function asset(path: string) {
     ) {
       return path;
     }
-    // @ts-ignore trust me
     url.searchParams.set(ASSET_CACHE_BUST_KEY, __FRSH_BUILD_ID);
     return url.pathname + url.search + url.hash;
   } catch (err) {

--- a/src/runtime/utils_test.ts
+++ b/src/runtime/utils_test.ts
@@ -1,7 +1,6 @@
 import { assertEquals } from "../../tests/deps.ts";
 import { asset, assetSrcSet } from "./utils.ts";
 
-// @ts-ignore trust me
 globalThis.__FRSH_BUILD_ID = "ID123";
 
 Deno.test("asset", () => {

--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -1,4 +1,4 @@
-import { BuildOptions } from "https://deno.land/x/esbuild@v0.17.2/mod.js";
+import { BuildOptions } from "https://deno.land/x/esbuild@v0.14.51/mod.js";
 import { BUILD_ID } from "./constants.ts";
 import { denoPlugin, esbuild, toFileUrl } from "./deps.ts";
 import { Island, Plugin } from "./types.ts";
@@ -12,7 +12,7 @@ let esbuildInitialized: boolean | Promise<void> = false;
 async function ensureEsbuildInitialized() {
   if (esbuildInitialized === false) {
     if (Deno.run === undefined) {
-      const wasmURL = new URL("./esbuild_v0.17.2.wasm", import.meta.url).href;
+      const wasmURL = new URL("./esbuild_v0.14.51.wasm", import.meta.url).href;
       esbuildInitialized = fetch(wasmURL).then(async (r) => {
         const resp = new Response(r.body, {
           headers: { "Content-Type": "application/wasm" },

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -374,10 +374,8 @@ export class ServerContext {
    */
   #handlers(): [
     rutt.Routes<RouterState>,
-    {
-      otherHandler: rutt.Handler<RouterState>;
-      errorHandler: rutt.ErrorHandler<RouterState>;
-    },
+    rutt.Handler<RouterState>,
+    rutt.ErrorHandler<RouterState>,
   ] {
     const routes: rutt.Routes<RouterState> = {};
 
@@ -524,7 +522,7 @@ export class ServerContext {
       }
     }
 
-    const otherHandler: rutt.Handler<RouterState> = (
+    const unknownHandler: rutt.Handler<RouterState> = (
       req,
       ctx,
     ) =>
@@ -560,7 +558,7 @@ export class ServerContext {
       );
     };
 
-    return [routes, { otherHandler, errorHandler }];
+    return [routes, unknownHandler, errorHandler];
   }
 
   #staticFileHandler(

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -3,30 +3,29 @@ export {
   extname,
   fromFileUrl,
   toFileUrl,
-} from "https://deno.land/std@0.177.0/path/mod.ts";
-export { walk } from "https://deno.land/std@0.177.0/fs/walk.ts";
-export { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+} from "https://deno.land/std@0.150.0/path/mod.ts";
+export { walk } from "https://deno.land/std@0.150.0/fs/walk.ts";
+export { serve } from "https://deno.land/std@0.150.0/http/server.ts";
 export type {
   ConnInfo,
   Handler as RequestHandler,
   ServeInit,
-} from "https://deno.land/std@0.177.0/http/server.ts";
-export { Status } from "https://deno.land/std@0.177.0/http/http_status.ts";
+} from "https://deno.land/std@0.150.0/http/server.ts";
+export { Status } from "https://deno.land/std@0.150.0/http/http_status.ts";
 export {
   typeByExtension,
-} from "https://deno.land/std@0.177.0/media_types/mod.ts";
+} from "https://deno.land/std@0.150.0/media_types/mod.ts";
 
 // -- rutt --
-export * as rutt from "https://deno.land/x/rutt@0.1.0/mod.ts";
+export * as rutt from "https://deno.land/x/rutt@0.0.14/mod.ts";
 
 // -- esbuild --
-// @deno-types="https://deno.land/x/esbuild@v0.17.2/mod.d.ts"
-import * as esbuildWasm from "https://deno.land/x/esbuild@v0.17.2/wasm.js";
-import * as esbuildNative from "https://deno.land/x/esbuild@v0.17.2/mod.js";
+// @deno-types="https://deno.land/x/esbuild@v0.14.51/mod.d.ts"
+import * as esbuildWasm from "https://deno.land/x/esbuild@v0.14.51/wasm.js";
+import * as esbuildNative from "https://deno.land/x/esbuild@v0.14.51/mod.js";
 // @ts-ignore trust me
 const esbuild: typeof esbuildWasm = Deno.run === undefined
   ? esbuildWasm
   : esbuildNative;
 export { esbuild, esbuildWasm as esbuildTypes };
-// TODO(lino-levan): replace with tagged version
-export { denoPlugin } from "https://raw.githubusercontent.com/lucacasonato/esbuild_deno_loader/b4b3ffb43e9380865ad12ab4d1c64c0ae0ca96cd/mod.ts";
+export { denoPlugin } from "https://deno.land/x/esbuild_deno_loader@0.5.2/mod.ts";

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -87,7 +87,7 @@ export type Handler<T = any, State = Record<string, unknown>> = (
 
 // deno-lint-ignore no-explicit-any
 export type Handlers<T = any, State = Record<string, unknown>> = {
-  [K in typeof rutt.knownMethods[number]]?: Handler<T, State>;
+  [K in typeof rutt.METHODS[number]]?: Handler<T, State>;
 };
 
 export interface RouteModule {

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -8,10 +8,10 @@ export {
   assert,
   assertEquals,
   assertStringIncludes,
-} from "https://deno.land/std@0.177.0/testing/asserts.ts";
+} from "https://deno.land/std@0.150.0/testing/asserts.ts";
 export {
   TextLineStream,
-} from "https://deno.land/std@0.177.0/streams/text_line_stream.ts";
-export { delay } from "https://deno.land/std@0.177.0/async/delay.ts";
-export { retry } from "https://deno.land/std@0.177.0/async/retry.ts";
+} from "https://deno.land/std@0.150.0/streams/delimiter.ts";
+export { delay } from "https://deno.land/std@0.150.0/async/delay.ts";
+export { retry } from "https://deno.land/std@0.170.0/async/retry.ts";
 export { default as puppeteer } from "https://deno.land/x/puppeteer@16.2.0/mod.ts";

--- a/www/import_map.json
+++ b/www/import_map.json
@@ -11,7 +11,7 @@
     "@preact/signals": "https://esm.sh/*@preact/signals@1.0.3",
     "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.0.1",
 
-    "$std/": "https://deno.land/std@0.177.0/",
+    "$std/": "https://deno.land/std@0.150.0/",
     "$ga4": "https://raw.githubusercontent.com/denoland/ga4/main/mod.ts"
   }
 }

--- a/www/main_test.ts
+++ b/www/main_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "$std/testing/asserts.ts";
-import { TextLineStream } from "$std/streams/text_line_stream.ts";
+import { TextLineStream } from "$std/streams/delimiter.ts";
 
 Deno.test("CORS should not set on GET /fresh-badge.svg", {
   sanitizeResources: false,

--- a/www/utils/markdown.ts
+++ b/www/utils/markdown.ts
@@ -1,7 +1,7 @@
-export * as gfm from "https://deno.land/x/gfm@0.2.0/mod.ts";
-import "https://esm.sh/prismjs@1.29.0/components/prism-jsx.js?no-check";
-import "https://esm.sh/prismjs@1.29.0/components/prism-typescript.js?no-check";
-import "https://esm.sh/prismjs@1.29.0/components/prism-tsx.js?no-check";
-import "https://esm.sh/prismjs@1.29.0/components/prism-diff.js?no-check";
+export * as gfm from "https://deno.land/x/gfm@0.1.23/mod.ts";
+import "https://esm.sh/prismjs@1.27.0/components/prism-jsx.js?no-check";
+import "https://esm.sh/prismjs@1.27.0/components/prism-typescript.js?no-check";
+import "https://esm.sh/prismjs@1.27.0/components/prism-tsx.js?no-check";
+import "https://esm.sh/prismjs@1.27.0/components/prism-diff.js?no-check";
 
-export { extract as frontMatter } from "$std/encoding/front_matter/yaml.ts";
+export { extract as frontMatter } from "$std/encoding/front_matter.ts";

--- a/www/utils/screenshot.ts
+++ b/www/utils/screenshot.ts
@@ -1,6 +1,6 @@
 import puppeteer from "https://deno.land/x/puppeteer@16.2.0/mod.ts";
-import { Image } from "https://deno.land/x/imagescript@1.2.15/mod.ts";
-import { join } from "https://deno.land/std@0.177.0/path/mod.ts";
+import { Image } from "https://deno.land/x/imagescript@v1.2.14/mod.ts";
+import { join } from "https://deno.land/std@0.137.0/path/mod.ts";
 
 const url = Deno.args[0];
 const id = Deno.args[1];


### PR DESCRIPTION
This PR temporarily reverts commit ed669865003cbcd9b47dd2e4975c0e7b2a3151a9.

#986 caused the error like the below when wasm version of esbuild is used:

```
✘ [ERROR] Cannot read file "www/twind.config.ts": not implemented on js

    data:application/javascript,import hydrate from "file:///src/plugins/twind/main.ts";import options from "file:///src/www/twind.config.ts";export default function(state) { hydrate(options, state); }:1:76:
      1 │ ...rt options from "file:///src/www/twind.config.ts";export default...
        ╵                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

cc @lucacasonato 