### PR TITLE
Pass page props to application wrapper

### DIFF
--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -129,6 +129,7 @@ export async function render<Data>(
     children: h(HEAD_CONTEXT.Provider, {
       value: headComponents,
       children: h(opts.app.default, {
+        page: props,
         Component() {
           return h(opts.route.component! as ComponentType<unknown>, props);
         },

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -111,6 +111,7 @@ export interface Route<Data = any> {
 // --- APP ---
 
 export interface AppProps {
+  page: Record<string, unknown>;
   Component: ComponentType<Record<never, never>>;
 }
 


### PR DESCRIPTION
I wanted to add a footer whose content changes based on the current route, but the application wrapper is only passed the component. This PR adds the `PageProps` under a new `page` property. I’m a bit confused about whether this is the right approach, though.

`render` currently sets `props` per the docs and [declares it as `Record<string, unknown>` to pass safely to `h`](https://github.com/denoland/fresh/blob/9d13f6ff26181ea6ebcb096043c983f4d485cd9b/src/server/render.ts#L112-133). Passing those `props` alongside `Component` works and passes type checking, but I’m not sure whether there’s a reason for the `unknown` or not, so I can’t tell whether I’ve broken something. (And I can’t run the tests because it keeps failing on account of the port being in use. No idea why. I’m on Windows, and I can see it succeeds in CI.)