### PR TITLE
fix: signals not serialized with newer versions

### DIFF
--- a/.vscode/import_map.json
+++ b/.vscode/import_map.json
@@ -11,6 +11,8 @@
     "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.1.0",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
     "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.2.3",
+    "@preact/signals-core@1.2.3": "https://esm.sh/@preact/signals-core@1.2.3",
+    "@preact/signals-core@1.3.0": "https://esm.sh/@preact/signals-core@1.3.0",
     "$std/": "https://deno.land/std@0.190.0/"
   }
 }

--- a/src/server/__snapshots__/serializer_test.ts.snap
+++ b/src/server/__snapshots__/serializer_test.ts.snap
@@ -8,6 +8,12 @@ snapshot[`serializer - Uint8Array 1`] = `'{"v":{"a":{"_f":"u8a","d":"AQID"}}}'`;
 
 snapshot[`serializer - signals 1`] = `'{"v":{"a":1,"b":{"_f":"s","v":2}}}'`;
 
+snapshot[`serializer - @preact/signals-core 1.2.3 1`] = `'{"v":{"a":1,"b":{"_f":"s","v":2}}}'`;
+
+snapshot[`serializer - @preact/signals-core 1.3.0 1`] = `'{"v":{"a":1,"b":{"_f":"s","v":2}}}'`;
+
+snapshot[`serializer - multiple versions of @preact/signals-core 1`] = `'{"v":{"a":1,"b":{"_f":"s","v":2},"c":{"_f":"s","v":2},"d":{"_f":"s","v":2}}}'`;
+
 snapshot[`serializer - magic key 1`] = `'{"v":{"_f":"l","k":"f","v":{"a":1}}}'`;
 
 snapshot[`serializer - circular reference objects 1`] = `'{"v":{"a":1,"b":0},"r":[[[],["b"]]]}'`;

--- a/src/server/serializer.ts
+++ b/src/server/serializer.ts
@@ -155,6 +155,22 @@ export function serialize(data: unknown): SerializeResult {
       parentStack.push(res);
       return res;
     } else {
+      if (key !== null) {
+        // Bypass signal's `.toJSON` method because we want to serialize
+        // the signal itself including the signal's value and not just
+        // the value. This is needed because `JSON.stringify` always
+        // calls `.toJSON` automatically if available.
+        // deno-lint-ignore no-explicit-any
+        const realValue = (this as any)[key];
+        if (isSignal(realValue)) {
+          requiresDeserializer = true;
+          hasSignals = true;
+          const res = { [KEY]: "s", v: realValue.peek() };
+          parentStack.push(res);
+          return res;
+        }
+      }
+
       parentStack.push(value);
       return value;
     }

--- a/src/server/serializer_test.ts
+++ b/src/server/serializer_test.ts
@@ -3,7 +3,9 @@
 import { serialize } from "./serializer.ts";
 import { assert, assertEquals, assertSnapshot } from "../../tests/deps.ts";
 import { deserialize, KEY } from "../runtime/deserializer.ts";
-import { signal } from "@preact/signals";
+import { signal } from "@preact/signals-core";
+import { signal as signal130 } from "@preact/signals-core@1.3.0";
+import { signal as signal123 } from "@preact/signals-core@1.2.3";
 
 Deno.test("serializer - primitives & plain objects", async (t) => {
   const data = {
@@ -56,6 +58,60 @@ Deno.test("serializer - signals", async (t) => {
   assertEquals(deserialized.a, 1);
   assertEquals(deserialized.b.value, 2);
   assertEquals(deserialized.b.peek(), 2);
+});
+
+Deno.test("serializer - @preact/signals-core 1.2.3", async (t) => {
+  const data = {
+    a: 1,
+    b: signal123(2),
+  };
+  const res = serialize(data);
+  assert(res.requiresDeserializer);
+  assert(res.hasSignals);
+  await assertSnapshot(t, res.serialized);
+  const deserialized: any = deserialize(res.serialized, signal);
+  assertEquals(typeof deserialized, "object");
+  assertEquals(deserialized.a, 1);
+  assertEquals(deserialized.b.value, 2);
+  assertEquals(deserialized.b.peek(), 2);
+});
+
+Deno.test("serializer - @preact/signals-core 1.3.0", async (t) => {
+  const data = {
+    a: 1,
+    b: signal130(2),
+  };
+  const res = serialize(data);
+  assert(res.requiresDeserializer);
+  assert(res.hasSignals);
+  await assertSnapshot(t, res.serialized);
+  const deserialized: any = deserialize(res.serialized, signal);
+  assertEquals(typeof deserialized, "object");
+  assertEquals(deserialized.a, 1);
+  assertEquals(deserialized.b.value, 2);
+  assertEquals(deserialized.b.peek(), 2);
+});
+
+Deno.test("serializer - multiple versions of @preact/signals-core", async (t) => {
+  const data = {
+    a: 1,
+    b: signal(2),
+    c: signal123(2),
+    d: signal130(2),
+  };
+  const res = serialize(data);
+  assert(res.requiresDeserializer);
+  assert(res.hasSignals);
+  await assertSnapshot(t, res.serialized);
+  const deserialized: any = deserialize(res.serialized, signal);
+  assertEquals(typeof deserialized, "object");
+  assertEquals(deserialized.a, 1);
+  assertEquals(deserialized.b.value, 2);
+  assertEquals(deserialized.b.peek(), 2);
+  assertEquals(deserialized.c.value, 2);
+  assertEquals(deserialized.c.peek(), 2);
+  assertEquals(deserialized.d.value, 2);
+  assertEquals(deserialized.d.peek(), 2);
 });
 
 Deno.test("serializer - magic key", async (t) => {


### PR DESCRIPTION
Newer versions of @preact/signals-core have a `toJSON` method which is called by `JSON.stringify` automatically. This means we miss signals during serialization. This PR adds a check if the value we received was from an unwrapped signal.

Fixes #1342