### PR TITLE
docs: add new "Examples" section

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,9 @@
+---
+description: |
+  In this chapter of the Fresh documentation, you can find examples of features that you may like in your Fresh project.
+---
+
+In this chapter of the Fresh documentation, you can find examples of features
+that you may like in your Fresh project. If there's a specific example you'd
+like to see here, please let us know in
+[a GitHub issue](https://github.com/denoland/fresh/issues/new).

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -5,5 +5,5 @@ description: |
 
 In this chapter of the Fresh documentation, you can find examples of features
 that you may like in your Fresh project. If there's a specific example you'd
-like to see here, please let us know in
-[a GitHub issue](https://github.com/denoland/fresh/issues/new).
+like to see here, please open
+[a GitHub discussion](https://github.com/denoland/fresh/issues/new).

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -6,4 +6,4 @@ description: |
 In this chapter of the Fresh documentation, you can find examples of features
 that you may like in your Fresh project. If there's a specific example you'd
 like to see here, please open
-[a GitHub discussion](https://github.com/denoland/fresh/issues/new).
+[a GitHub discussion](https://github.com/denoland/fresh/discussions/new?category=ideas).

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -36,5 +36,8 @@
   },
   "integrations": {
     "title": "Integrations"
+  },
+  "examples": {
+    "title": "Examples"
   }
 }

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -36,8 +36,5 @@
   },
   "integrations": {
     "title": "Integrations"
-  },
-  "examples": {
-    "title": "Examples"
   }
 }


### PR DESCRIPTION
It's currently empty, but this sets up future Fresh examples.

Closes #1204
Moves towards #1211