### PR TITLE
chore(ci): run tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: set "PUPPETEER_PRODUCT=chrome" && deno run -A --unstable https://deno.land/x/puppeteer@16.2.0/install.ts
 
       - name: Run tests
-        run: deno test -A
+        run: deno test -A --parallel
 
       - name: Type check init script
         run: deno check --remote init.ts

--- a/.github/workflows/www.yml
+++ b/.github/workflows/www.yml
@@ -33,5 +33,5 @@ jobs:
         working-directory: www/
 
       - name: Run tests
-        run: deno test -A
+        run: deno test -A --parallel
         working-directory: www/

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": false,
   "tasks": {
-    "test": "deno test -A && deno check --config=www/deno.json www/main.ts www/dev.ts && deno check init.ts",
+    "test": "deno test -A --parallel && deno check --config=www/deno.json www/main.ts www/dev.ts && deno check init.ts",
     "fixture": "deno run -A --watch=static/,routes/ tests/fixture/dev.ts",
     "www": "deno task --cwd=www start",
     "screenshot": "deno run -A www/utils/screenshot.ts"


### PR DESCRIPTION
With #1274 merged we can now run tests in parallel. On my machine this leads to a great speedup.

| Mode | Time |
|---|--:|
| Sequential | 43s |
| Parallel | 12s |