### PR TITLE
chore(tests): don't cancel child process stream

### DIFF
--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -11,7 +11,9 @@ export async function startFreshServer(options: Deno.CommandOptions) {
   const decoder = new TextDecoderStream();
   const lines: ReadableStream<string> = serverProcess.stdout
     .pipeThrough(decoder)
-    .pipeThrough(new TextLineStream());
+    .pipeThrough(new TextLineStream(), {
+      preventCancel: true,
+    });
 
   let started = false;
   for await (const line of lines) {


### PR DESCRIPTION
This makes debugging tests a lot easier with console logging. Before this it would often error with a "Broken Pipe" error because the stream was closed.

See: https://github.com/denoland/deno/issues/19401