### PR TITLE
fix: incorrect coloring in ansi256 terminals

### DIFF
--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -80,11 +80,12 @@ export async function start(routes: Manifest, opts: StartOptions = {}) {
   if (!opts.onListen) {
     opts.onListen = (params) => {
       console.log(
-        `\n%c 🍋 Fresh ready %c`,
-        "background-color: #86efac; color: black; font-weight: bold",
-        "",
+        colors.bgRgb8(colors.black(colors.bold("\n 🍋 Fresh ready ")), 121),
       );
-      const address = colors.cyan(`http://localhost:${params.port}/`);
+
+      const address = colors.cyan(
+        `http://localhost:${params.port}/`,
+      );
       const localLabel = colors.bold("Local:");
       console.log(`    ${localLabel} ${address}\n`);
     };


### PR DESCRIPTION
Looks like the built in `Terminal.app` app on macOS is the only one which doesn't support 24bit colors yet. I've attempted to work on a more generalised solution for converting color spaces in deno itself in https://github.com/denoland/deno/pull/18549 , but that takes a little more time to get ready. For now just using the closest match for fresh's brand color in `ansi256` space is a good enough.


Before:

<img width="370" alt="Screenshot 2023-06-18 at 20 23 43" src="https://github.com/denoland/fresh/assets/1062408/77224899-49e8-4791-80b1-1a396c6a63b9">


After:
<img width="356" alt="Screenshot 2023-06-18 at 20 23 53" src="https://github.com/denoland/fresh/assets/1062408/088135e5-9310-4ef7-b06d-460da4566a22">

Here is a comparison on the original color value from a terminal that supports 24bit colors and the closest ansi256 color.

Original:

<img width="245" alt="Screenshot 2023-06-18 at 20 28 38" src="https://github.com/denoland/fresh/assets/1062408/792e7efa-97ce-42d1-8bd4-e8e6f9baa2a4">


Ansi256:

<img width="253" alt="Screenshot 2023-06-18 at 20 28 18" src="https://github.com/denoland/fresh/assets/1062408/8aa64d04-d52f-45c3-9d07-7561acbc4cd0">



