### PR TITLE
fixes typo in init.ts "Projet" -> "Project"

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -50,7 +50,7 @@ console.log(
 
 let unresolvedDirectory = Deno.args[0];
 if (flags._.length !== 1) {
-  const userInput = prompt("Projet Name", "fresh-project");
+  const userInput = prompt("Project Name", "fresh-project");
   if (!userInput) {
     error(help);
   }


### PR DESCRIPTION
I found a typo in the `init.ts` file where it prompts the user for a project name if one is not provided.