### PR TITLE
fix: `update.ts` fails when there is no islands directory

### DIFF
--- a/src/dev/deps.ts
+++ b/src/dev/deps.ts
@@ -10,7 +10,7 @@ export {
   SEP,
   toFileUrl,
 } from "https://deno.land/std@0.190.0/path/mod.ts";
-export { walk } from "https://deno.land/std@0.190.0/fs/walk.ts";
+export { walk, WalkError } from "https://deno.land/std@0.190.0/fs/walk.ts";
 export { parse } from "https://deno.land/std@0.190.0/flags/mod.ts";
 export { gte } from "https://deno.land/std@0.190.0/semver/mod.ts";
 

--- a/src/dev/mod.ts
+++ b/src/dev/mod.ts
@@ -1,4 +1,12 @@
-import { dirname, fromFileUrl, gte, join, toFileUrl, walk } from "./deps.ts";
+import {
+  dirname,
+  fromFileUrl,
+  gte,
+  join,
+  toFileUrl,
+  walk,
+  WalkError,
+} from "./deps.ts";
 import { error } from "./error.ts";
 
 const MIN_DENO_VERSION = "1.25.0";
@@ -28,12 +36,22 @@ async function collectDir(dir: string): Promise<string[]> {
     includeFiles: true,
     exts: ["tsx", "jsx", "ts", "js"],
   });
-  for await (const entry of routesFolder) {
-    const path = toFileUrl(entry.path).href.substring(
-      dirUrl.href.length,
-    );
-    paths.push(path);
+
+  try {
+    for await (const entry of routesFolder) {
+      const path = toFileUrl(entry.path).href.substring(
+        dirUrl.href.length,
+      );
+      paths.push(path);
+    }
+  } catch (err) {
+    if (err instanceof WalkError && err.cause instanceof Deno.errors.NotFound) {
+      // Do nothing.
+      return [];
+    }
+    throw err;
   }
+
   paths.sort();
   return paths;
 }

--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -1,5 +1,8 @@
 import * as path from "$std/path/mod.ts";
-import { assertNotMatch } from "https://deno.land/std@0.190.0/testing/asserts.ts";
+import {
+  assertMatch,
+  assertNotMatch,
+} from "https://deno.land/std@0.190.0/testing/asserts.ts";
 import { Status } from "../src/server/deps.ts";
 import {
   assert,
@@ -437,4 +440,75 @@ Deno.test({
     await retry(() => Deno.remove(tmpDirName, { recursive: true }));
   },
   sanitizeResources: false,
+});
+
+Deno.test("fresh-update", async function fn(t) {
+  // Preparation
+  const tmpDirName = await Deno.makeTempDir();
+
+  const cliProcess = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "-A",
+      path.join(Deno.cwd(), "init.ts"),
+      ".",
+    ],
+    cwd: tmpDirName,
+    stdin: "null",
+    stdout: "null",
+  });
+
+  await cliProcess.output();
+
+  await t.step("execute update command", async () => {
+    const cliProcess = new Deno.Command(Deno.execPath(), {
+      args: [
+        "run",
+        "-A",
+        path.join(Deno.cwd(), "update.ts"),
+        ".",
+      ],
+      cwd: tmpDirName,
+      stdin: "null",
+      stdout: "piped",
+    });
+
+    const { code, stdout } = await cliProcess.output();
+    const output = new TextDecoder().decode(stdout);
+
+    assertMatch(
+      output,
+      /The manifest has been generated for \d+ routes and \d+ islands./,
+    );
+    assertEquals(code, 0);
+  });
+
+  await t.step("execute update command (no islands directory)", async () => {
+    await retry(() =>
+      Deno.remove(path.join(tmpDirName, "islands"), { recursive: true })
+    );
+
+    const cliProcess = new Deno.Command(Deno.execPath(), {
+      args: [
+        "run",
+        "-A",
+        path.join(Deno.cwd(), "update.ts"),
+        ".",
+      ],
+      cwd: tmpDirName,
+      stdin: "null",
+      stdout: "piped",
+    });
+
+    const { code, stdout } = await cliProcess.output();
+    const output = new TextDecoder().decode(stdout);
+
+    assertMatch(
+      output,
+      /The manifest has been generated for \d+ routes and 0 islands./,
+    );
+    assertEquals(code, 0);
+  });
+
+  await retry(() => Deno.remove(tmpDirName, { recursive: true }));
 });


### PR DESCRIPTION
Fix #1326 

Fixed to ignore the error if the directory did not exist, referring to the change diff in #1185.