### PR TITLE
chore: update ci deno version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        # TODO(kt3k): Change this back to ["v1.x", "canary"]
-        # when denoland/deno#18572 is released.
-        # Note: v1.32.2 and v1.32.3 are not compatible with Fresh.
-        deno: ["v1.32.1", "canary"]
+        deno: ["v1.x", "canary"]
         os: [macOS-latest, windows-latest, ubuntu-latest]
 
     steps:


### PR DESCRIPTION
The issue should be fixed now with the latest stable Deno.