### PR TITLE
fix: better HEAD handling with less special casing

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -624,10 +624,9 @@ export class ServerContext {
       if (key !== null && BUILD_ID !== key) {
         url.searchParams.delete(ASSET_CACHE_BUST_KEY);
         const location = url.pathname + url.search;
-        return new Response("", {
+        return new Response(null, {
           status: 307,
           headers: {
-            "content-type": "text/plain",
             location,
           },
         });

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -160,10 +160,24 @@ export class ServerContext {
         let { handler } = module as RouteModule;
         handler ??= {};
         if (
-          component &&
-          typeof handler === "object" && handler.GET === undefined
+          component && typeof handler === "object" && handler.GET === undefined
         ) {
           handler.GET = (_req, { render }) => render();
+        }
+        if (
+          typeof handler === "object" && handler.GET !== undefined &&
+          handler.HEAD === undefined
+        ) {
+          const GET = handler.GET;
+          handler.HEAD = async (req, ctx) => {
+            const resp = await GET(req, ctx);
+            resp.body?.cancel();
+            return new Response(null, {
+              headers: resp.headers,
+              status: resp.status,
+              statusText: resp.statusText,
+            });
+          };
         }
         const route: Route = {
           pattern,
@@ -327,17 +341,7 @@ export class ServerContext {
         });
       }
 
-      const res = await withMiddlewares(req, connInfo, inner);
-      // Internally, HEAD is handled in the same way as GET if not overridden.
-      if (req.method === "HEAD") {
-        res.body?.cancel();
-        return new Response(null, {
-          headers: res.headers,
-          status: res.status,
-          statusText: res.statusText,
-        });
-      }
-      return res;
+      return await withMiddlewares(req, connInfo, inner);
     };
   }
 
@@ -458,7 +462,12 @@ export class ServerContext {
     ) {
       const route = sanitizePathToRegex(path);
       staticRoutes[route] = {
-        "GET": this.#staticFileHandler(
+        "HEAD": this.#staticFileHeadHandler(
+          size,
+          contentType,
+          etag,
+        ),
+        "GET": this.#staticFileGetHandler(
           localUrl,
           size,
           contentType,
@@ -604,7 +613,44 @@ export class ServerContext {
     return { internalRoutes, staticRoutes, routes, otherHandler, errorHandler };
   }
 
-  #staticFileHandler(
+  #staticFileHeadHandler(
+    size: number,
+    contentType: string,
+    etag: string,
+  ): router.MatchHandler {
+    return (req: Request) => {
+      const url = new URL(req.url);
+      const key = url.searchParams.get(ASSET_CACHE_BUST_KEY);
+      if (key !== null && BUILD_ID !== key) {
+        url.searchParams.delete(ASSET_CACHE_BUST_KEY);
+        const location = url.pathname + url.search;
+        return new Response("", {
+          status: 307,
+          headers: {
+            "content-type": "text/plain",
+            location,
+          },
+        });
+      }
+      const headers = new Headers({
+        "content-type": contentType,
+        etag,
+        vary: "If-None-Match",
+      });
+      if (key !== null) {
+        headers.set("Cache-Control", "public, max-age=31536000, immutable");
+      }
+      const ifNoneMatch = req.headers.get("if-none-match");
+      if (ifNoneMatch === etag || ifNoneMatch === "W/" + etag) {
+        return new Response(null, { status: 304, headers });
+      } else {
+        headers.set("content-length", String(size));
+        return new Response(null, { status: 200, headers });
+      }
+    };
+  }
+
+  #staticFileGetHandler(
     localUrl: URL,
     size: number,
     contentType: string,

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -66,7 +66,7 @@ Deno.test("/[name] page prerender", async () => {
   assertStringIncludes(body, "<div>Hello bar</div>");
 });
 
-Deno.test("/intercept - HEAD", async () => {
+Deno.test("/api/head_override - HEAD", async () => {
   const req = new Request("https://fresh.deno.dev/api/head_override", {
     method: "HEAD",
   });
@@ -80,7 +80,7 @@ Deno.test("/intercept - HEAD", async () => {
   );
 });
 
-Deno.test("/intercept - HEAD fallback", async () => {
+Deno.test("/api/get_only - HEAD fallback", async () => {
   const req = new Request("https://fresh.deno.dev/api/get_only", {
     method: "HEAD",
   });


### PR DESCRIPTION
We now add a default HEAD handler to the server, rather than special
casing HEAD requests elsewhere. Static files now get their own optimized
HEAD handler that does not read the file contents.
