### PR TITLE
feat: improve starter template design

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -117,19 +117,22 @@ export default function Home() {
       <Head>
         <title>Fresh App</title>
       </Head>
-      <div${useTwind ? ` class="p-4 mx-auto max-w-screen-md"` : ""}>
-        <img
-          src="/logo.svg"
-          ${
-  useTwind ? `class="w-32 h-32"` : `width="128"\n          height="128"`
-}
-          alt="the fresh logo: a sliced lemon dripping with juice"
-        />
-        <p${useTwind ? ` class="my-6"` : ""}>
-          Welcome to \`fresh\`. Try updating this message in the
-          ./routes/index.tsx file, and refresh.
-        </p>
-        <Counter count={count} />
+      <div class="px-4 py-8 mx-auto bg-[#86efac]">
+        <div class="max-w-screen-md mx-auto flex flex-col items-center justify-center">
+          <img
+            class="my-6"
+            src="/logo.svg"
+            width="128"
+            height="128"
+            alt="the fresh logo: a sliced lemon dripping with juice"
+          />
+          <h1 class="text-4xl font-bold">Welcome to fresh</h1>
+          <p class="my-4">
+            Try updating this message in the
+            <code class="mx-2">./routes/index.tsx</code> file, and refresh.
+          </p>
+          <Counter count={count} />
+        </div>
       </div>
     </>
   );
@@ -148,11 +151,8 @@ export function Button(props: JSX.HTMLAttributes<HTMLButtonElement>) {
     <button
       {...props}
       disabled={!IS_BROWSER || props.disabled}
-${
-  useTwind
-    ? '      class="px-2 py-1 border(gray-100 2) hover:bg-gray-200"\n'
-    : ""
-}    />
+      class="px-2 py-1 border-gray-500 border-2 rounded bg-white hover:bg-gray-200 transition-colors"
+    />
   );
 }
 `;
@@ -170,11 +170,9 @@ interface CounterProps {
 
 export default function Counter(props: CounterProps) {
   return (
-    <div${useTwind ? ' class="flex gap-2 w-full"' : ""}>
-      <p${
-  useTwind ? ' class="flex-grow-1 font-bold text-xl"' : ""
-}>{props.count}</p>
+    <div class="flex gap-8 py-6">
       <Button onClick={() => props.count.value -= 1}>-1</Button>
+      <p class="text-3xl">{props.count}</p>
       <Button onClick={() => props.count.value += 1}>+1</Button>
     </div>
   );
@@ -233,6 +231,162 @@ if (useTwind) {
   await Deno.writeTextFile(
     join(resolvedDirectory, "twind.config.ts"),
     TWIND_CONFIG_TS,
+  );
+}
+
+const NO_TWIND_STYLES = `
+*,
+*::before,
+*::after {
+  box-sizing: boder-box;
+}
+* {
+  margin: 0;
+}
+button {
+  color: inherit;
+}
+button, [role="button"] {
+  cursor: pointer;
+}
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  font-size: 1em;
+}
+img,
+svg {
+  display: block;
+}
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+html {
+  line-height: 1.5;
+  -webkit-text-size-adjust: 100%;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+.transition-colors {
+  transition-property: background-color, border-color, color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+.my-6 {
+  margin-bottom: 1.5rem;
+  margin-top: 1.5rem;
+}
+.text-4xl {
+  font-size: 2.25rem;
+  line-height: 2.5rem;
+}
+.mx-2 {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+.my-4 {
+  margin-bottom: 1rem;
+  margin-top: 1rem;
+}
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+.py-8 {
+  padding-bottom: 2rem;
+  padding-top: 2rem;
+}
+.bg-\\[\\#86efac\\] {
+  background-color: #86efac;
+}
+.text-3xl {
+  font-size: 1.875rem;
+  line-height: 2.25rem;
+}
+.py-6 {
+  padding-bottom: 1.5rem;
+  padding-top: 1.5rem;
+}
+.px-2 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+.py-1 {
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
+}
+.border-gray-500 {
+  border-color: #6b7280;
+}
+.bg-white {
+  background-color: #fff;
+}
+.flex {
+  display: flex;
+}
+.gap-8 {
+  grid-gap: 2rem;
+  gap: 2rem;
+}
+.font-bold {
+  font-weight: 700;
+}
+.max-w-screen-md {
+  max-width: 768px;
+}
+.flex-col {
+  flex-direction: column;
+}
+.items-center {
+  align-items: center;
+}
+.justify-center {
+  justify-content: center;
+}
+.border-2 {
+  border-width: 2px;
+}
+.rounded {
+  border-radius: 0.25rem;
+}
+.hover\:bg-gray-200:hover {
+  background-color: #e5e7eb;
+}
+`;
+
+const NO_TWIND_APP_WRAPPER = `
+import { AppProps } from "$fresh/server.ts";
+import { Head } from "$fresh/runtime.ts";
+
+export default function App({ Component }: AppProps) {
+  return (
+    <>
+      <Head>
+        <link rel="stylesheet" href="/styles.css" />
+      </Head>
+      <Component />
+    </>
+  );
+}
+`;
+
+if (!useTwind) {
+  await Deno.writeTextFile(
+    join(resolvedDirectory, "static", "styles.css"),
+    NO_TWIND_STYLES,
+  );
+
+  await Deno.writeTextFile(
+    join(resolvedDirectory, "routes", "_app.tsx"),
+    NO_TWIND_APP_WRAPPER,
   );
 }
 

--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -130,11 +130,13 @@ Deno.test({
       });
       const page = await browser.newPage();
       await page.goto(address, { waitUntil: "networkidle2" });
-      const counter = await page.$("body > div > div > p");
+      const counter = await page.$("body > div > div > div > p");
       let counterValue = await counter?.evaluate((el) => el.textContent);
       assert(counterValue === "3");
 
-      const buttonPlus = await page.$("body > div > div > button:nth-child(3)");
+      const buttonPlus = await page.$(
+        "body > div > div > div > button:nth-child(3)",
+      );
       await buttonPlus?.click();
 
       await delay(100);
@@ -258,16 +260,18 @@ Deno.test({
       const page = await browser.newPage();
       await page.goto(address, { waitUntil: "networkidle2" });
 
-      const counter = await page.$("body > div > div > p");
+      const counter = await page.$("body > div > div > div > p");
       let counterValue = await counter?.evaluate((el) => el.textContent);
-      assert(counterValue === "3");
+      assertEquals(counterValue, "3");
 
       const fontWeight = await counter?.evaluate((el) =>
         getComputedStyle(el).fontWeight
       );
-      assertEquals(fontWeight, "700");
+      assertEquals(fontWeight, "400");
 
-      const buttonPlus = await page.$("body > div > div > button:nth-child(3)");
+      const buttonPlus = await page.$(
+        "body > div > div > div > button:nth-child(3)",
+      );
       await buttonPlus?.click();
 
       await delay(100);


### PR DESCRIPTION
Made it so that the same styles apply for the twind preset and the non-twind one. When twind is not selected we'll create a plain old style sheet directly and insert it into the head via a generated `_app.tsx`.

Before:

<img width="988" alt="Screenshot 2023-06-17 at 19 03 02" src="https://github.com/denoland/fresh/assets/1062408/a1f8c61a-8da2-421d-bc08-71d853327d54">

After:

<img width="986" alt="Screenshot 2023-06-17 at 18 59 34" src="https://github.com/denoland/fresh/assets/1062408/306eb19f-1f21-47a9-8986-184c04d3136e">

Fixes #1308 .