### PR TITLE
chore(ci): enable Deno v1.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        # FIXME: temporarially disabled 1.x until https://github.com/denoland/deno/commit/64e072e499d36ca824db297a493667415ed67cdf is released
-        deno: ["canary"]
+        deno: ["v1.x", "canary"]
         os: [macOS-latest, windows-latest, ubuntu-latest]
 
     steps:


### PR DESCRIPTION
https://github.com/denoland/deno/commit/64e072e499d36ca824db297a493667415ed67cdf has been merged and is now part of the latest version of Deno.