### PR TITLE
fix(search): work around inline click handler

### DIFF
--- a/www/components/DocsSidebar.tsx
+++ b/www/components/DocsSidebar.tsx
@@ -15,9 +15,15 @@ export default function DocsSidebar(props: { path: string; mobile?: boolean }) {
           <button
             type="button"
             class="bg-gray-200 font-bold text-gray-400 rounded-full py-1 px-2 w-full mb-2"
-            // @ts-ignore: Inline event handler
-            onClick={`document.querySelector(".DocSearch.DocSearch-Button").click()`}
           >
+            <script
+              dangerouslySetInnerHTML={{
+                __html:
+                  `document.currentScript.parentNode.onclick = function () {
+                    document.querySelector(".DocSearch.DocSearch-Button").click()
+                  }`,
+              }}
+            />
             <span class="DocSearch-Button-Container">
               <svg
                 width="20"


### PR DESCRIPTION
Preact, like most other popular frameworks disallows passing stringified JavaScript code as event handlers. We have one occurrence of that in our doc search. The recent addition of including `preact/debug` during server rendering in #1256 surfaced this problem.

This PR works around that by injecting a tiny script tag that attaches the event handler. Basically only a slightly different approach than before.

Fixes #1266