### PR TITLE
fix: `__FRSH_BUILD_ID is not defined`

### DIFF
--- a/src/runtime/build_id.ts
+++ b/src/runtime/build_id.ts
@@ -1,0 +1,2 @@
+// Note: in the client build this file is replaced with a file exporting a static string
+export { BUILD_ID } from "../server/build_id.ts";

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,4 +1,5 @@
 import { VNode } from "preact";
+import { BUILD_ID } from "./build_id.ts";
 
 export const INTERNAL_PREFIX = "/_frsh";
 export const ASSET_CACHE_BUST_KEY = "__frsh_c";
@@ -20,7 +21,7 @@ export function asset(path: string) {
     ) {
       return path;
     }
-    url.searchParams.set(ASSET_CACHE_BUST_KEY, __FRSH_BUILD_ID);
+    url.searchParams.set(ASSET_CACHE_BUST_KEY, BUILD_ID);
     return url.pathname + url.search + url.hash;
   } catch (err) {
     console.warn(

--- a/src/runtime/utils_test.ts
+++ b/src/runtime/utils_test.ts
@@ -1,13 +1,12 @@
 import { assertEquals } from "../../tests/deps.ts";
 import { asset, assetSrcSet } from "./utils.ts";
-
-globalThis.__FRSH_BUILD_ID = "ID123";
+import { BUILD_ID } from "./build_id.ts";
 
 Deno.test("asset", () => {
-  assertEquals(asset("/test.png"), "/test.png?__frsh_c=ID123");
-  assertEquals(asset("/test?f=1"), "/test?f=1&__frsh_c=ID123");
-  assertEquals(asset("/test#foo"), "/test?__frsh_c=ID123#foo");
-  assertEquals(asset("/test?f=1#foo"), "/test?f=1&__frsh_c=ID123#foo");
+  assertEquals(asset("/test.png"), `/test.png?__frsh_c=${BUILD_ID}`);
+  assertEquals(asset("/test?f=1"), `/test?f=1&__frsh_c=${BUILD_ID}`);
+  assertEquals(asset("/test#foo"), `/test?__frsh_c=${BUILD_ID}#foo`);
+  assertEquals(asset("/test?f=1#foo"), `/test?f=1&__frsh_c=${BUILD_ID}#foo`);
 
   assertEquals(asset("./test.png"), "./test.png");
   assertEquals(asset("//example.com/logo.png"), "//example.com/logo.png");
@@ -19,42 +18,42 @@ Deno.test("asset", () => {
 });
 
 Deno.test("assetSrcSet", () => {
-  assertEquals(assetSrcSet("/img.png"), "/img.png?__frsh_c=ID123");
+  assertEquals(assetSrcSet("/img.png"), `/img.png?__frsh_c=${BUILD_ID}`);
   assertEquals(
     assetSrcSet("/img.png, /img.png 2x"),
-    "/img.png?__frsh_c=ID123, /img.png?__frsh_c=ID123 2x",
+    `/img.png?__frsh_c=${BUILD_ID}, /img.png?__frsh_c=${BUILD_ID} 2x`,
   );
-  assertEquals(assetSrcSet("/img.png 1x"), "/img.png?__frsh_c=ID123 1x");
+  assertEquals(assetSrcSet("/img.png 1x"), `/img.png?__frsh_c=${BUILD_ID} 1x`);
   assertEquals(
     assetSrcSet("/img.png 1x, /img.png 2x"),
-    "/img.png?__frsh_c=ID123 1x, /img.png?__frsh_c=ID123 2x",
+    `/img.png?__frsh_c=${BUILD_ID} 1x, /img.png?__frsh_c=${BUILD_ID} 2x`,
   );
   assertEquals(
     assetSrcSet("/img.png 1.5x, /img.png 3x"),
-    "/img.png?__frsh_c=ID123 1.5x, /img.png?__frsh_c=ID123 3x",
+    `/img.png?__frsh_c=${BUILD_ID} 1.5x, /img.png?__frsh_c=${BUILD_ID} 3x`,
   );
 
   //test with queries
   assertEquals(
     assetSrcSet("/img.png?w=140, /img.png?w=200 2x"),
-    "/img.png?w=140&__frsh_c=ID123, /img.png?w=200&__frsh_c=ID123 2x",
+    `/img.png?w=140&__frsh_c=${BUILD_ID}, /img.png?w=200&__frsh_c=${BUILD_ID} 2x`,
   );
 
   // test with extra spaces
   assertEquals(
     assetSrcSet("/img-s.png 300w,  /img-l.png  600w , /img-xl.png  900w"),
-    "/img-s.png?__frsh_c=ID123 300w,  /img-l.png?__frsh_c=ID123  600w , /img-xl.png?__frsh_c=ID123  900w",
+    `/img-s.png?__frsh_c=${BUILD_ID} 300w,  /img-l.png?__frsh_c=${BUILD_ID}  600w , /img-xl.png?__frsh_c=${BUILD_ID}  900w`,
   );
 
   // test with ( syntax
   assertEquals(
     assetSrcSet("/img.png ( 140,0w)"),
-    "/img.png ( 140,0w)",
+    `/img.png ( 140,0w)`,
   );
 
   // test with invalid parts
   assertEquals(
     assetSrcSet("/img.png,, /img-s.png 300w"),
-    "/img.png,, /img-s.png 300w",
+    `/img.png,, /img-s.png 300w`,
   );
 });

--- a/src/runtime/utils_test.ts
+++ b/src/runtime/utils_test.ts
@@ -48,12 +48,12 @@ Deno.test("assetSrcSet", () => {
   // test with ( syntax
   assertEquals(
     assetSrcSet("/img.png ( 140,0w)"),
-    `/img.png ( 140,0w)`,
+    "/img.png ( 140,0w)",
   );
 
   // test with invalid parts
   assertEquals(
     assetSrcSet("/img.png,, /img-s.png 300w"),
-    `/img.png,, /img-s.png 300w`,
+    "/img.png,, /img-s.png 300w",
   );
 });

--- a/src/server/build_id.ts
+++ b/src/server/build_id.ts
@@ -1,0 +1,10 @@
+import { toHashString } from "./deps.ts";
+
+const deploymentId = Deno.env.get("DENO_DEPLOYMENT_ID") ||
+  crypto.randomUUID();
+const buildIdHash = await crypto.subtle.digest(
+  "SHA-1",
+  new TextEncoder().encode(deploymentId),
+);
+
+export const BUILD_ID = toHashString(buildIdHash, "hex");

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -1,30 +1,11 @@
 import { INTERNAL_PREFIX } from "../runtime/utils.ts";
-import { toHashString } from "./deps.ts";
+import { BUILD_ID } from "./build_id.ts";
 
 export const REFRESH_JS_URL = `${INTERNAL_PREFIX}/refresh.js`;
 export const ALIVE_URL = `${INTERNAL_PREFIX}/alive`;
 export const JS_PREFIX = `/js`;
 export const DEBUG = !Deno.env.get("DENO_DEPLOYMENT_ID");
 
-const deploymentId = Deno.env.get("DENO_DEPLOYMENT_ID") ||
-  crypto.randomUUID();
-const buildIdHash = await crypto.subtle.digest(
-  "SHA-1",
-  new TextEncoder().encode(deploymentId),
-);
-export const BUILD_ID = toHashString(buildIdHash, "hex");
-
 export function bundleAssetUrl(path: string) {
   return `${INTERNAL_PREFIX}${JS_PREFIX}/${BUILD_ID}${path}`;
-}
-
-globalThis.__FRSH_BUILD_ID = BUILD_ID;
-
-declare global {
-  interface Crypto {
-    randomUUID(): string;
-  }
-
-  // deno-lint-ignore no-var
-  var __FRSH_BUILD_ID: string;
 }

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -12,7 +12,8 @@ import { h } from "preact";
 import * as router from "./router.ts";
 import { Manifest } from "./mod.ts";
 import { Bundler, JSXConfig } from "./bundle.ts";
-import { ALIVE_URL, BUILD_ID, JS_PREFIX, REFRESH_JS_URL } from "./constants.ts";
+import { ALIVE_URL, JS_PREFIX, REFRESH_JS_URL } from "./constants.ts";
+import { BUILD_ID } from "./build_id.ts";
 import DefaultErrorHandler from "./default_error_page.ts";
 import {
   AppModule,

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -16,7 +16,7 @@ export {
   typeByExtension,
 } from "https://deno.land/std@0.189.0/media_types/mod.ts";
 export { toHashString } from "https://deno.land/std@0.189.0/crypto/to_hash_string.ts";
-export { escape } from "https://deno.land/std@0.189.0/regexp/mod.ts";
+export { escape } from "https://deno.land/std@0.189.0/regexp/escape.ts";
 
 // -- esbuild --
 // @deno-types="https://deno.land/x/esbuild@v0.17.11/mod.d.ts"

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -16,6 +16,7 @@ export {
   typeByExtension,
 } from "https://deno.land/std@0.189.0/media_types/mod.ts";
 export { toHashString } from "https://deno.land/std@0.189.0/crypto/to_hash_string.ts";
+export { escape } from "https://deno.land/std@0.189.0/regexp/mod.ts";
 
 // -- esbuild --
 // @deno-types="https://deno.land/x/esbuild@v0.17.11/mod.d.ts"

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -9,6 +9,7 @@ import {
 } from "./deps.ts";
 import manifest from "./fixture/fresh.gen.ts";
 import options from "./fixture/options.ts";
+import { BUILD_ID } from "../src/server/build_id.ts";
 
 const ctx = await ServerContext.fromManifest(manifest, options);
 const handler = ctx.handler();
@@ -345,7 +346,7 @@ Deno.test("static file - by 'hashed' path", async () => {
   const body = await resp.text();
   const imgFilePath = body.match(/img id="img-with-hashing" src="(.*?)"/)?.[1];
   assert(imgFilePath);
-  assert(imgFilePath.includes(`?__frsh_c=${globalThis.__FRSH_BUILD_ID}`));
+  assert(imgFilePath.includes(`?__frsh_c=${BUILD_ID}`));
 
   // check the static file is served corectly under its cacheable route
   const resp2 = await router(
@@ -373,20 +374,20 @@ Deno.test("static file - by 'hashed' path", async () => {
   )?.[1];
   assert(imgFilePathWithNoCache);
   assert(
-    !imgFilePathWithNoCache.includes(globalThis.__FRSH_BUILD_ID),
+    !imgFilePathWithNoCache.includes(BUILD_ID),
     "img-without-hashing",
   );
 
   // ensure asset hook is applied on img within an island
   const imgInIsland = body.match(/img id="img-in-island" src="(.*?)"/)?.[1];
   assert(imgInIsland);
-  assert(imgInIsland.includes(globalThis.__FRSH_BUILD_ID), "img-in-island");
+  assert(imgInIsland.includes(BUILD_ID), "img-in-island");
 
   // verify that the asset hook is applied to the srcset
   const imgInIslandSrcSet = body.match(/srcset="(.*?)"/)?.[1];
   assert(imgInIslandSrcSet);
   assert(
-    imgInIslandSrcSet.includes(globalThis.__FRSH_BUILD_ID),
+    imgInIslandSrcSet.includes(BUILD_ID),
     "img-in-island-srcset",
   );
 
@@ -394,7 +395,7 @@ Deno.test("static file - by 'hashed' path", async () => {
   const imgMissing = body.match(/img id="img-missing" src="(.*?)"/)?.[1];
   assert(imgMissing);
   assert(
-    !imgMissing.includes(globalThis.__FRSH_BUILD_ID),
+    !imgMissing.includes(BUILD_ID),
     "Applying hash on unknown asset",
   );
 });

--- a/www/routes/docs/[...slug].tsx
+++ b/www/routes/docs/[...slug].tsx
@@ -1,4 +1,4 @@
-import { Head } from "$fresh/runtime.ts";
+import { asset, Head } from "$fresh/runtime.ts";
 import { Handlers, PageProps } from "$fresh/server.ts";
 import { frontMatter, gfm } from "../../utils/markdown.ts";
 
@@ -61,7 +61,7 @@ export default function DocsPage(props: PageProps<Data>) {
     <>
       <Head>
         <title>{props.data.page?.title ?? "Not Found"} | fresh docs</title>
-        <link rel="stylesheet" href={`/gfm.css?build=${__FRSH_BUILD_ID}`} />
+        <link rel="stylesheet" href={asset("/gfm.css")} />
         {description && <meta name="description" content={description} />}
       </Head>
       <div class="flex flex-col min-h-screen">


### PR DESCRIPTION
This could happen if the runtime/utils.ts coe was loaded
prior to server/constants.ts, because they had some shared state on
`globalThis`.

I have mitigated this by not relying on global state anymore.

Fixes #1191