### PR TITLE
feat(starter): add 404 page template

### DIFF
--- a/docs/examples/changing-the-src-dir.md
+++ b/docs/examples/changing-the-src-dir.md
@@ -18,9 +18,11 @@ you'll end up with a project like the following:
 │   └── Counter.tsx
 ├── main.ts
 ├── routes
-│   ├── [name].tsx
+│   ├── greet
+│   │   ├── [name].tsx
 │   ├── api
 │   │   └── joke.ts
+│   ├── _404.tsx
 │   └── index.tsx
 └── static
     ├── favicon.ico
@@ -64,9 +66,11 @@ The resulting file structure looks like this:
     │   └── Counter.tsx
     ├── main.ts
     ├── routes
-    │   ├── [name].tsx
+    │   ├── greet
+    │   │   ├── [name].tsx
     │   ├── api
     │   │   └── joke.ts
+    │   ├── _404.tsx
     │   └── index.tsx
     └── static
         ├── favicon.ico

--- a/docs/getting-started/dynamic-routes.md
+++ b/docs/getting-started/dynamic-routes.md
@@ -1,31 +1,31 @@
 ---
 description: |
   Create a dynamic route in fresh by adding a dynamic segment to the route name
-  in the routes' file name on disk: `/[name].tsx`.
+  in the routes' file name on disk: `/greet/[name].tsx`.
 ---
 
 The `/about` route created on the last page is pretty static. It does not matter
 what query or path parameters are passed to the route, it will always render the
-same page. Let's create a `/:name` that will render a page with a greeting that
-contains the name passed in the path.
+same page. Let's create a `/greet/:name` that will render a page with a greeting
+that contains the name passed in the path.
 
 Before diving in, a quick refresher on "dynamic" routes. Dynamic routes don't
 just match a single static path, but rather a whole bunch of different paths
-based on a pattern. For example, the `/:name` route will match the paths `/Luca`
-and `/John`, but not `/Luca/John`.
+based on a pattern. For example, the `/greet/:name` route will match the paths
+`/greet/Luca` and `/John`, but not `/greet/Luca/John`.
 
 Fresh supports dynamic routes out of the box through file system routing. To
 make any path segment dynamic, just put square brackets around that segment in
-the file name. For example the `/:name` route maps to the file name
-`routes/[name].tsx`.
+the file name. For example the `/greet/:name` route maps to the file name
+`routes/greet/[name].tsx`.
 
-Just like the static `/about` route, the dynamic `/:name` route will render a
-page. The module must once again expose a component as a default export. This
-time the component will receive the matched path segment properties as arguments
-in its `props` object though.
+Just like the static `/about` route, the dynamic `/greet/:name` route will
+render a page. The module must once again expose a component as a default
+export. This time the component will receive the matched path segment properties
+as arguments in its `props` object though.
 
 ```tsx
-// routes/[name].tsx
+// routes/greet/[name].tsx
 
 import { PageProps } from "$fresh/server.ts";
 
@@ -43,7 +43,7 @@ The `PageProps` interface actually contains a bunch of useful properties that
 can be used to customize the rendered output. Next to the matched url pattern
 parameters, the raw `url`, and the `route` name can also be found in here.
 
-Navigating to `http://localhost:8000/Luca` will now render a page showing
+Navigating to `http://localhost:8000/greet/Luca` will now render a page showing
 "Greetings to you, Luca!".
 
 The [_Concepts: Routing_][concepts-routing] page has more information about

--- a/init.ts
+++ b/init.ts
@@ -189,9 +189,48 @@ export default function Greet(props: PageProps) {
   return <div>Hello {props.params.name}</div>;
 }
 `;
+await Deno.mkdir(join(resolvedDirectory, "routes", "greet"), {
+  recursive: true,
+});
 await Deno.writeTextFile(
-  join(resolvedDirectory, "routes", "[name].tsx"),
+  join(resolvedDirectory, "routes", "greet", "[name].tsx"),
   ROUTES_GREET_TSX,
+);
+
+// 404 page
+const ROUTES_404_PAGE = `
+import { Head } from "$fresh/runtime.ts";
+
+export default function Error404() {
+  return (
+    <>
+      <Head>
+        <title>404 - Page not found</title>
+      </Head>
+      <div class="px-4 py-8 mx-auto bg-[#86efac]">
+        <div class="max-w-screen-md mx-auto flex flex-col items-center justify-center">
+          <img
+            class="my-6"
+            src="/logo.svg"
+            width="128"
+            height="128"
+            alt="the fresh logo: a sliced lemon dripping with juice"
+          />
+          <h1 class="text-4xl font-bold">404 - Page not found</h1>
+          <p class="my-4">
+            The page you were looking for doesn't exist.
+          </p>
+          <a href="/" class="underline">Go back home</a>
+        </div>
+      </div>
+    </>
+  );
+}
+`;
+
+await Deno.writeTextFile(
+  join(resolvedDirectory, "routes", "_404.tsx"),
+  ROUTES_404_PAGE,
 );
 
 const ROUTES_API_JOKE_TS = `import { HandlerContext } from "$fresh/server.ts";

--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -85,7 +85,13 @@ Deno.test({
             "type": "directory",
             "name": "routes",
             "contents": [
-              { "type": "file", "name": "[name].tsx" },
+              {
+                "type": "directory",
+                "name": "greet",
+                "contents": [
+                  { "type": "file", "name": "[name].tsx" },
+                ],
+              },
               {
                 "type": "directory",
                 "name": "api",
@@ -207,7 +213,13 @@ Deno.test({
             "type": "directory",
             "name": "routes",
             "contents": [
-              { "type": "file", "name": "[name].tsx" },
+              {
+                "type": "directory",
+                "name": "greet",
+                "contents": [
+                  { "type": "file", "name": "[name].tsx" },
+                ],
+              },
               {
                 "type": "directory",
                 "name": "api",

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -45,7 +45,7 @@ Deno.test("/props/123 page prerender", async () => {
   );
 });
 
-Deno.test("/[name] page prerender", async () => {
+Deno.test("/greet/[name] page prerender", async () => {
   const resp = await handler(new Request("https://fresh.deno.dev/bar"));
   assert(resp);
   assertEquals(resp.status, Status.OK);


### PR DESCRIPTION
This required moving the catchall greet route to `/greet/[name].tsx`

Preview:

![Screenshot 2023-06-21 at 10 42 00](https://github.com/denoland/fresh/assets/1062408/84990762-c7b9-4ee3-9b8d-9da0971973bb)

Fixes #1335 