### PR TITLE
Oldest Deno version should change to 1.31.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The [documentation](https://fresh.deno.dev/docs/) is available on
 
 ## 🚀 Getting started
 
-Install [Deno CLI](https://deno.land/) version 1.25.0 or higher.
+Install [Deno CLI](https://deno.land/) version 1.31.0 or higher.
 
 You can scaffold a new project by running the Fresh init script. To scaffold a
 project run the following:

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -10,7 +10,7 @@ framework. You'll learn how to create a new project, run it locally, edit and
 create pages, fetch data, handle user interactions, and how to then deploy the
 project to [Deno Deploy][deno-deploy].
 
-The documentation assumes you have Deno 1.25.0 or later installed.
+The documentation assumes you have Deno 1.31.0 or later installed.
 
 To install Deno, follow the
 [installation instructions in the Deno manual][manual-installation].

--- a/src/dev/mod.ts
+++ b/src/dev/mod.ts
@@ -1,7 +1,7 @@
 import { dirname, fromFileUrl, gte, join, toFileUrl, walk } from "./deps.ts";
 import { error } from "./error.ts";
 
-const MIN_DENO_VERSION = "1.25.0";
+const MIN_DENO_VERSION = "1.31.0";
 
 export function ensureMinDenoVersion() {
   // Check that the minimum supported Deno version is being used.

--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -198,7 +198,7 @@ function GettingStarted(props: { origin: string }) {
           <a href="https://deno.land" class="text-blue-600 hover:underline">
             Deno CLI
           </a>{" "}
-          version 1.25.0 or higher is required.{" "}
+          version 1.31.0 or higher is required.{" "}
           <a
             href="https://deno.land/manual/getting_started/installation"
             class="text-blue-600 hover:underline"


### PR DESCRIPTION
Fresh uses `Deno.Command` since [this commit](https://github.com/denoland/fresh/commit/7e72fa236c1abc183aae31e5532af914ed060ec5) (release as [1.1.5](https://github.com/denoland/fresh/compare/1.1.4...1.1.5)) to run command. However, `Deno.Command` was first introduced in [Deno 1.28.0](https://github.com/denoland/deno/releases/tag/v1.28.0) as an unstable function and became stable at [Deno 1.31.0](https://github.com/denoland/deno/releases/tag/v1.31.0).

If you're running latest Fresh with older version of Deno, an error will be raised as below:

```
error: Uncaught (in promise) TypeError: Deno.Command is not a constructor
  const proc = new Deno.Command(Deno.execPath(), {
               ^
    at generate (https://deno.land/x/fresh@1.2.0/src/dev/mod.ts:91:16)
    at https://deno.land/x/fresh@1.2.0/init.ts:378:7

```

Therefore, the oldest version of Deno should change to 1.31.0.

If there's any problem of this PR, please let me know. Thank you!