### PR TITLE
chore(tests): use to spin up server

### DIFF
--- a/tests/islands_wasm_test.ts
+++ b/tests/islands_wasm_test.ts
@@ -1,30 +1,14 @@
-import { assert, delay, puppeteer, TextLineStream } from "./deps.ts";
+import { assert, delay, puppeteer } from "./deps.ts";
+import { startFreshServer } from "./test_utils.ts";
 
 Deno.test({
   name: "wasm island tests",
   ignore: Deno.build.os === "windows",
   async fn(t) {
     // Preparation
-    const serverProcess = new Deno.Command(Deno.execPath(), {
+    const { lines, serverProcess } = await startFreshServer({
       args: ["run", "-A", "./tests/fixture/main_wasm.ts"],
-      stdout: "piped",
-    }).spawn();
-
-    const decoder = new TextDecoderStream();
-    const lines = serverProcess.stdout
-      .pipeThrough(decoder)
-      .pipeThrough(new TextLineStream());
-
-    let started = false;
-    for await (const line of lines) {
-      if (line.includes("Listening on http://")) {
-        started = true;
-        break;
-      }
-    }
-    if (!started) {
-      throw new Error("Server didn't start up");
-    }
+    });
 
     await delay(100);
 

--- a/www/main_test.ts
+++ b/www/main_test.ts
@@ -1,32 +1,13 @@
 import { assertEquals } from "$std/testing/asserts.ts";
-import { TextLineStream } from "$std/streams/text_line_stream.ts";
 import { delay } from "$std/async/delay.ts";
+import { startFreshServer } from "../tests/test_utils.ts";
 
 Deno.test("CORS should not set on GET /fresh-badge.svg", {
   sanitizeResources: false,
 }, async () => {
-  const serverProcess = new Deno.Command(Deno.execPath(), {
+  const { serverProcess, lines } = await startFreshServer({
     args: ["run", "-A", "./main.ts"],
-    stdin: "null",
-    stdout: "piped",
-    stderr: "inherit",
-  }).spawn();
-
-  const decoder = new TextDecoderStream();
-  const lines = serverProcess.stdout
-    .pipeThrough(decoder)
-    .pipeThrough(new TextLineStream());
-
-  let started = false;
-  for await (const line of lines) {
-    if (line.includes("Listening on http://")) {
-      started = true;
-      break;
-    }
-  }
-  if (!started) {
-    throw new Error("Server didn't start up");
-  }
+  });
 
   const res = await fetch("http://localhost:8000/fresh-badge.svg");
   await res.body?.cancel();


### PR DESCRIPTION
Use the `startFreshServer` helper function everywhere where it makes sense. Follow up PR to #1250 .

Fixes #1070