### PR TITLE
docs: add "Dealing with CORS" example

### DIFF
--- a/docs/concepts/server-configuration.md
+++ b/docs/concepts/server-configuration.md
@@ -58,7 +58,7 @@ export interface RouterOptions {
 
 ## Plugins
 
-See the [docs](./docs/concepts/plugins) on this topic for more detail. But for
+See the [docs](/docs/concepts/plugins) on this topic for more detail. But for
 completion, you can do something like this to load plugins:
 
 ```ts

--- a/docs/examples/dealing-with-cors.md
+++ b/docs/examples/dealing-with-cors.md
@@ -98,4 +98,4 @@ requests.
 
 Of course there's no reason why you need to use middleware in order to solve
 this. The headers can be set directly in the
-[handler](https://fresh.deno.dev/docs/getting-started/custom-handlers) as well.
+[handler](/docs/getting-started/custom-handlers) as well.

--- a/docs/examples/dealing-with-cors.md
+++ b/docs/examples/dealing-with-cors.md
@@ -98,4 +98,4 @@ requests.
 
 Of course there's no reason why you need to use middleware in order to solve
 this. The headers can be set directly in the
-[handler](http://localhost:8000/docs/getting-started/custom-handlers) as well.
+[handler](https://fresh.deno.dev/docs/getting-started/custom-handlers) as well.

--- a/docs/examples/dealing-with-cors.md
+++ b/docs/examples/dealing-with-cors.md
@@ -1,0 +1,101 @@
+---
+description: |
+  CORS enabling routes in your Fresh project.
+---
+
+So you've encountered some CORS problems and are on the hunt for the solution?
+You're in the right spot.
+
+Here's a good [resource](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+talking about CORS in general, in case you don't fully understand what's wrong.
+
+## Simple CORS -- Middleware
+
+As per the above link, "simple" requests involve `GET`, `HEAD`, or `POST`
+requests. You can CORS enable all the routes affected by some `middleware` by
+doing the following:
+
+```ts
+import { MiddlewareHandlerContext } from "$fresh/server.ts";
+
+export async function handler(
+  req: Request,
+  ctx: MiddlewareHandlerContext,
+) {
+  const origin = req.headers.get("Origin") || "*";
+  const resp = await ctx.next();
+  const headers = resp.headers;
+
+  headers.set("Access-Control-Allow-Origin", origin);
+  headers.set("Access-Control-Allow-Credentials", "true");
+  headers.set(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With",
+  );
+  headers.set(
+    "Access-Control-Allow-Methods",
+    "POST, OPTIONS, GET, PUT, DELETE",
+  );
+
+  return resp;
+}
+```
+
+## Complex CORS -- Middleware
+
+What about for one of the other HTTP methods? Then you'll need to be able to
+deal with "preflight requests". Let's imagine you're trying to support a
+`DELETE` route. Then you'd need to do something like this:
+
+```ts
+import { MiddlewareHandlerContext } from "$fresh/server.ts";
+
+export async function handler(
+  _req: Request,
+  ctx: MiddlewareHandlerContext,
+) {
+  if (_req.method == "OPTIONS") {
+    const resp = new Response(null, {
+      status: 204,
+    });
+    const origin = _req.headers.get("Origin") || "*";
+    const headers = resp.headers;
+    headers.set("Access-Control-Allow-Origin", origin);
+    headers.set(
+      "Access-Control-Allow-Methods",
+      "DELETE",
+    );
+    return resp;
+  }
+  const origin = _req.headers.get("Origin") || "*";
+  const resp = await ctx.next();
+  const headers = resp.headers;
+
+  headers.set("Access-Control-Allow-Origin", origin);
+  headers.set("Access-Control-Allow-Credentials", "true");
+  headers.set(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With",
+  );
+  headers.set(
+    "Access-Control-Allow-Methods",
+    "POST, OPTIONS, GET, PUT, DELETE",
+  );
+
+  return resp;
+}
+```
+
+These complex results require a two step process:
+
+1. the browser makes an `OPTIONS` request to find out about the allowed methods
+2. the browser makes the actual request
+
+So you can see the middleware has some special handling to deal with `OPTIONS`
+requests.
+
+## CORS in Routes
+
+Of course there's no reason why you need to use middleware in order to solve
+this. The headers can be set directly in the
+[handler](http://localhost:8000/docs/getting-started/custom-handlers) as well.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -14,3 +14,4 @@ like to see here, please open
 - [Changing the source directory](./examples/changing-the-src-dir)
 - [Initializing the server](./examples/init-the-server)
 - [Using Fresh canary version](./examples/using-fresh-canary-version)
+- [Dealing with CORS](./examples/dealing-with-cors)

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -47,7 +47,8 @@
       ["changing-the-src-dir", "Changing the source directory"],
       ["using-twind-v1", "Using Twind v1"],
       ["init-the-server", "Initializing the server"],
-      ["using-fresh-canary-version", "Using Fresh canary version"]
+      ["using-fresh-canary-version", "Using Fresh canary version"],
+      ["dealing-with-cors", "Dealing with CORS"]
     ]
   }
 }


### PR DESCRIPTION
closes https://github.com/denoland/fresh/issues/1247

I'll let someone who has spent more than one day thinking about CORS have the final say on how this should be phrased. But this is at least a starting point to critique / improve upon.

Technically it does even solve the problem, as evidenced by the links [here](https://github.com/denoland/fresh/issues/1247#issuecomment-1603079202). Maybe these should be included in the documentation as an example?