### PR TITLE
fix: rendering islands inside other islands

### DIFF
--- a/tests/fixture_island_nesting/fresh.gen.ts
+++ b/tests/fixture_island_nesting/fresh.gen.ts
@@ -4,29 +4,33 @@
 
 import * as $0 from "./routes/index.tsx";
 import * as $1 from "./routes/island_in_island.tsx";
-import * as $2 from "./routes/island_jsx_child.tsx";
-import * as $3 from "./routes/island_jsx_children.tsx";
-import * as $4 from "./routes/island_jsx_island_jsx.tsx";
-import * as $5 from "./routes/island_jsx_text.tsx";
-import * as $6 from "./routes/island_nested_props.tsx";
-import * as $7 from "./routes/island_siblings.tsx";
+import * as $2 from "./routes/island_in_island_definition.tsx";
+import * as $3 from "./routes/island_jsx_child.tsx";
+import * as $4 from "./routes/island_jsx_children.tsx";
+import * as $5 from "./routes/island_jsx_island_jsx.tsx";
+import * as $6 from "./routes/island_jsx_text.tsx";
+import * as $7 from "./routes/island_nested_props.tsx";
+import * as $8 from "./routes/island_siblings.tsx";
 import * as $$0 from "./islands/Island.tsx";
-import * as $$1 from "./islands/IslandWithProps.tsx";
+import * as $$1 from "./islands/IslandInsideIsland.tsx";
+import * as $$2 from "./islands/IslandWithProps.tsx";
 
 const manifest = {
   routes: {
     "./routes/index.tsx": $0,
     "./routes/island_in_island.tsx": $1,
-    "./routes/island_jsx_child.tsx": $2,
-    "./routes/island_jsx_children.tsx": $3,
-    "./routes/island_jsx_island_jsx.tsx": $4,
-    "./routes/island_jsx_text.tsx": $5,
-    "./routes/island_nested_props.tsx": $6,
-    "./routes/island_siblings.tsx": $7,
+    "./routes/island_in_island_definition.tsx": $2,
+    "./routes/island_jsx_child.tsx": $3,
+    "./routes/island_jsx_children.tsx": $4,
+    "./routes/island_jsx_island_jsx.tsx": $5,
+    "./routes/island_jsx_text.tsx": $6,
+    "./routes/island_nested_props.tsx": $7,
+    "./routes/island_siblings.tsx": $8,
   },
   islands: {
     "./islands/Island.tsx": $$0,
-    "./islands/IslandWithProps.tsx": $$1,
+    "./islands/IslandInsideIsland.tsx": $$1,
+    "./islands/IslandWithProps.tsx": $$2,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/fixture_island_nesting/islands/IslandInsideIsland.tsx
+++ b/tests/fixture_island_nesting/islands/IslandInsideIsland.tsx
@@ -1,0 +1,14 @@
+import { ComponentChildren } from "preact";
+import Island from "./Island.tsx";
+
+export default function IslandInsideIsland(
+  props: { children?: ComponentChildren },
+) {
+  return (
+    <div class="island">
+      <Island>
+        {props.children}
+      </Island>
+    </div>
+  );
+}

--- a/tests/fixture_island_nesting/routes/island_in_island_definition.tsx
+++ b/tests/fixture_island_nesting/routes/island_in_island_definition.tsx
@@ -1,0 +1,11 @@
+import IslandInsideIsland from "../islands/IslandInsideIsland.tsx";
+
+export default function Home() {
+  return (
+    <div id="page">
+      <IslandInsideIsland>
+        <p>it works</p>
+      </IslandInsideIsland>
+    </div>
+  );
+}

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -345,6 +345,37 @@ Deno.test({
 });
 
 Deno.test({
+  name: "render island inside island definition",
+
+  async fn(_t) {
+    await withPageName(
+      "./tests/fixture_island_nesting/main.ts",
+      async (page, address) => {
+        await page.goto(`${address}/island_in_island_definition`, {
+          waitUntil: "networkidle2",
+        });
+        await page.waitForSelector(".island");
+
+        await delay(100);
+        const text = await page.$eval(
+          ".island .island p",
+          (el) => el.textContent,
+        );
+        assertEquals(text, "it works");
+
+        // Check that there is no duplicated content which could happen
+        // when islands aren't initialized correctly
+        const pageText = await page.$eval("#page", (el) => el.textContent);
+        assertEquals(pageText, "it works");
+      },
+    );
+  },
+
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
   name:
     "render island with JSX children that render another island with JSX children",
 


### PR DESCRIPTION
Noticed that one use case of nesting islands wasn't supported and this PR addresses that.

```jsx
function Island() {
  return <OtherIsland />
}
```

The previous code had trouble with this too, but it often wasn't a problem because the outer island removed the incorrect HTML.

The approach taken here relies on keeping track of `vnode` "owners". An owner of a `vnode` is the component whose render call lead to the creation of said `vnode`. The same logic is used in lots of tooling related to Preact (DevTools, prefresh, debug) and can be found in other frameworks like React too. That said this makes the fix look a little more involved than it actually is.

This is a follow up to #1285 .