### PR TITLE
chore: fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ jobs:
 
     strategy:
       matrix:
-        deno: ["v1.x", "canary"]
+        # TODO(kt3k): Change this back to ["v1.x", "canary"]
+        # when denoland/deno#18572 is released.
+        # Note: v1.32.2 and v1.32.3 are not compatible with Fresh.
+        deno: ["v1.32.1", "canary"]
         os: [macOS-latest, windows-latest, ubuntu-latest]
 
     steps:

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -555,7 +555,7 @@ Deno.test("experimental Deno.serve", {
     assert(body.startsWith("bar"));
     const etag = resp.headers.get("etag");
     assert(etag);
-    // Enable this assertion when new Deno.serve is released.
+    // TODO(kt3k): Enable this assertion when new Deno.serve is released.
     // https://github.com/denoland/deno/pull/18568
     // assert(etag.startsWith("W/"), "etag should be weak");
     assertEquals(resp.headers.get("content-type"), "text/plain");

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -555,7 +555,9 @@ Deno.test("experimental Deno.serve", {
     assert(body.startsWith("bar"));
     const etag = resp.headers.get("etag");
     assert(etag);
-    assert(!etag.startsWith("W/"), "etag should be weak");
+    // Enable this assertion when new Deno.serve is released.
+    // https://github.com/denoland/deno/pull/18568
+    // assert(etag.startsWith("W/"), "etag should be weak");
     assertEquals(resp.headers.get("content-type"), "text/plain");
   });
 


### PR DESCRIPTION
This PR fixes CI by specifying the last compatible Deno version in ci.yml, and also skipping the assertion about weak etag. (`Deno.serve` has been replaced by a wrapper of `Deno.serveHttp` and it now compresses the responses automatically and therefore etag becomes weak etag.)