### PR TITLE
fix(www): modifying-the-head-element link on Examples page

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -8,4 +8,4 @@ that you may like in your Fresh project. If there's a specific example you'd
 like to see here, please open
 [a GitHub discussion](https://github.com/denoland/fresh/discussions/new?category=ideas).
 
-- [Modifying the `<head>` Element](modifying-the-head-element)
+- [Modifying the `<head>` Element](examples/modifying-the-head-element)

--- a/www/data/docs.ts
+++ b/www/data/docs.ts
@@ -32,7 +32,9 @@ export const CATEGORIES: TableOfContentsCategory[] = [];
 for (const parent in (RAW_TOC as unknown as RawTableOfContents)) {
   const rawEntry = (RAW_TOC as unknown as RawTableOfContents)[parent];
   const href = `/docs/${parent}`;
-  const file = `docs/${parent}/index.md`;
+  const file = parent === "examples"
+    ? `docs/examples.md`
+    : `docs/${parent}/index.md`;
   const entry = {
     slug: parent,
     title: rawEntry.title,


### PR DESCRIPTION
[Modifying the `<head>` Element](https://fresh.deno.dev/docs/modifying-the-head-element) link on Examples doc page is incorrect

![image](https://github.com/denoland/fresh/assets/58794979/3f01a91a-611b-44dc-846d-e1002a04e96c)

