### PR TITLE
fix: use `await Deno.serve().finished`

### DIFF
--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -128,7 +128,7 @@ export async function start(routes: Manifest, opts: StartOptions = {}) {
 async function bootServer(handler: ServeHandler, opts: StartOptions) {
   if (opts.experimentalDenoServe === true) {
     // @ts-ignore as `Deno.serve` is still unstable.
-    await Deno.serve({ ...opts, handler });
+    await Deno.serve({ ...opts, handler }).finished;
   } else {
     await serve(handler, opts);
   }

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -603,7 +603,7 @@ Deno.test("middleware destination", async (t) => {
 Deno.test("experimental Deno.serve", {
   sanitizeOps: false,
   sanitizeResources: false,
-  ignore: Deno.build.os === "windows", // TODO: Deno.serve hang on Windows?
+  // ignore: Deno.build.os === "windows", // TODO: Deno.serve hang on Windows?
 }, async (t) => {
   // Preparation
   const { serverProcess, lines, address } = await startFreshServer({

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -603,7 +603,7 @@ Deno.test("middleware destination", async (t) => {
 Deno.test("experimental Deno.serve", {
   sanitizeOps: false,
   sanitizeResources: false,
-  // ignore: Deno.build.os === "windows", // TODO: Deno.serve hang on Windows?
+  ignore: Deno.build.os === "windows", // TODO: Deno.serve hang on Windows?
 }, async (t) => {
   // Preparation
   const { serverProcess, lines, address } = await startFreshServer({


### PR DESCRIPTION
[A recent change in the runtime](https://github.com/denoland/deno/pull/19485) has changed the behaviour of `Deno.serve()` such that it throws when called a promise. The correct way to do it is instead to call `Deno.serve().finished` as a promise. This PR does that.

Fixes https://github.com/denoland/fresh/pull/1286#issuecomment-1589987387