### PR TITLE
fix: update script supports deno.jsonc files

### DIFF
--- a/src/dev/deps.ts
+++ b/src/dev/deps.ts
@@ -13,6 +13,7 @@ export {
 export { walk, WalkError } from "https://deno.land/std@0.190.0/fs/walk.ts";
 export { parse } from "https://deno.land/std@0.190.0/flags/mod.ts";
 export { gte } from "https://deno.land/std@0.190.0/semver/mod.ts";
+export { existsSync } from "https://deno.land/std@0.190.0/fs/mod.ts";
 
 // ts-morph
 export { Node, Project } from "https://deno.land/x/ts_morph@17.0.1/mod.ts";

--- a/update.ts
+++ b/update.ts
@@ -1,4 +1,11 @@
-import { join, Node, parse, Project, resolve } from "./src/dev/deps.ts";
+import {
+  existsSync,
+  join,
+  Node,
+  parse,
+  Project,
+  resolve,
+} from "./src/dev/deps.ts";
 import { error } from "./src/dev/error.ts";
 import { freshImports, twindImports } from "./src/dev/imports.ts";
 import { collect, ensureMinDenoVersion, generate } from "./src/dev/mod.ts";
@@ -27,9 +34,17 @@ const unresolvedDirectory = Deno.args[0];
 const resolvedDirectory = resolve(unresolvedDirectory);
 
 // Update dependencies in the import map. The import map can either be embedded
-// in a deno.json file or be in a separate JSON file referenced with the
+// in a deno.json (or .jsonc) file or be in a separate JSON file referenced with the
 // `importMap` key in deno.json.
-const DENO_JSON_PATH = join(resolvedDirectory, "deno.json");
+const fileNames = ["deno.json", "deno.jsonc"];
+const DENO_JSON_PATH = fileNames
+  .map((fileName) => join(resolvedDirectory, fileName))
+  .find((path) => existsSync(path));
+if (!DENO_JSON_PATH) {
+  throw new Error(
+    `Neither deno.json nor deno.jsonc could be found in ${resolvedDirectory}`,
+  );
+}
 let denoJsonText = await Deno.readTextFile(DENO_JSON_PATH);
 let denoJson = JSON.parse(denoJsonText);
 if (denoJson.importMap) {


### PR DESCRIPTION
closes https://github.com/denoland/fresh/issues/800

I refactored the test a bit because it seemed to be getting a bit repetitive. There's now an `updateAndVerify` function which is called from the three cases:
1. execute update command
2. execute update command deno.jsonc support
3. execute update command (no islands directory)