### PR TITLE
fix: preload all the necessary files

### DIFF
--- a/src/build/esbuild.ts
+++ b/src/build/esbuild.ts
@@ -110,8 +110,6 @@ export class EsbuildBuilder implements Builder {
         dependencies.set(path, [...seen]);
       }
 
-      console.error(dependencies);
-
       return new EsbuildSnapshot(files, dependencies);
     } finally {
       stopEsbuild();

--- a/src/build/esbuild.ts
+++ b/src/build/esbuild.ts
@@ -90,24 +90,11 @@ export class EsbuildBuilder implements Builder {
 
       const metaOutputs = new Map(Object.entries(bundle.metafile.outputs));
 
-      // deno-lint-ignore no-inner-declarations
-      function walk(path: string, seen: Set<string>) {
-        if (seen.has(path)) return;
-        seen.add(path);
-        const entry = metaOutputs.get(path);
-        if (entry === undefined) return;
-        for (const dep of entry.imports) {
-          if (dep.kind === "import-statement") {
-            walk(dep.path, seen);
-          }
-        }
-      }
-
       for (const [path, entry] of metaOutputs.entries()) {
-        if (entry.entryPoint === undefined) continue;
-        const seen = new Set<string>();
-        walk(path, seen);
-        dependencies.set(path, [...seen]);
+        const imports = entry.imports
+          .filter(({ kind }) => kind === "import-statement")
+          .map(({ path }) => path);
+        dependencies.set(path, imports);
       }
 
       return new EsbuildSnapshot(files, dependencies);

--- a/src/build/esbuild.ts
+++ b/src/build/esbuild.ts
@@ -110,6 +110,8 @@ export class EsbuildBuilder implements Builder {
         dependencies.set(path, [...seen]);
       }
 
+      console.error(dependencies);
+
       return new EsbuildSnapshot(files, dependencies);
     } finally {
       stopEsbuild();

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -551,11 +551,6 @@ export class ServerContext {
             imports,
             dependenciesFn: (path) => {
               const snapshot = this.#maybeBuildSnapshot();
-              console.error(
-                "dependenciesFn",
-                path,
-                snapshot?.dependencies(path),
-              );
               return snapshot?.dependencies(path) ?? [];
             },
             renderFn: this.#renderFn,

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -551,6 +551,11 @@ export class ServerContext {
             imports,
             dependenciesFn: (path) => {
               const snapshot = this.#maybeBuildSnapshot();
+              console.error(
+                "dependenciesFn",
+                path,
+                snapshot?.dependencies(path),
+              );
               return snapshot?.dependencies(path) ?? [];
             },
             renderFn: this.#renderFn,

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -218,7 +218,7 @@ export async function render<Data>(
         nonce(randomNonce),
       ];
     }
-    const url = bundleAssetUrl(path);
+    const url = bundleAssetUrl(`/${path}`);
     imports.push([url, randomNonce]);
     preloadSet.add(url);
     for (const depPath of opts.dependenciesFn(path)) {
@@ -264,11 +264,11 @@ export async function render<Data>(
       `<script id="__FRSH_STATE" type="application/json">${escapedState}</script>`;
 
     if (res.requiresDeserializer) {
-      const url = addImport("/deserializer.js");
+      const url = addImport("deserializer.js");
       script += `import { deserialize } from "${url}";`;
     }
     if (res.hasSignals) {
-      const url = addImport("/signals.js");
+      const url = addImport("signals.js");
       script += `import { signal } from "${url}";`;
     }
     script += `const ST = document.getElementById("__FRSH_STATE").textContent;`;
@@ -287,7 +287,7 @@ export async function render<Data>(
   // Then it imports all plugin scripts and executes them (with their respective
   // state).
   for (const [pluginName, entrypoint, i] of pluginScripts) {
-    const url = addImport(`/plugin-${pluginName}-${entrypoint}.js`);
+    const url = addImport(`plugin-${pluginName}-${entrypoint}.js`);
     script += `import p${i} from "${url}";p${i}(STATE[1][${i}]);`;
   }
 
@@ -295,13 +295,13 @@ export async function render<Data>(
   // reviver from the "main" script.
   if (ENCOUNTERED_ISLANDS.size > 0) {
     // Load the main.js script
-    const url = addImport("/main.js");
+    const url = addImport("main.js");
     script += `import { revive } from "${url}";`;
 
     // Prepare the inline script that loads and revives the islands
     let islandRegistry = "";
     for (const island of ENCOUNTERED_ISLANDS) {
-      const url = addImport(`/island-${island.id}.js`);
+      const url = addImport(`island-${island.id}.js`);
       script += `import ${island.name} from "${url}";`;
       islandRegistry += `${island.id}:${island.name},`;
     }

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -752,7 +752,7 @@ Deno.test("preloading javascript files", {
     throw new Error("Server didn't start up");
   }
 
-  await delay(2000); // wait running esbuild
+  await delay(10000); // wait running esbuild
 
   const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
   const page = await browser.newPage();

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -752,17 +752,16 @@ Deno.test("preloading javascript files", {
     throw new Error("Server didn't start up");
   }
 
-  await delay(20000); // wait running esbuild
-
   const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
   const page = await browser.newPage();
 
   try {
+    // request js file to start esbuild execution
     await page.goto("http://localhost:8000", {
       waitUntil: "networkidle2",
     });
 
-    await delay(20000); // wait running esbuild
+    await delay(5000); // wait running esbuild
 
     await page.goto("http://localhost:8000", {
       waitUntil: "networkidle2",
@@ -772,8 +771,6 @@ Deno.test("preloading javascript files", {
       'link[rel="modulepreload"]',
       (elements) => elements.map((element) => element.getAttribute("href")),
     );
-
-    console.log(preloads);
 
     assert(
       preloads.some((url) => url.match(/\/_frsh\/js\/.*\/main\.js/)),

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -724,3 +724,55 @@ Deno.test("jsx pragma works", {
   await lines.cancel();
   serverProcess.kill("SIGTERM");
 });
+
+Deno.test("preloading javascript files", {
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async () => {
+  // Preparation
+  const serverProcess = new Deno.Command(Deno.execPath(), {
+    args: ["run", "-A", "./tests/fixture/main.ts"],
+    stdout: "piped",
+    stderr: "inherit",
+  }).spawn();
+
+  const decoder = new TextDecoderStream();
+  const lines = serverProcess.stdout
+    .pipeThrough(decoder)
+    .pipeThrough(new TextLineStream());
+
+  let started = false;
+  for await (const line of lines) {
+    if (line.includes("Listening on http://")) {
+      started = true;
+      break;
+    }
+  }
+  if (!started) {
+    throw new Error("Server didn't start up");
+  }
+
+  await delay(2000); // wait running esbuild
+
+  const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
+  const page = await browser.newPage();
+
+  try {
+    await page.goto("http://localhost:8000", {
+      waitUntil: "networkidle2",
+    });
+
+    const preloads: string[] = await page.$$eval(
+      'link[rel="modulepreload"]',
+      (elements) => elements.map((element) => element.getAttribute("href")),
+    );
+    assert(preloads.some((url) => url.match(/\/_frsh\/js\/.*\/main\.js/)));
+    assert(preloads.some((url) => url.match(/\/_frsh\/js\/.*\/island-.*\.js/)));
+    assert(preloads.some((url) => url.match(/\/_frsh\/js\/.*\/chunk-.*\.js/)));
+  } finally {
+    await browser.close();
+
+    await lines.cancel();
+    serverProcess.kill("SIGTERM");
+  }
+});

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -766,9 +766,21 @@ Deno.test("preloading javascript files", {
       'link[rel="modulepreload"]',
       (elements) => elements.map((element) => element.getAttribute("href")),
     );
-    assert(preloads.some((url) => url.match(/\/_frsh\/js\/.*\/main\.js/)));
-    assert(preloads.some((url) => url.match(/\/_frsh\/js\/.*\/island-.*\.js/)));
-    assert(preloads.some((url) => url.match(/\/_frsh\/js\/.*\/chunk-.*\.js/)));
+
+    console.log(preloads);
+
+    assert(
+      preloads.some((url) => url.match(/\/_frsh\/js\/.*\/main\.js/)),
+      "preloads does not include main.js",
+    );
+    assert(
+      preloads.some((url) => url.match(/\/_frsh\/js\/.*\/island-.*\.js/)),
+      "preloads does not include island-*.js",
+    );
+    assert(
+      preloads.some((url) => url.match(/\/_frsh\/js\/.*\/chunk-.*\.js/)),
+      "preloads does not include chunk-*.js",
+    );
   } finally {
     await browser.close();
 

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -762,6 +762,12 @@ Deno.test("preloading javascript files", {
       waitUntil: "networkidle2",
     });
 
+    await delay(20000); // wait running esbuild
+
+    await page.goto("http://localhost:8000", {
+      waitUntil: "networkidle2",
+    });
+
     const preloads: string[] = await page.$$eval(
       'link[rel="modulepreload"]',
       (elements) => elements.map((element) => element.getAttribute("href")),

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -752,7 +752,7 @@ Deno.test("preloading javascript files", {
     throw new Error("Server didn't start up");
   }
 
-  await delay(10000); // wait running esbuild
+  await delay(20000); // wait running esbuild
 
   const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
   const page = await browser.newPage();


### PR DESCRIPTION
close #1241

According to `console.log(dependencies)`, we should use filenames without slashes to get the dependencies.

![image](https://github.com/denoland/fresh/assets/40050810/b8743ad3-49fc-4d35-b9ac-688a39ead863)

---

Also, this includes fixes related to https://github.com/denoland/fresh/pull/1231#discussion_r1215491755.