### PR TITLE
fix(www): docs title align center

### DIFF
--- a/www/components/DocsTitle.tsx
+++ b/www/components/DocsTitle.tsx
@@ -3,7 +3,7 @@ export default function DocsTitle(props: { title: string }) {
     <>
       <a
         href="/"
-        class="text(2xl gray-900) block flex items-center"
+        class="text(2xl gray-900) flex items-center"
       >
         <svg
           preserveAspectRatio="xMinYMin"


### PR DESCRIPTION
I removed dead class, "block".
The "block" class conflicted with "flex".
That had shifted a docs title to up and down.

Please compare following URL and check the title.
https://fresh.deno.dev/docs/introduction
https://fresh.deno.dev/components