### PR TITLE
refactor: include router directly in fresh

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -446,12 +446,14 @@ export class ServerContext {
       const { localUrl, path, size, contentType, etag } of this.#staticFiles
     ) {
       const route = sanitizePathToRegex(path);
-      routes[route]["GET"] = this.#staticFileHandler(
-        localUrl,
-        size,
-        contentType,
-        etag,
-      );
+      routes[route] = {
+        "GET": this.#staticFileHandler(
+          localUrl,
+          size,
+          contentType,
+          etag,
+        ),
+      }
     }
 
     const genRender = <Data = undefined>(

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -453,7 +453,7 @@ export class ServerContext {
           contentType,
           etag,
         ),
-      }
+      };
     }
 
     const genRender = <Data = undefined>(

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -16,9 +16,6 @@ export {
   typeByExtension,
 } from "https://deno.land/std@0.178.0/media_types/mod.ts";
 
-// -- rutt --
-export * as rutt from "https://deno.land/x/rutt@0.1.0/mod.ts";
-
 // -- esbuild --
 // @deno-types="https://deno.land/x/esbuild@v0.17.11/mod.d.ts"
 import * as esbuildWasm from "https://deno.land/x/esbuild@v0.17.11/wasm.js";

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -109,7 +109,7 @@ export function router<T = unknown>(
     for (const [method, handler] of Object.entries(methods)) {
       if (method === "default") {
         entry.default = handler;
-      } else {
+      } else if (knownMethods.includes(method as KnownMethod)) {
         entry.methods[method as KnownMethod] = handler;
       }
     }
@@ -153,3 +153,5 @@ export function router<T = unknown>(
     }
   };
 }
+
+Deno.serve(router({ "/": {fvdbf: () => new Response("foo")}}))

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -153,5 +153,3 @@ export function router<T = unknown>(
     }
   };
 }
