### PR TITLE
feat(server): make startup message easier to see

### DIFF
--- a/docs/getting-started/running-locally.md
+++ b/docs/getting-started/running-locally.md
@@ -11,7 +11,8 @@ automatically read from `.env`.
 ```
 $ deno task start
 Watcher Process started.
-Listening on http://localhost:8000
+ 🍋 Fresh ready
+     Local: http://localhost:8000
 ```
 
 If you want to start manually without Deno task, `deno run` the `main.ts` with
@@ -52,7 +53,8 @@ Combining all of this we get the following `deno run` command:
 ```
 $ deno run --allow-net --allow-read --allow-env --allow-run --watch=static/,routes/ main.ts
 Watcher Process started.
-Listening on http://localhost:8000
+ 🍋 Fresh ready
+     Local: http://localhost:8000
 ```
 
 If you now visit http://localhost:8000, you can see the running project. Try

--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -1,4 +1,5 @@
 import { ServerContext } from "./context.ts";
+import * as colors from "https://deno.land/std@0.190.0/fmt/colors.ts";
 import { serve } from "./deps.ts";
 export { Status } from "./deps.ts";
 import {
@@ -71,9 +72,23 @@ export async function createHandler(
 export async function start(routes: Manifest, opts: StartOptions = {}) {
   const ctx = await ServerContext.fromManifest(routes, opts);
   opts.port ??= parseInt(Deno.env.get("PORT") || "8000");
+
+  if (!opts.onListen) {
+    opts.onListen = (params) => {
+      console.log(
+        `\n%c 🍋 Fresh ready %c`,
+        "background-color: #86efac; color: black; font-weight: bold",
+        "",
+      );
+      const address = colors.cyan(`http://localhost:${params.port}/`);
+      const localLabel = colors.bold("Local:");
+      console.log(`    ${localLabel} ${address}\n`);
+    };
+  }
+
   if (opts.experimentalDenoServe === true) {
     // @ts-ignore as `Deno.serve` is still unstable.
-    await Deno.serve(ctx.handler() as Deno.ServeHandler, opts);
+    await Deno.serve({ ...opts, handler: ctx.handler() });
   } else {
     await serve(ctx.handler(), opts);
   }

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -17,7 +17,7 @@ export async function startFreshServer(options: Deno.CommandOptions) {
 
   let started = false;
   for await (const line of lines) {
-    if (line.includes("Listening on http://")) {
+    if (line.includes("Fresh ready")) {
       started = true;
       break;
     }


### PR DESCRIPTION
Noticed that it takes me a tiny amount of time to find the address in our output. It looked a bit too similar to the other output we log, and I think it's a good opportunity to make that more visually distinct. Best explained via pictures.

Before:

<img width="462" alt="Screenshot 2023-06-12 at 08 14 09" src="https://github.com/denoland/fresh/assets/1062408/54b8fc30-462b-4e93-b3ae-dee5b02ee8c5">


After:

<img width="450" alt="Screenshot 2023-06-12 at 08 12 37" src="https://github.com/denoland/fresh/assets/1062408/231e7669-65e0-410b-8f87-537a9d5d5fd7">
