### PR TITLE
fix: Exclude Twitter/Slack bots from root page redirects

### DIFF
--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -11,10 +11,18 @@ import Projects from "../components/Projects.tsx";
 import projects from "../data/showcase.json" assert { type: "json" };
 import Header from "../components/Header.tsx";
 
+function isOpenGraphUA(header: string | null): boolean {
+  if (!header) {
+    return false;
+  }
+  return header.startsWith("Twitterbot") || header.startsWith("Slackbot");
+}
+
 export const handler: Handlers = {
   GET(req, ctx) {
     const accept = req.headers.get("accept");
-    if (accept && !accept.includes("text/html")) {
+    const userAgent = req.headers.get("user-agent");
+    if (!accept?.includes("text/html") && !isOpenGraphUA(userAgent)) {
       const path = `https://deno.land/x/fresh@${VERSIONS[0]}/init.ts`;
       return new Response(`Redirecting to ${path}`, {
         headers: { "Location": path },


### PR DESCRIPTION
It's caused by 307 redirects that most Open Graph protocols happily follow.
Unfortunately, there's no single trivial way to "catch" them all, so we'll need to go the "manual" route for now and add them for every more widely used vendor.

Fixes https://github.com/denoland/fresh/issues/1313

---

Before Twitter:
<img width="588" alt="image" src="https://github.com/denoland/fresh/assets/1523305/8cefebb7-a3d8-4408-b037-fdbdb05006a8">

After Twitter:
<img width="591" alt="image" src="https://github.com/denoland/fresh/assets/1523305/b7592dcd-f09d-4e6c-b8e0-fa869bd021eb">

Before Slack:
<img width="320" alt="image" src="https://github.com/denoland/fresh/assets/1523305/49badea4-11c5-473f-ae65-3cfe4b0dd99f">

After Slack:
<img width="309" alt="image" src="https://github.com/denoland/fresh/assets/1523305/9547436f-9391-464a-8c4a-669e22f97a0b">