### PR TITLE
docs: fix "Writing Tests" example title typo

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -10,4 +10,4 @@ like to see here, please open
 
 - [Modifying the `<head>`](./examples/modifying-the-head)
 - [Setting the language](./examples/setting-the-language)
-- [Writing Tests](./examples/writing-tests)
+- [Writing tests](./examples/writing-tests)

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -42,7 +42,7 @@
     "pages": [
       ["modifying-the-head", "Modifying the <head>"],
       ["setting-the-language", "Setting the language"],
-      ["writing-tests", "Writing Tests"]
+      ["writing-tests", "Writing tests"]
     ]
   }
 }


### PR DESCRIPTION
To align the casing with the rest of the documentation titles.