### PR TITLE
feat: Support JSX island children

### DIFF
--- a/demo/fresh.gen.ts
+++ b/demo/fresh.gen.ts
@@ -4,6 +4,7 @@
 
 import * as $0 from "./routes/index.tsx";
 import * as $$0 from "./islands/Counter.tsx";
+import * as $$1 from "./islands/Passthrough.tsx";
 
 const manifest = {
   routes: {
@@ -11,6 +12,7 @@ const manifest = {
   },
   islands: {
     "./islands/Counter.tsx": $$0,
+    "./islands/Passthrough.tsx": $$1,
   },
   baseUrl: import.meta.url,
 };

--- a/demo/islands/Passthrough.tsx
+++ b/demo/islands/Passthrough.tsx
@@ -1,0 +1,9 @@
+import { type ComponentChildren } from "preact";
+
+interface PassThroughProps {
+  children: ComponentChildren;
+}
+
+export default function PassThrough({ children }: PassThroughProps) {
+  return <div>children: {children}</div>;
+}

--- a/demo/routes/index.tsx
+++ b/demo/routes/index.tsx
@@ -1,5 +1,6 @@
 import { useSignal } from "@preact/signals";
 import Counter from "../islands/Counter.tsx";
+import PassThrough from "../islands/Passthrough.tsx";
 
 export default function Home() {
   const count = useSignal(3);
@@ -12,6 +13,9 @@ export default function Home() {
       <Counter count={count} />
       <Counter count={count} />
       <Counter count={count} />
+      <PassThrough>
+        <h1 key="abc">asd test</h1>
+      </PassThrough>
     </div>
   );
 }

--- a/src/runtime/deserializer.ts
+++ b/src/runtime/deserializer.ts
@@ -1,6 +1,8 @@
 // Run `deno run -A npm:esbuild --minify src/runtime/deserializer.ts` to minify
 // this file. It is embedded into src/server/deserializer_code.ts.
 
+import { Fragment, h } from "preact";
+
 export const KEY = "_f";
 
 interface Signal<T> {
@@ -36,6 +38,10 @@ export function deserialize(
         const val = v.v;
         val[KEY] = v.k;
         return val;
+      }
+      if (v[KEY] === "pv") {
+        const type = v.type === "_F" ? Fragment : v.type;
+        return h(type, v.props);
       }
       throw new Error(`Unknown key: ${v[KEY]}`);
     }

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -17,31 +17,35 @@ import * as $11 from "./routes/failure.ts";
 import * as $12 from "./routes/index.tsx";
 import * as $13 from "./routes/intercept.tsx";
 import * as $14 from "./routes/intercept_args.tsx";
-import * as $15 from "./routes/islands/index.tsx";
-import * as $16 from "./routes/islands/returning_null.tsx";
-import * as $17 from "./routes/islands/root_fragment.tsx";
-import * as $18 from "./routes/islands/root_fragment_conditional_first.tsx";
-import * as $19 from "./routes/layeredMdw/_middleware.ts";
-import * as $20 from "./routes/layeredMdw/layer2-no-mw/without_mw.ts";
-import * as $21 from "./routes/layeredMdw/layer2/_middleware.ts";
-import * as $22 from "./routes/layeredMdw/layer2/abc.ts";
-import * as $23 from "./routes/layeredMdw/layer2/index.ts";
-import * as $24 from "./routes/layeredMdw/layer2/layer3/[id].ts";
-import * as $25 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
-import * as $26 from "./routes/middleware_root.ts";
-import * as $27 from "./routes/not_found.ts";
-import * as $28 from "./routes/params.tsx";
-import * as $29 from "./routes/props/[id].tsx";
-import * as $30 from "./routes/static.tsx";
-import * as $31 from "./routes/status_overwrite.tsx";
-import * as $32 from "./routes/wildcard.tsx";
+import * as $15 from "./routes/islands/component-children-throw.tsx";
+import * as $16 from "./routes/islands/dom_children_fragments.tsx";
+import * as $17 from "./routes/islands/dom_only_children.tsx";
+import * as $18 from "./routes/islands/index.tsx";
+import * as $19 from "./routes/islands/returning_null.tsx";
+import * as $20 from "./routes/islands/root_fragment.tsx";
+import * as $21 from "./routes/islands/root_fragment_conditional_first.tsx";
+import * as $22 from "./routes/layeredMdw/_middleware.ts";
+import * as $23 from "./routes/layeredMdw/layer2-no-mw/without_mw.ts";
+import * as $24 from "./routes/layeredMdw/layer2/_middleware.ts";
+import * as $25 from "./routes/layeredMdw/layer2/abc.ts";
+import * as $26 from "./routes/layeredMdw/layer2/index.ts";
+import * as $27 from "./routes/layeredMdw/layer2/layer3/[id].ts";
+import * as $28 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
+import * as $29 from "./routes/middleware_root.ts";
+import * as $30 from "./routes/not_found.ts";
+import * as $31 from "./routes/params.tsx";
+import * as $32 from "./routes/props/[id].tsx";
+import * as $33 from "./routes/static.tsx";
+import * as $34 from "./routes/status_overwrite.tsx";
+import * as $35 from "./routes/wildcard.tsx";
 import * as $$0 from "./islands/Counter.tsx";
-import * as $$1 from "./islands/ReturningNull.tsx";
-import * as $$2 from "./islands/RootFragment.tsx";
-import * as $$3 from "./islands/RootFragmentWithConditionalFirst.tsx";
-import * as $$4 from "./islands/Test.tsx";
-import * as $$5 from "./islands/folder/Counter.tsx";
-import * as $$6 from "./islands/kebab-case-counter-test.tsx";
+import * as $$1 from "./islands/PassThrough.tsx";
+import * as $$2 from "./islands/ReturningNull.tsx";
+import * as $$3 from "./islands/RootFragment.tsx";
+import * as $$4 from "./islands/RootFragmentWithConditionalFirst.tsx";
+import * as $$5 from "./islands/Test.tsx";
+import * as $$6 from "./islands/folder/Counter.tsx";
+import * as $$7 from "./islands/kebab-case-counter-test.tsx";
 
 const manifest = {
   routes: {
@@ -60,33 +64,37 @@ const manifest = {
     "./routes/index.tsx": $12,
     "./routes/intercept.tsx": $13,
     "./routes/intercept_args.tsx": $14,
-    "./routes/islands/index.tsx": $15,
-    "./routes/islands/returning_null.tsx": $16,
-    "./routes/islands/root_fragment.tsx": $17,
-    "./routes/islands/root_fragment_conditional_first.tsx": $18,
-    "./routes/layeredMdw/_middleware.ts": $19,
-    "./routes/layeredMdw/layer2-no-mw/without_mw.ts": $20,
-    "./routes/layeredMdw/layer2/_middleware.ts": $21,
-    "./routes/layeredMdw/layer2/abc.ts": $22,
-    "./routes/layeredMdw/layer2/index.ts": $23,
-    "./routes/layeredMdw/layer2/layer3/[id].ts": $24,
-    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $25,
-    "./routes/middleware_root.ts": $26,
-    "./routes/not_found.ts": $27,
-    "./routes/params.tsx": $28,
-    "./routes/props/[id].tsx": $29,
-    "./routes/static.tsx": $30,
-    "./routes/status_overwrite.tsx": $31,
-    "./routes/wildcard.tsx": $32,
+    "./routes/islands/component-children-throw.tsx": $15,
+    "./routes/islands/dom_children_fragments.tsx": $16,
+    "./routes/islands/dom_only_children.tsx": $17,
+    "./routes/islands/index.tsx": $18,
+    "./routes/islands/returning_null.tsx": $19,
+    "./routes/islands/root_fragment.tsx": $20,
+    "./routes/islands/root_fragment_conditional_first.tsx": $21,
+    "./routes/layeredMdw/_middleware.ts": $22,
+    "./routes/layeredMdw/layer2-no-mw/without_mw.ts": $23,
+    "./routes/layeredMdw/layer2/_middleware.ts": $24,
+    "./routes/layeredMdw/layer2/abc.ts": $25,
+    "./routes/layeredMdw/layer2/index.ts": $26,
+    "./routes/layeredMdw/layer2/layer3/[id].ts": $27,
+    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $28,
+    "./routes/middleware_root.ts": $29,
+    "./routes/not_found.ts": $30,
+    "./routes/params.tsx": $31,
+    "./routes/props/[id].tsx": $32,
+    "./routes/static.tsx": $33,
+    "./routes/status_overwrite.tsx": $34,
+    "./routes/wildcard.tsx": $35,
   },
   islands: {
     "./islands/Counter.tsx": $$0,
-    "./islands/ReturningNull.tsx": $$1,
-    "./islands/RootFragment.tsx": $$2,
-    "./islands/RootFragmentWithConditionalFirst.tsx": $$3,
-    "./islands/Test.tsx": $$4,
-    "./islands/folder/Counter.tsx": $$5,
-    "./islands/kebab-case-counter-test.tsx": $$6,
+    "./islands/PassThrough.tsx": $$1,
+    "./islands/ReturningNull.tsx": $$2,
+    "./islands/RootFragment.tsx": $$3,
+    "./islands/RootFragmentWithConditionalFirst.tsx": $$4,
+    "./islands/Test.tsx": $$5,
+    "./islands/folder/Counter.tsx": $$6,
+    "./islands/kebab-case-counter-test.tsx": $$7,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/fixture/islands/PassThrough.tsx
+++ b/tests/fixture/islands/PassThrough.tsx
@@ -1,0 +1,9 @@
+import { ComponentChildren } from "preact";
+
+export interface PassThroughProps {
+  children: ComponentChildren;
+}
+
+export default function PassThrough({ children }: PassThroughProps) {
+  return <div>children: {children}</div>;
+}

--- a/tests/fixture/routes/islands/component-children-throw.tsx
+++ b/tests/fixture/routes/islands/component-children-throw.tsx
@@ -1,0 +1,16 @@
+import { ComponentChildren } from "preact";
+import PassThrough from "../../islands/PassThrough.tsx";
+
+function Foo({ children }: { children: ComponentChildren }) {
+  return <div>{children}</div>;
+}
+
+export default function Home() {
+  return (
+    <div>
+      <PassThrough>
+        <Foo>should throw</Foo>
+      </PassThrough>
+    </div>
+  );
+}

--- a/tests/fixture/routes/islands/dom_children_fragments.tsx
+++ b/tests/fixture/routes/islands/dom_children_fragments.tsx
@@ -1,0 +1,16 @@
+import PassThrough from "../../islands/PassThrough.tsx";
+
+export default function Home() {
+  return (
+    <div>
+      <PassThrough>
+        <>
+          <h1 class="it-works">it works</h1>
+          <>
+            <h2 key="foo">even with keyed</h2>
+          </>
+        </>
+      </PassThrough>
+    </div>
+  );
+}

--- a/tests/fixture/routes/islands/dom_only_children.tsx
+++ b/tests/fixture/routes/islands/dom_only_children.tsx
@@ -1,0 +1,12 @@
+import PassThrough from "../../islands/PassThrough.tsx";
+
+export default function Home() {
+  return (
+    <div>
+      <PassThrough>
+        <h1 class="it-works">it works</h1>
+        <h2 key="foo">even with keyed</h2>
+      </PassThrough>
+    </div>
+  );
+}

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -222,3 +222,37 @@ Deno.test({
   sanitizeOps: false,
   sanitizeResources: false,
 });
+
+Deno.test({
+  name: "island receives DOM JSX children",
+
+  async fn(_t) {
+    await withPage(async (page) => {
+      await page.goto("http://localhost:8000/islands/dom_only_children", {
+        waitUntil: "networkidle2",
+      });
+
+      await page.waitForSelector("h1.it-works");
+    });
+  },
+
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "island receives DOM JSX children with Fragments",
+
+  async fn(_t) {
+    await withPage(async (page) => {
+      await page.goto("http://localhost:8000/islands/dom_children_fragments", {
+        waitUntil: "networkidle2",
+      });
+
+      await page.waitForSelector("h1.it-works");
+    });
+  },
+
+  sanitizeOps: false,
+  sanitizeResources: false,
+});


### PR DESCRIPTION
This PR adds support for JSX children being passed to islands. It's limited to non-components though as serialising functions would rely on eval'ing the code in the browser which is not cool from a security perspective.

- `<></>` works
- `<div />` works
- `foo` works
- `<Foo />` doesn't work, cannot serialise function

Note that this is a first draft of how this feature could work as I need to get more familiar with fresh itself. The final implementation might change substantially.

Fixes #750

TODO:
- [ ] Might make sense to drop `Fragments` and only support DOM nodes. Benefit would be that we could skip serializing these and reconstruct the vnodes from the DOM itself. I kinda want to explore that.
- [ ] Add more tests