### PR TITLE
fix: remove duplicated esbuild imports

### DIFF
--- a/src/build/deps.ts
+++ b/src/build/deps.ts
@@ -6,7 +6,7 @@ export {
 export { escape as regexpEscape } from "https://deno.land/std@0.190.0/regexp/escape.ts";
 
 // -- esbuild --
-// @deno-types="https://deno.land/x/esbuild@v0.17.11/mod.d.ts"
+// @deno-types="https://deno.land/x/esbuild@v0.17.19/mod.d.ts"
 import * as esbuildWasm from "https://deno.land/x/esbuild@v0.17.19/wasm.js";
 import * as esbuildNative from "https://deno.land/x/esbuild@v0.17.19/mod.js";
 // @ts-ignore trust me

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -23,16 +23,3 @@ export {
 export { toHashString } from "https://deno.land/std@0.190.0/crypto/to_hash_string.ts";
 export { escape } from "https://deno.land/std@0.190.0/regexp/escape.ts";
 export * as JSONC from "https://deno.land/std@0.190.0/jsonc/mod.ts";
-
-// -- esbuild --
-// @deno-types="https://deno.land/x/esbuild@v0.17.11/mod.d.ts"
-import * as esbuildWasm from "https://deno.land/x/esbuild@v0.17.11/wasm.js";
-import * as esbuildNative from "https://deno.land/x/esbuild@v0.17.11/mod.js";
-// @ts-ignore trust me
-// deno-lint-ignore no-deprecated-deno-api
-const esbuild: typeof esbuildWasm = Deno.run === undefined
-  ? esbuildWasm
-  : esbuildNative;
-export { esbuild, esbuildWasm as esbuildTypes };
-
-export { denoPlugins } from "https://deno.land/x/esbuild_deno_loader@0.7.0/mod.ts";


### PR DESCRIPTION
This somehow snuck in during the src/build/ refactor.
