### PR TITLE
chore(ci): disable fail-fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     timeout-minutes: 10
 
     strategy:
+      fail-fast: false
       matrix:
         # FIXME: temporarially disabled 1.x until https://github.com/denoland/deno/commit/64e072e499d36ca824db297a493667415ed67cdf is released
         deno: ["canary"]


### PR DESCRIPTION
This change allows CI to continue on an OS even if CI on another OS fails.