### PR TITLE
chore: Carousel Component is island

### DIFF
--- a/www/islands/ComponentGallery.tsx
+++ b/www/islands/ComponentGallery.tsx
@@ -112,7 +112,7 @@ export default function ComponentGallery(props: ComponentGalleryProps) {
         <Features />
       </Section>
 
-      <Section title="Carousel" source={props.sources.Carousel}>
+      <Section title="Carousel" island={true} source={props.sources.Carousel}>
         <Carousel />
       </Section>
     </>


### PR DESCRIPTION
Carousel(#1096 ) is good.
But carousel is island. 
Carousel don't work in components because carousel use JavaScript.

So, need to add 'island' tag for developers.


