### PR TITLE
fix: conditional sibling islands DOM order

### DIFF
--- a/tests/fixture_island_nesting/fresh.gen.ts
+++ b/tests/fixture_island_nesting/fresh.gen.ts
@@ -3,34 +3,40 @@
 // This file is automatically updated during development when running `dev.ts`.
 
 import * as $0 from "./routes/index.tsx";
-import * as $1 from "./routes/island_in_island.tsx";
-import * as $2 from "./routes/island_in_island_definition.tsx";
-import * as $3 from "./routes/island_jsx_child.tsx";
-import * as $4 from "./routes/island_jsx_children.tsx";
-import * as $5 from "./routes/island_jsx_island_jsx.tsx";
-import * as $6 from "./routes/island_jsx_text.tsx";
-import * as $7 from "./routes/island_nested_props.tsx";
-import * as $8 from "./routes/island_siblings.tsx";
-import * as $$0 from "./islands/Island.tsx";
-import * as $$1 from "./islands/IslandInsideIsland.tsx";
-import * as $$2 from "./islands/IslandWithProps.tsx";
+import * as $1 from "./routes/island_conditional.tsx";
+import * as $2 from "./routes/island_in_island.tsx";
+import * as $3 from "./routes/island_in_island_definition.tsx";
+import * as $4 from "./routes/island_jsx_child.tsx";
+import * as $5 from "./routes/island_jsx_children.tsx";
+import * as $6 from "./routes/island_jsx_island_jsx.tsx";
+import * as $7 from "./routes/island_jsx_text.tsx";
+import * as $8 from "./routes/island_nested_props.tsx";
+import * as $9 from "./routes/island_siblings.tsx";
+import * as $$0 from "./islands/BooleanButton.tsx";
+import * as $$1 from "./islands/Island.tsx";
+import * as $$2 from "./islands/IslandConditional.tsx";
+import * as $$3 from "./islands/IslandInsideIsland.tsx";
+import * as $$4 from "./islands/IslandWithProps.tsx";
 
 const manifest = {
   routes: {
     "./routes/index.tsx": $0,
-    "./routes/island_in_island.tsx": $1,
-    "./routes/island_in_island_definition.tsx": $2,
-    "./routes/island_jsx_child.tsx": $3,
-    "./routes/island_jsx_children.tsx": $4,
-    "./routes/island_jsx_island_jsx.tsx": $5,
-    "./routes/island_jsx_text.tsx": $6,
-    "./routes/island_nested_props.tsx": $7,
-    "./routes/island_siblings.tsx": $8,
+    "./routes/island_conditional.tsx": $1,
+    "./routes/island_in_island.tsx": $2,
+    "./routes/island_in_island_definition.tsx": $3,
+    "./routes/island_jsx_child.tsx": $4,
+    "./routes/island_jsx_children.tsx": $5,
+    "./routes/island_jsx_island_jsx.tsx": $6,
+    "./routes/island_jsx_text.tsx": $7,
+    "./routes/island_nested_props.tsx": $8,
+    "./routes/island_siblings.tsx": $9,
   },
   islands: {
-    "./islands/Island.tsx": $$0,
-    "./islands/IslandInsideIsland.tsx": $$1,
-    "./islands/IslandWithProps.tsx": $$2,
+    "./islands/BooleanButton.tsx": $$0,
+    "./islands/Island.tsx": $$1,
+    "./islands/IslandConditional.tsx": $$2,
+    "./islands/IslandInsideIsland.tsx": $$3,
+    "./islands/IslandWithProps.tsx": $$4,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/fixture_island_nesting/islands/BooleanButton.tsx
+++ b/tests/fixture_island_nesting/islands/BooleanButton.tsx
@@ -1,0 +1,13 @@
+import { Signal } from "@preact/signals";
+
+export default function BooleanButton({ signal }: { signal: Signal }) {
+  return (
+    <button
+      onClick={() => {
+        signal.value = !signal.value;
+      }}
+    >
+      Toggle
+    </button>
+  );
+}

--- a/tests/fixture_island_nesting/islands/IslandConditional.tsx
+++ b/tests/fixture_island_nesting/islands/IslandConditional.tsx
@@ -1,0 +1,9 @@
+import { Signal } from "@preact/signals";
+
+export interface IslandConditionalProps {
+  show: Signal<boolean>;
+}
+
+export default function IslandConditional({ show }: IslandConditionalProps) {
+  return show.value ? <>it works</> : null;
+}

--- a/tests/fixture_island_nesting/routes/island_conditional.tsx
+++ b/tests/fixture_island_nesting/routes/island_conditional.tsx
@@ -1,0 +1,14 @@
+import IslandConditional from "../islands/IslandConditional.tsx";
+import BooleanButton from "../islands/BooleanButton.tsx";
+import { signal } from "@preact/signals";
+
+const show = signal(false);
+
+export default function Page() {
+  return (
+    <div id="page">
+      <IslandConditional show={show} />
+      <BooleanButton signal={show} />
+    </div>
+  );
+}

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -435,6 +435,37 @@ Deno.test({
 });
 
 Deno.test({
+  name: "render sibling islands that render nothing initially",
+
+  async fn(_t) {
+    await withPageName(
+      "./tests/fixture_island_nesting/main.ts",
+      async (page, address) => {
+        await page.goto(`${address}/island_conditional`, {
+          waitUntil: "networkidle2",
+        });
+        await page.waitForSelector("button");
+
+        await delay(100);
+        await page.click("button");
+
+        const text = await page.$eval(
+          "#page",
+          (el) => el.textContent,
+        );
+        // Button text is matched too, but this allows us
+        // to assert correct ordering. The "it works" should
+        // be left of "Toggle"
+        assertEquals(text, "it worksToggle");
+      },
+    );
+  },
+
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
   name: "serialize inner island props",
 
   async fn(_t) {


### PR DESCRIPTION
This happened when both share the same parent and one or both render nothing into the DOM. Once an island starts rendering something into our root fragment that we wrap around each island, it was guaranteed to call `.appendChild()`. But when islands share the same parent this leads to children being added to the very end of the parent DOM node instead of just of the end of the current island tree.

For that reason we need to keep at least the end comment marker of an island as a reference point of where `appendChild` should insert children.

Fixes the first issue mentioned in #1322