### PR TITLE
fix: remove top level <script> imports

### DIFF
--- a/src/server/render_test.ts
+++ b/src/server/render_test.ts
@@ -6,7 +6,7 @@ Deno.test("check lang", () => {
   const body = template({
     bodyHtml: "",
     headComponents: [],
-    imports: [],
+    moduleScripts: [],
     preloads: [],
     lang,
   });


### PR DESCRIPTION
Instead, rely only on modulepreload for script preloading.

Fixes #1177