-
-Deno.serve(router({ "/": {fvdbf: () => new Response("foo")}}))

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -1,0 +1,155 @@
+import type { ConnInfo } from "./deps.ts";
+
+type HandlerContext<T = unknown> = T & ConnInfo;
+
+export type Handler<T = unknown> = (
+  req: Request,
+  ctx: HandlerContext<T>,
+) => Response | Promise<Response>;
+
+export type ErrorHandler<T = unknown> = (
+  req: Request,
+  ctx: HandlerContext<T>,
+  err: unknown,
+) => Response | Promise<Response>;
+
+type UnknownMethodHandler<T = unknown> = (
+  req: Request,
+  ctx: HandlerContext<T>,
+  knownMethods: KnownMethod[],
+) => Response | Promise<Response>;
+
+export type MatchHandler<T = unknown> = (
+  req: Request,
+  ctx: HandlerContext<T>,
+  match: Record<string, string>,
+) => Response | Promise<Response>;
+
+// deno-lint-ignore ban-types
+export interface Routes<T = {}> {
+  [key: string]: Record<KnownMethod | "default", MatchHandler<T>>;
+}
+
+// deno-lint-ignore ban-types
+export type InternalRoute<T = {}> = {
+  pattern: URLPattern;
+  methods: { [K in KnownMethod]?: MatchHandler<T> };
+  default?: MatchHandler<T>;
+};
+
+export interface RouterOptions<T> {
+  otherHandler?: Handler<T>;
+  errorHandler?: ErrorHandler<T>;
+  unknownMethodHandler?: UnknownMethodHandler<T>;
+}
+
+export type KnownMethod = typeof knownMethods[number];
+
+export const knownMethods = [
+  "GET",
+  "HEAD",
+  "POST",
+  "PUT",
+  "DELETE",
+  "OPTIONS",
+  "PATCH",
+] as const;
+
+export function defaultOtherHandler(_req: Request): Response {
+  return new Response(null, {
+    status: 404,
+  });
+}
+
+export function defaultErrorHandler(
+  _req: Request,
+  _ctx: HandlerContext,
+  err: unknown,
+): Response {
+  console.error(err);
+
+  return new Response(null, {
+    status: 500,
+  });
+}
+
+export function defaultUnknownMethodHandler(
+  _req: Request,
+  _ctx: HandlerContext,
+  knownMethods: KnownMethod[],
+): Response {
+  return new Response(null, {
+    status: 405,
+    headers: {
+      Accept: knownMethods.join(", "),
+    },
+  });
+}
+
+export function router<T = unknown>(
+  routes: Routes<T>,
+  { otherHandler, errorHandler, unknownMethodHandler }: RouterOptions<T> = {
+    otherHandler: defaultOtherHandler,
+    errorHandler: defaultErrorHandler,
+    unknownMethodHandler: defaultUnknownMethodHandler,
+  },
+): Handler<T> {
+  otherHandler ??= defaultOtherHandler;
+  errorHandler ??= defaultErrorHandler;
+  unknownMethodHandler ??= defaultUnknownMethodHandler;
+
+  const internalRoutes: InternalRoute<T>[] = [];
+  for (const [path, methods] of Object.entries(routes)) {
+    const entry: InternalRoute<T> = {
+      pattern: new URLPattern({ pathname: path }),
+      methods: {},
+      default: undefined,
+    };
+
+    for (const [method, handler] of Object.entries(methods)) {
+      if (method === "default") {
+        entry.default = handler;
+      } else {
+        entry.methods[method as KnownMethod] = handler;
+      }
+    }
+
+    internalRoutes.push(entry);
+  }
+
+  return async (req, ctx) => {
+    try {
+      for (const route of internalRoutes) {
+        const res = route.pattern.exec(req.url);
+
+        if (res !== null) {
+          const groups = res?.pathname.groups ?? {};
+
+          for (const key in groups) {
+            groups[key] = decodeURIComponent(groups[key]);
+          }
+
+          for (const [method, handler] of Object.entries(route.methods)) {
+            if (req.method === method) {
+              return await handler(req, ctx, groups);
+            }
+          }
+
+          if (route.default) {
+            return await route.default(req, ctx, groups);
+          } else {
+            return await unknownMethodHandler!(
+              req,
+              ctx,
+              Object.keys(route.methods) as KnownMethod[],
+            );
+          }
+        }
+      }
+
+      return await otherHandler!(req, ctx);
+    } catch (err) {
+      return errorHandler!(req, ctx, err);
+    }
+  };
+}

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -27,7 +27,7 @@ export type MatchHandler<T = unknown> = (
 
 // deno-lint-ignore ban-types
 export interface Routes<T = {}> {
-  [key: string]: Record<KnownMethod | "default", MatchHandler<T>>;
+  [key: string]: { [K in KnownMethod | "default"]?: MatchHandler<T> };
 }
 
 // deno-lint-ignore ban-types

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,5 +1,6 @@
 import { ComponentType } from "preact";
-import { ConnInfo, rutt, ServeInit } from "./deps.ts";
+import { ConnInfo, ServeInit } from "./deps.ts";
+import * as router from "./router.ts";
 import { InnerRenderFunction, RenderContext } from "./render.ts";
 
 // --- APPLICATION CONFIGURATION ---
@@ -87,7 +88,7 @@ export type Handler<T = any, State = Record<string, unknown>> = (
 
 // deno-lint-ignore no-explicit-any
 export type Handlers<T = any, State = Record<string, unknown>> = {
-  [K in typeof rutt.knownMethods[number]]?: Handler<T, State>;
+  [K in router.KnownMethod]?: Handler<T, State>;
 };
 
 export interface RouteModule {

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -125,6 +125,7 @@ Deno.test("/api/get_only - NOTAMETHOD", async () => {
       method: "NOTAMETHOD",
     }),
   );
+  console.log(resp, await resp.text());
   assert(resp);
   assertEquals(resp.status, Status.MethodNotAllowed);
 });

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -125,7 +125,6 @@ Deno.test("/api/get_only - NOTAMETHOD", async () => {
       method: "NOTAMETHOD",
     }),
   );
-  console.log(resp, await resp.text());
   assert(resp);
   assertEquals(resp.status, Status.MethodNotAllowed);
 });


### PR DESCRIPTION
This PR changes from depending on https://deno.land/x/rutt to instead include a reduced & simplified version of it.