### PR TITLE
Allow passing additional ESBuild Targets

### DIFF
--- a/src/server/bundle.ts
+++ b/src/server/bundle.ts
@@ -46,6 +46,7 @@ export class Bundler {
   #plugins: Plugin[];
   #cache: Map<string, Uint8Array> | Promise<void> | undefined = undefined;
   #dev: boolean;
+  #additionalTargets: string[];
 
   constructor(
     islands: Island[],
@@ -53,7 +54,9 @@ export class Bundler {
     importMapURL: URL,
     jsxConfig: JSXConfig,
     dev: boolean,
+    additionalTargets?: string[],
   ) {
+    this.#additionalTargets = additionalTargets ?? [];
     this.#islands = islands;
     this.#plugins = plugins;
     this.#importMapURL = importMapURL;
@@ -101,7 +104,7 @@ export class Bundler {
       plugins: [denoPlugin({ importMapURL: this.#importMapURL })],
       sourcemap: this.#dev ? "linked" : false,
       splitting: true,
-      target: ["chrome99", "firefox99", "safari15"],
+      target: ["chrome99", "firefox99", "safari15", ...this.#additionalTargets],
       treeShaking: true,
       write: false,
       jsx: JSX_RUNTIME_MODE[this.#jsxConfig.jsx],

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -77,6 +77,7 @@ export class ServerContext {
     plugins: Plugin[],
     importMapURL: URL,
     jsxConfig: JSXConfig,
+    additionalESBuildTargets: string[] = [],
   ) {
     this.#routes = routes;
     this.#islands = islands;
@@ -94,6 +95,7 @@ export class ServerContext {
       importMapURL,
       jsxConfig,
       this.#dev,
+      additionalESBuildTargets,
     );
   }
 
@@ -303,6 +305,7 @@ export class ServerContext {
       opts.plugins ?? [],
       importMapURL,
       jsxConfig,
+      opts.additionalESBuildTargets,
     );
   }
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -19,6 +19,7 @@ export interface FreshOptions {
   render?: RenderFunction;
   plugins?: Plugin[];
   staticDir?: string;
+  additionalESBuildTargets?: string[];
 }
 
 export type RenderFunction = (


### PR DESCRIPTION
# Description

This pull request introduces a crucial enhancement to the open source repository by enabling the capability to pass additional esbuild targets. This feature proves to be especially valuable for supporting older browsers, such as Safari 11, which lacks support for top-level await.

The inclusion of this enhancement offers developers greater flexibility and compatibility when using fresh. By allowing the specification of additional esbuild targets, it becomes possible to transpile the code to a format that is compatible with Safari 11 and other older browsers that lack support for top-level await.

To achieve this, the following modifications have been made:

1. Added a new configuration option, additionalESBuildTargets, to the existing FreshOptions configuration. This option accepts an array of target environments that need to be supported.

2. Pass the targets to the bundler

By making these changes, developers can now easily extend the support of the repository to encompass browsers like Safari 11 without sacrificing the utilization of top-level await in their codebase.

This pull request aims to empowers developers to build applications that cater to a wider range of browser environments.

Thank you for considering this pull request. I'm excited to hear your feedback and collaborate on further enhancing the repository's functionality.