### PR TITLE
fix(www): show missing GA env warning once

### DIFF
--- a/www/routes/_middleware.ts
+++ b/www/routes/_middleware.ts
@@ -4,6 +4,8 @@ import { GA4Report, isDocument, isServerError } from "$ga4";
 
 const GA4_MEASUREMENT_ID = Deno.env.get("GA4_MEASUREMENT_ID");
 
+let showedMissingEnvWarning = false;
+
 function ga4(
   request: Request,
   conn: MiddlewareHandlerContext,
@@ -11,6 +13,15 @@ function ga4(
   _start: number,
   error?: unknown,
 ) {
+  if (GA4_MEASUREMENT_ID === undefined) {
+    if (!showedMissingEnvWarning) {
+      showedMissingEnvWarning = true;
+      console.warn(
+        "GA4_MEASUREMENT_ID environment variable not set. Google Analytics reporting disabled.",
+      );
+    }
+    return;
+  }
   Promise.resolve().then(async () => {
     // We're tracking page views and file downloads. These are the only two
     // HTTP methods that _might_ be used.


### PR DESCRIPTION
This makes sure that the google analytics middleware only warns once when it's not configured vs warning on every request.