### PR TITLE
fix: update script broken when using src dir

### DIFF
--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -363,6 +363,32 @@ Deno.test("fresh-update", async function fn(t) {
     }
   });
 
+  await t.step("execute update command src dir", async () => {
+    const names = [
+      "components",
+      "islands",
+      "routes",
+      "static",
+      "dev.ts",
+      "main.ts",
+      "fresh.gen.ts",
+    ];
+    try {
+      Deno.mkdirSync(tmpDirName + "/src");
+      names.forEach((x) => {
+        Deno.rename(path.join(tmpDirName, x), path.join(tmpDirName, "src", x));
+      });
+      await updateAndVerify(
+        /The manifest has been generated for (?!0 routes and 0 islands)\d+ routes and \d+ islands./,
+      );
+    } finally {
+      names.forEach((x) => {
+        Deno.rename(path.join(tmpDirName, "src", x), path.join(tmpDirName, x));
+      });
+      await retry(() => Deno.remove(tmpDirName + "/src", { recursive: true }));
+    }
+  });
+
   await t.step("execute update command (no islands directory)", async () => {
     await retry(() =>
       Deno.remove(path.join(tmpDirName, "islands"), { recursive: true })


### PR DESCRIPTION
closes https://github.com/denoland/fresh/issues/1338

This is more complex than first expected. It turns out the head of main no longer has this error, because we started swallowing errors in https://github.com/denoland/fresh/pull/1327. I'm not sure this is the right implementation. It seems like we should explicitly check for the `islands` folder instead of ignoring errors. But the obvious approach (https://deno.land/std@0.192.0/fs/mod.ts?s=exists) is apparently forbidden, due to some sort of nonsense with race conditions. Well, not being able to find `islands` because it doesn't exist at all is definitely different than it being buried in a source directory, so we'll need to sort this out at some point.

I suppose that's now some technical debt to deal with, and not related to this issue. The latest "error" when running `update` and using a source directory is the following:
```
deno run -A -r file:///Users/reed/code/fresh/update.ts .
The manifest has been generated for 0 routes and 0 islands.
```
i.e. it just doesn't do anything. (To be fair, it does generate a `fresh.gen.ts` in the incorrect location, so I suppose it does _something_.)

But of course this isn't what we want. So we'll hunt for a source directory, as defined by the precense of `main.ts`.

The fix for this is relatively straightforward. The test implements the user's actions, i.e. init a project, move things, and then try to update.