### PR TITLE
feat: Allow passing props to renderNotFound method

### DIFF
--- a/docs/concepts/error-pages.md
+++ b/docs/concepts/error-pages.md
@@ -36,7 +36,9 @@ export const handler: Handlers = {
   async GET(req, ctx) {
     const blogpost = await fetchBlogpost(ctx.params.slug);
     if (!blogpost) {
-      return ctx.renderNotFound();
+      return ctx.renderNotFound({
+        custom: "prop",
+      });
     }
     return ctx.render({ blogpost });
   },

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -91,7 +91,7 @@ export interface HandlerContext<Data = unknown, State = Record<string, unknown>>
     data?: Data,
     options?: RenderOptions,
   ) => Response | Promise<Response>;
-  renderNotFound: () => Response | Promise<Response>;
+  renderNotFound: (data?: Data) => Response | Promise<Response>;
   state: State;
 }
 
@@ -135,13 +135,20 @@ export interface AppModule {
 
 // --- UNKNOWN PAGE ---
 
-export interface UnknownPageProps {
+// deno-lint-ignore no-explicit-any
+export interface UnknownPageProps<T = any> {
   /** The URL of the request that resulted in this page being rendered. */
   url: URL;
 
   /** The route matcher (e.g. /blog/:id) that the request matched for this page
    * to be rendered. */
   route: string;
+
+  /**
+   * Additional data passed into `HandlerContext.renderNotFound`. Defaults to
+   * `undefined`.
+   */
+  data: T;
 }
 
 export interface UnknownHandlerContext<State = Record<string, unknown>>

--- a/tests/fixture/routes/_404.tsx
+++ b/tests/fixture/routes/_404.tsx
@@ -1,5 +1,10 @@
 import { UnknownPageProps } from "$fresh/server.ts";
 
-export default function NotFoundPage({ url }: UnknownPageProps) {
-  return <p>404 not found: {url.pathname}</p>;
+export default function NotFoundPage({ data, url }: UnknownPageProps) {
+  return (
+    <>
+      <p>404 not found: {url.pathname}</p>
+      {data?.hello && <p>Hello {data.hello}</p>}
+    </>
+  );
 }

--- a/tests/fixture/routes/not_found.ts
+++ b/tests/fixture/routes/not_found.ts
@@ -2,6 +2,8 @@ import { Handlers } from "../../../server.ts";
 
 export const handler: Handlers = {
   GET(_req, ctx) {
-    return ctx.renderNotFound();
+    return ctx.renderNotFound({
+      hello: "Dino",
+    });
   },
 };

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -565,6 +565,7 @@ Deno.test({
     assertEquals(resp.status, 404);
     const body = await resp.text();
     assertStringIncludes(body, "404 not found: /not_found");
+    assertStringIncludes(body, "Hello Dino");
   },
 });
 


### PR DESCRIPTION
This update allows for passing custom props to `renderNotFound` method and making `_404.tsx` pages customizable based on the place it was triggered from.

Fixes https://github.com/denoland/fresh/issues/1300