### PR TITLE
refactor: disable lock

### DIFF
--- a/examples/counter/deno.json
+++ b/examples/counter/deno.json
@@ -1,4 +1,5 @@
 {
+  "lock": false,
   "tasks": {
     "start": "deno run -A --watch=static/,routes/ dev.ts"
   },

--- a/init.ts
+++ b/init.ts
@@ -303,6 +303,7 @@ try {
 }
 
 const config = {
+  lock: false,
   tasks: {
     start: "deno run -A --watch=static/,routes/ dev.ts",
   },

--- a/tests/fixture/deno.json
+++ b/tests/fixture/deno.json
@@ -1,4 +1,5 @@
 {
+  "lock": false,
   "importMap": "./import_map.json",
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/tests/fixture_jsx_pragma/deno.json
+++ b/tests/fixture_jsx_pragma/deno.json
@@ -1,3 +1,4 @@
 {
+  "lock": false,
   "importMap": "./import-map.json"
 }

--- a/tests/fixture_plugin/deno.json
+++ b/tests/fixture_plugin/deno.json
@@ -1,4 +1,5 @@
 {
+  "lock": false,
   "importMap": "./import_map.json",
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/tests/fixture_twind_hydrate/deno.json
+++ b/tests/fixture_twind_hydrate/deno.json
@@ -1,4 +1,5 @@
 {
+  "lock": false,
   "tasks": {
     "start": "deno run -A --watch=static/,routes/ dev.ts"
   },

--- a/www/deno.json
+++ b/www/deno.json
@@ -1,4 +1,5 @@
 {
+  "lock": false,
   "tasks": {
     "start": "deno run -A --watch=static/,routes/ dev.ts"
   },


### PR DESCRIPTION
This change disables the lock file for tests and the initialisation script. The noise produced in tests by generated lock files is now gone. This was also done because of Fresh's use of [esm.sh](https://esm.sh/) and [this](https://github.com/denoland/deno-gfm/issues/47#issuecomment-1460872019).