### PR TITLE
feat: don't require connInfo in request handler

### DIFF
--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -13,7 +13,6 @@ export {
 } from "https://deno.land/std@0.190.0/http/server.ts";
 export type {
   ConnInfo,
-  Handler as RequestHandler,
   ServeInit,
 } from "https://deno.land/std@0.190.0/http/server.ts";
 export { Status } from "https://deno.land/std@0.190.0/http/http_status.ts";

--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -1,6 +1,6 @@
 import { ServerContext } from "./context.ts";
 import * as colors from "https://deno.land/std@0.190.0/fmt/colors.ts";
-import { serve, ServeHandler } from "./deps.ts";
+import { ConnInfo, serve, ServeHandler } from "./deps.ts";
 export { Status } from "./deps.ts";
 import {
   AppModule,
@@ -69,7 +69,7 @@ export { ServerContext };
 export async function createHandler(
   routes: Manifest,
   opts: StartOptions = {},
-) {
+): Promise<(req: Request, connInfo?: ConnInfo) => Promise<Response>> {
   const ctx = await ServerContext.fromManifest(routes, opts);
   return ctx.handler();
 }

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -13,23 +13,9 @@ import { startFreshServer } from "./test_utils.ts";
 
 const ctx = await ServerContext.fromManifest(manifest, options);
 const handler = ctx.handler();
-const router = (req: Request) => {
-  return handler(req, {
-    localAddr: {
-      transport: "tcp",
-      hostname: "127.0.0.1",
-      port: 80,
-    },
-    remoteAddr: {
-      transport: "tcp",
-      hostname: "127.0.0.1",
-      port: 80,
-    },
-  });
-};
 
 Deno.test("/ page prerender", async () => {
-  const resp = await router(new Request("https://fresh.deno.dev/"));
+  const resp = await handler(new Request("https://fresh.deno.dev/"));
   assert(resp);
   assertEquals(resp.status, Status.OK);
   assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
@@ -48,7 +34,7 @@ Deno.test("/ page prerender", async () => {
 });
 
 Deno.test("/props/123 page prerender", async () => {
-  const resp = await router(new Request("https://fresh.deno.dev/props/123"));
+  const resp = await handler(new Request("https://fresh.deno.dev/props/123"));
   assert(resp);
   assertEquals(resp.status, Status.OK);
   assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
@@ -60,7 +46,7 @@ Deno.test("/props/123 page prerender", async () => {
 });
 
 Deno.test("/[name] page prerender", async () => {
-  const resp = await router(new Request("https://fresh.deno.dev/bar"));
+  const resp = await handler(new Request("https://fresh.deno.dev/bar"));
   assert(resp);
   assertEquals(resp.status, Status.OK);
   assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
@@ -72,7 +58,7 @@ Deno.test("/api/head_override - HEAD", async () => {
   const req = new Request("https://fresh.deno.dev/api/head_override", {
     method: "HEAD",
   });
-  const resp = await router(req);
+  const resp = await handler(req);
   assert(resp);
   assertEquals(resp.status, Status.NoContent);
   assertEquals(resp.body, null);
@@ -86,7 +72,7 @@ Deno.test("/api/get_only - HEAD fallback", async () => {
   const req = new Request("https://fresh.deno.dev/api/get_only", {
     method: "HEAD",
   });
-  const resp = await router(req);
+  const resp = await handler(req);
   assert(resp);
   assertEquals(resp.status, Status.OK);
   assertEquals(resp.body, null);
@@ -100,7 +86,7 @@ Deno.test("/intercept - GET html", async () => {
   const req = new Request("https://fresh.deno.dev/intercept", {
     headers: { "accept": "text/html" },
   });
-  const resp = await router(req);
+  const resp = await handler(req);
   assert(resp);
   assertEquals(resp.status, Status.OK);
   const body = await resp.text();
@@ -111,7 +97,7 @@ Deno.test("/intercept - GET text", async () => {
   const req = new Request("https://fresh.deno.dev/intercept", {
     headers: { "accept": "text/plain" },
   });
-  const resp = await router(req);
+  const resp = await handler(req);
   assert(resp);
   assertEquals(resp.status, Status.OK);
   const body = await resp.text();
@@ -122,7 +108,7 @@ Deno.test("/intercept - POST", async () => {
   const req = new Request("https://fresh.deno.dev/intercept", {
     method: "POST",
   });
-  const resp = await router(req);
+  const resp = await handler(req);
   assert(resp);
   assertEquals(resp.status, Status.OK);
   const body = await resp.text();
@@ -133,7 +119,7 @@ Deno.test("/intercept - DELETE", async () => {
   const req = new Request("https://fresh.deno.dev/intercept", {
     method: "DELETE",
   });
-  const resp = await router(req);
+  const resp = await handler(req);
   assert(resp);
   assertEquals(resp.status, Status.MethodNotAllowed);
 });
@@ -142,7 +128,7 @@ Deno.test("/intercept_args - GET html", async () => {
   const req = new Request("https://fresh.deno.dev/intercept_args", {
     headers: { "accept": "text/html" },
   });
-  const resp = await router(req);
+  const resp = await handler(req);
   assert(resp);
   assertEquals(resp.status, Status.OK);
   const body = await resp.text();
@@ -153,7 +139,7 @@ Deno.test("/status_overwrite", async () => {
   const req = new Request("https://fresh.deno.dev/status_overwrite", {
     headers: { "accept": "text/html" },
   });
-  const resp = await router(req);
+  const resp = await handler(req);
   assert(resp);
   assertEquals(resp.status, Status.Unauthorized);
   assertEquals(resp.headers.get("x-some-header"), "foo");
@@ -162,7 +148,7 @@ Deno.test("/status_overwrite", async () => {
 });
 
 Deno.test("/api/get_only - NOTAMETHOD", async () => {
-  const resp = await router(
+  const resp = await handler(
     new Request("https://fresh.deno.dev/api/get_only", {
       method: "NOTAMETHOD",
     }),
@@ -172,7 +158,7 @@ Deno.test("/api/get_only - NOTAMETHOD", async () => {
 });
 
 Deno.test("/api/xyz not found", async () => {
-  const resp = await router(new Request("https://fresh.deno.dev/api/xyz"));
+  const resp = await handler(new Request("https://fresh.deno.dev/api/xyz"));
   assert(resp);
   assertEquals(resp.status, Status.NotFound);
   const body = await resp.text();
@@ -180,7 +166,7 @@ Deno.test("/api/xyz not found", async () => {
 });
 
 Deno.test("/static page prerender", async () => {
-  const resp = await router(new Request("https://fresh.deno.dev/static"));
+  const resp = await handler(new Request("https://fresh.deno.dev/static"));
   assert(resp);
   assertEquals(resp.status, Status.OK);
   assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
@@ -193,7 +179,7 @@ Deno.test("/static page prerender", async () => {
 });
 
 Deno.test("/books/:id page - /books/123", async () => {
-  const resp = await router(new Request("https://fresh.deno.dev/books/123"));
+  const resp = await handler(new Request("https://fresh.deno.dev/books/123"));
   assert(resp);
   assertEquals(resp.status, Status.OK);
   assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
@@ -202,13 +188,15 @@ Deno.test("/books/:id page - /books/123", async () => {
 });
 
 Deno.test("/books/:id page - /books/abc", async () => {
-  const resp = await router(new Request("https://fresh.deno.dev/books/abc"));
+  const resp = await handler(new Request("https://fresh.deno.dev/books/abc"));
   assert(resp);
   assertEquals(resp.status, Status.NotFound);
 });
 
 Deno.test("redirect /pages/fresh/ to /pages/fresh", async () => {
-  const resp = await router(new Request("https://fresh.deno.dev/pages/fresh/"));
+  const resp = await handler(
+    new Request("https://fresh.deno.dev/pages/fresh/"),
+  );
   assert(resp);
   assertEquals(resp.status, Status.TemporaryRedirect);
   assertEquals(
@@ -218,7 +206,7 @@ Deno.test("redirect /pages/fresh/ to /pages/fresh", async () => {
 });
 
 Deno.test("redirect /pages/////fresh///// to /pages/////fresh", async () => {
-  const resp = await router(
+  const resp = await handler(
     new Request("https://fresh.deno.dev/pages/////fresh/////"),
   );
   assert(resp);
@@ -230,7 +218,7 @@ Deno.test("redirect /pages/////fresh///// to /pages/////fresh", async () => {
 });
 
 Deno.test("redirect /pages/////fresh/ to /pages/////fresh", async () => {
-  const resp = await router(
+  const resp = await handler(
     new Request("https://fresh.deno.dev/pages/////fresh/"),
   );
   assert(resp);
@@ -242,7 +230,7 @@ Deno.test("redirect /pages/////fresh/ to /pages/////fresh", async () => {
 });
 
 Deno.test("no redirect for /pages/////fresh", async () => {
-  const resp = await router(
+  const resp = await handler(
     new Request("https://fresh.deno.dev/pages/////fresh"),
   );
   assert(resp);
@@ -250,7 +238,7 @@ Deno.test("no redirect for /pages/////fresh", async () => {
 });
 
 Deno.test("/failure", async () => {
-  const resp = await router(new Request("https://fresh.deno.dev/failure"));
+  const resp = await handler(new Request("https://fresh.deno.dev/failure"));
   assert(resp);
   assertEquals(resp.status, Status.InternalServerError);
   const body = await resp.text();
@@ -258,7 +246,7 @@ Deno.test("/failure", async () => {
 });
 
 Deno.test("/foo/:path*", async () => {
-  const resp = await router(new Request("https://fresh.deno.dev/foo/bar/baz"));
+  const resp = await handler(new Request("https://fresh.deno.dev/foo/bar/baz"));
   assert(resp);
   assertEquals(resp.status, Status.OK);
   const body = await resp.text();
@@ -294,7 +282,7 @@ Deno.test("static files in custom directory", async () => {
 });
 
 Deno.test("static file - by file path", async () => {
-  const resp = await router(new Request("https://fresh.deno.dev/foo.txt"));
+  const resp = await handler(new Request("https://fresh.deno.dev/foo.txt"));
   assertEquals(resp.status, Status.OK);
   const body = await resp.text();
   assert(body.startsWith("bar"));
@@ -305,7 +293,7 @@ Deno.test("static file - by file path", async () => {
   assert(!etag.startsWith("W/"), "etag should be weak");
   assertEquals(resp.headers.get("content-type"), "text/plain");
 
-  const resp2 = await router(
+  const resp2 = await handler(
     new Request("https://fresh.deno.dev/foo.txt", {
       headers: {
         "if-none-match": etag,
@@ -316,7 +304,7 @@ Deno.test("static file - by file path", async () => {
   assertEquals(resp2.headers.get("etag"), etag);
   assertEquals(resp2.headers.get("content-type"), "text/plain");
 
-  const resp3 = await router(
+  const resp3 = await handler(
     new Request("https://fresh.deno.dev/foo.txt", {
       headers: {
         "if-none-match": `W/${etag}`,
@@ -330,7 +318,7 @@ Deno.test("static file - by file path", async () => {
 
 Deno.test("HEAD request", async () => {
   // Static file
-  const resp = await router(
+  const resp = await handler(
     new Request("https://fresh.deno.dev/foo.txt", {
       method: "HEAD",
     }),
@@ -340,7 +328,7 @@ Deno.test("HEAD request", async () => {
   assertEquals(body, "");
 
   // route
-  const resp2 = await router(
+  const resp2 = await handler(
     new Request("https://fresh.deno.dev/books/123", {
       method: "HEAD",
     }),
@@ -353,7 +341,7 @@ Deno.test("HEAD request", async () => {
 
 Deno.test("static file - by 'hashed' path", async () => {
   // Check that the file path have the BUILD_ID
-  const resp = await router(
+  const resp = await handler(
     new Request("https://fresh.deno.dev/assetsCaching"),
   );
   const body = await resp.text();
@@ -362,7 +350,7 @@ Deno.test("static file - by 'hashed' path", async () => {
   assert(imgFilePath.includes(`?__frsh_c=${BUILD_ID}`));
 
   // check the static file is served corectly under its cacheable route
-  const resp2 = await router(
+  const resp2 = await handler(
     new Request(`https://fresh.deno.dev${imgFilePath}`),
   );
   const _ = await resp2.text();
@@ -372,7 +360,7 @@ Deno.test("static file - by 'hashed' path", async () => {
     "public, max-age=31536000, immutable",
   );
 
-  const resp3 = await router(
+  const resp3 = await handler(
     new Request(`https://fresh.deno.dev${imgFilePath}`, {
       headers: {
         "if-none-match": resp2.headers.get("etag")!,
@@ -414,7 +402,7 @@ Deno.test("static file - by 'hashed' path", async () => {
 });
 
 Deno.test("/params/:path*", async () => {
-  const resp = await router(
+  const resp = await handler(
     new Request("https://fresh.deno.dev/params/bar/baz"),
   );
   assert(resp);
@@ -424,17 +412,17 @@ Deno.test("/params/:path*", async () => {
 });
 
 Deno.test("/connInfo", async () => {
-  const resp = await router(new Request("https://fresh.deno.dev/connInfo"));
+  const resp = await handler(new Request("https://fresh.deno.dev/connInfo"));
   assert(resp);
   assertEquals(resp.status, Status.OK);
   const body = await resp.text();
-  assertEquals(body, "127.0.0.1");
+  assertEquals(body, "localhost");
 });
 
 Deno.test({
   name: "/middleware - root",
   fn: async () => {
-    const resp = await router(
+    const resp = await handler(
       new Request("https://fresh.deno.dev/middleware_root"),
     );
     assert(resp);
@@ -448,7 +436,7 @@ Deno.test({
 Deno.test({
   name: "/middleware - mixedHandler(cors)",
   fn: async () => {
-    const resp = await router(
+    const resp = await handler(
       new Request("https://fresh.deno.dev/middleware_root", {
         method: "OPTIONS",
       }),
@@ -463,7 +451,7 @@ Deno.test({
 Deno.test({
   name: "/middleware - mixedHandler(log)",
   fn: async () => {
-    const resp = await router(
+    const resp = await handler(
       new Request("https://fresh.deno.dev/middleware_root"),
     );
     assert(resp);
@@ -479,7 +467,7 @@ Deno.test({
 Deno.test({
   name: "/middleware - layer 2 middleware",
   fn: async () => {
-    const resp = await router(
+    const resp = await handler(
       new Request("https://fresh.deno.dev/layeredMdw/layer2/abc"),
     );
     assert(resp);
@@ -492,7 +480,7 @@ Deno.test({
     // layered 2 should not run layer 3 middleware
     assert(!body.includes("layer3_mw"));
 
-    const resp1 = await router(
+    const resp1 = await handler(
       new Request("https://fresh.deno.dev/layeredMdw/layer2-no-mw/without_mw"),
     );
     assert(resp1);
@@ -509,7 +497,7 @@ Deno.test({
 Deno.test({
   name: "/middleware - layer 2 middleware at index",
   fn: async () => {
-    const resp = await router(
+    const resp = await handler(
       new Request("https://fresh.deno.dev/layeredMdw/layer2"),
     );
     assert(resp);
@@ -522,7 +510,7 @@ Deno.test({
     // layered 2 should not run layer 3 middleware
     assert(!body.includes("layer3_mw"));
 
-    const resp1 = await router(
+    const resp1 = await handler(
       new Request("https://fresh.deno.dev/layeredMdw/layer2-no-mw/without_mw"),
     );
     assert(resp1);
@@ -540,7 +528,7 @@ Deno.test({
   name: "/middleware - layer 3 middleware",
   fn: async () => {
     // layered 3 should contain layer 3 middleware data
-    const resp = await router(
+    const resp = await handler(
       new Request("https://fresh.deno.dev/layeredMdw/layer2/layer3/abc"),
     );
     assert(resp);
@@ -560,7 +548,7 @@ Deno.test({
 Deno.test({
   name: "/not_found",
   fn: async () => {
-    const resp = await router(new Request("https://fresh.deno.dev/not_found"));
+    const resp = await handler(new Request("https://fresh.deno.dev/not_found"));
     assert(resp);
     assertEquals(resp.status, 404);
     const body = await resp.text();
@@ -571,7 +559,7 @@ Deno.test({
 
 Deno.test("middleware destination", async (t) => {
   await t.step("internal", async () => {
-    const resp = await router(
+    const resp = await handler(
       new Request("https://fresh.deno.dev/_frsh/refresh.js"),
     );
     assert(resp);
@@ -580,21 +568,21 @@ Deno.test("middleware destination", async (t) => {
   });
 
   await t.step("static", async () => {
-    const resp = await router(new Request("https://fresh.deno.dev/foo.txt"));
+    const resp = await handler(new Request("https://fresh.deno.dev/foo.txt"));
     assert(resp);
     assertEquals(resp.headers.get("destination"), "static");
     await resp.body?.cancel();
   });
 
   await t.step("route", async () => {
-    const resp = await router(new Request("https://fresh.deno.dev/"));
+    const resp = await handler(new Request("https://fresh.deno.dev/"));
     assert(resp);
     assertEquals(resp.headers.get("destination"), "route");
     await resp.body?.cancel();
   });
 
   await t.step("notFound", async () => {
-    const resp = await router(new Request("https://fresh.deno.dev/bar/bar"));
+    const resp = await handler(new Request("https://fresh.deno.dev/bar/bar"));
     assert(resp);
     assertEquals(resp.headers.get("destination"), "notFound");
     await resp.body?.cancel();


### PR DESCRIPTION
This makes testing easier, because users now do not need to pass a
fake `ConnInfo` themselves anymore.
