### PR TITLE
feat(init): make directory argument optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ The [documentation](https://fresh.deno.dev/docs/) is available on
 Install [Deno CLI](https://deno.land/) version 1.25.0 or higher.
 
 You can scaffold a new project by running the Fresh init script. To scaffold a
-project in the `deno-fresh-demo` folder, run the following:
+project run the following:
 
 ```sh
-deno run -A -r https://fresh.deno.dev deno-fresh-demo
+deno run -A -r https://fresh.deno.dev
 ```
 
 Then navigate to the newly created project folder:
@@ -90,7 +90,12 @@ preferably with source code on GitHub, but not required.
 
 ```html
 <a href="https://fresh.deno.dev">
-   <img width="197" height="37" src="https://fresh.deno.dev/fresh-badge.svg" alt="Made with Fresh" />
+  <img
+    width="197"
+    height="37"
+    src="https://fresh.deno.dev/fresh-badge.svg"
+    alt="Made with Fresh"
+  />
 </a>
 ```
 
@@ -102,6 +107,11 @@ preferably with source code on GitHub, but not required.
 
 ```html
 <a href="https://fresh.deno.dev">
-   <img width="197" height="37" src="https://fresh.deno.dev/fresh-badge-dark.svg" alt="Made with Fresh" />
+  <img
+    width="197"
+    height="37"
+    src="https://fresh.deno.dev/fresh-badge-dark.svg"
+    alt="Made with Fresh"
+  />
 </a>
 ```

--- a/docs/getting-started/create-a-project.md
+++ b/docs/getting-started/create-a-project.md
@@ -10,8 +10,8 @@ will scaffold out a new project with some example files to get you started.
 To create a new project, run:
 
 ```
-deno run -A -r https://fresh.deno.dev deno-fresh-demo
-cd deno-fresh-demo
+deno run -A -r https://fresh.deno.dev
+cd fresh-project
 deno task start
 ```
 

--- a/init.ts
+++ b/init.ts
@@ -21,7 +21,7 @@ To generate a project in the current directory:
   fresh-init .
 
 USAGE:
-    fresh-init <DIRECTORY>
+    fresh-init [DIRECTORY]
 
 OPTIONS:
     --force   Overwrite existing files
@@ -42,17 +42,22 @@ const flags = parse(Deno.args, {
   default: { "force": null, "twind": null, "vscode": null },
 });
 
-if (flags._.length !== 1) {
-  error(help);
-}
-
 console.log(
   `\n%c  🍋 Fresh: the next-gen web framework.  %c\n`,
   "background-color: #86efac; color: black; font-weight: bold",
   "",
 );
 
-const unresolvedDirectory = Deno.args[0];
+let unresolvedDirectory = Deno.args[0];
+if (flags._.length !== 1) {
+  const userInput = prompt("Projet Name", "fresh-project");
+  if (!userInput) {
+    error(help);
+  }
+
+  unresolvedDirectory = userInput;
+}
+
 const resolvedDirectory = resolve(unresolvedDirectory);
 
 try {

--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -212,7 +212,7 @@ function GettingStarted(props: { origin: string }) {
       </p>
 
       <CopyArea>
-        {`deno run -A -r ${props.origin} deno-fresh-demo`}
+        {`deno run -A -r ${props.origin}`}
       </CopyArea>
 
       <p class="text-gray-600">

--- a/www/routes/update.tsx
+++ b/www/routes/update.tsx
@@ -199,7 +199,7 @@ function GettingStarted(props: { origin: string }) {
       </p>
 
       <CopyArea>
-        {`deno run -A -r ${props.origin} deno-fresh-demo`}
+        {`deno run -A -r ${props.origin}`}
       </CopyArea>
 
       <p class="text-gray-600">


### PR DESCRIPTION
This PR makes the init command a little shorter and easier to remember by making the directory argument optional.

Before:

```sh
deno run -A -r https://fresh.deno.dev deno-fresh-demo
```

After:

```sh
deno run -A -r https://fresh.deno.dev
```

You can still specify it like before, but not doing so simply asks for a project name as the first step:

<img width="844" alt="Screenshot 2023-06-09 at 14 41 41" src="https://github.com/denoland/fresh/assets/1062408/1f21f4fe-9ec5-494c-b3fc-699ca07fc153">


