### PR TITLE
feat: support conditional island JSX children

### DIFF
--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -220,8 +220,6 @@ function _walkInner(
                 | HTMLTemplateElement
                 | null;
 
-              console.log(marker, sel, template);
-
               if (template !== null) {
                 markerStack.push({
                   kind: MarkerKind.Slot,

--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -97,7 +97,7 @@ interface Marker {
   // string representing the actual intended comment value which makes
   // a bunch of stuff easier.
   text: string;
-  startNode: Comment;
+  startNode: Comment | null;
   endNode: Comment | null;
 }
 
@@ -190,7 +190,7 @@ function _walkInner(
           }
 
           // Remove markers
-          marker.startNode.remove();
+          marker.startNode?.remove();
           sib = sib.nextSibling;
           marker.endNode.remove();
           continue;
@@ -203,12 +203,46 @@ function _walkInner(
 
             let child: Node | null = marker.startNode;
             while (
-              (child = child.nextSibling) !== null && child !== marker.endNode
+              (child = child!.nextSibling) !== null && child !== marker.endNode
             ) {
               children.push(child);
             }
 
-            const vnode = vnodeStack.pop();
+            const vnode = vnodeStack[vnodeStack.length - 1];
+
+            if (vnode.props.children == null) {
+              const [id, exportName, n] = comment.slice("/frsh-".length).split(
+                ":",
+              );
+
+              const sel = `#frsh-slot-${id}-${exportName}-${n}-children`;
+              const template = document.querySelector(sel) as
+                | HTMLTemplateElement
+                | null;
+
+              console.log(marker, sel, template);
+
+              if (template !== null) {
+                markerStack.push({
+                  kind: MarkerKind.Slot,
+                  endNode: null,
+                  startNode: null,
+                  text: "foo",
+                });
+
+                const node = template.content.cloneNode(true);
+                _walkInner(
+                  islands,
+                  props,
+                  markerStack,
+                  vnodeStack,
+                  node,
+                );
+
+                markerStack.pop();
+              }
+            }
+            vnodeStack.pop();
 
             const parentNode = sib.parentNode! as HTMLElement;
 
@@ -242,7 +276,7 @@ function _walkInner(
               : setTimeout(_render, 0);
 
             // Remove markers
-            marker.startNode.remove();
+            marker.startNode?.remove();
             sib = sib.nextSibling;
             marker.endNode.remove();
             continue;

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -618,7 +618,6 @@ options.vnode = (vnode) => {
             children,
             markerText,
           );
-          console.log("MARKER", markerText);
           SLOTS_TRACKER.set(markerText, children);
           children = props.children;
           // deno-lint-ignore no-explicit-any

--- a/tests/fixture_island_nesting/fresh.gen.ts
+++ b/tests/fixture_island_nesting/fresh.gen.ts
@@ -4,49 +4,55 @@
 
 import * as $0 from "./routes/index.tsx";
 import * as $1 from "./routes/island_conditional.tsx";
-import * as $2 from "./routes/island_fn_child.tsx";
-import * as $3 from "./routes/island_in_island.tsx";
-import * as $4 from "./routes/island_in_island_definition.tsx";
-import * as $5 from "./routes/island_jsx_child.tsx";
-import * as $6 from "./routes/island_jsx_children.tsx";
-import * as $7 from "./routes/island_jsx_island_jsx.tsx";
-import * as $8 from "./routes/island_jsx_text.tsx";
-import * as $9 from "./routes/island_nested_props.tsx";
-import * as $10 from "./routes/island_order.tsx";
-import * as $11 from "./routes/island_siblings.tsx";
+import * as $2 from "./routes/island_conditional_lazy.tsx";
+import * as $3 from "./routes/island_conditional_lazy_island.tsx";
+import * as $4 from "./routes/island_fn_child.tsx";
+import * as $5 from "./routes/island_in_island.tsx";
+import * as $6 from "./routes/island_in_island_definition.tsx";
+import * as $7 from "./routes/island_jsx_child.tsx";
+import * as $8 from "./routes/island_jsx_children.tsx";
+import * as $9 from "./routes/island_jsx_island_jsx.tsx";
+import * as $10 from "./routes/island_jsx_text.tsx";
+import * as $11 from "./routes/island_nested_props.tsx";
+import * as $12 from "./routes/island_order.tsx";
+import * as $13 from "./routes/island_siblings.tsx";
 import * as $$0 from "./islands/BooleanButton.tsx";
-import * as $$1 from "./islands/FragmentIsland.tsx";
-import * as $$2 from "./islands/Island.tsx";
-import * as $$3 from "./islands/IslandCenter.tsx";
-import * as $$4 from "./islands/IslandConditional.tsx";
-import * as $$5 from "./islands/IslandFn.tsx";
-import * as $$6 from "./islands/IslandInsideIsland.tsx";
-import * as $$7 from "./islands/IslandWithProps.tsx";
+import * as $$1 from "./islands/Counter.tsx";
+import * as $$2 from "./islands/FragmentIsland.tsx";
+import * as $$3 from "./islands/Island.tsx";
+import * as $$4 from "./islands/IslandCenter.tsx";
+import * as $$5 from "./islands/IslandConditional.tsx";
+import * as $$6 from "./islands/IslandFn.tsx";
+import * as $$7 from "./islands/IslandInsideIsland.tsx";
+import * as $$8 from "./islands/IslandWithProps.tsx";
 
 const manifest = {
   routes: {
     "./routes/index.tsx": $0,
     "./routes/island_conditional.tsx": $1,
-    "./routes/island_fn_child.tsx": $2,
-    "./routes/island_in_island.tsx": $3,
-    "./routes/island_in_island_definition.tsx": $4,
-    "./routes/island_jsx_child.tsx": $5,
-    "./routes/island_jsx_children.tsx": $6,
-    "./routes/island_jsx_island_jsx.tsx": $7,
-    "./routes/island_jsx_text.tsx": $8,
-    "./routes/island_nested_props.tsx": $9,
-    "./routes/island_order.tsx": $10,
-    "./routes/island_siblings.tsx": $11,
+    "./routes/island_conditional_lazy.tsx": $2,
+    "./routes/island_conditional_lazy_island.tsx": $3,
+    "./routes/island_fn_child.tsx": $4,
+    "./routes/island_in_island.tsx": $5,
+    "./routes/island_in_island_definition.tsx": $6,
+    "./routes/island_jsx_child.tsx": $7,
+    "./routes/island_jsx_children.tsx": $8,
+    "./routes/island_jsx_island_jsx.tsx": $9,
+    "./routes/island_jsx_text.tsx": $10,
+    "./routes/island_nested_props.tsx": $11,
+    "./routes/island_order.tsx": $12,
+    "./routes/island_siblings.tsx": $13,
   },
   islands: {
     "./islands/BooleanButton.tsx": $$0,
-    "./islands/FragmentIsland.tsx": $$1,
-    "./islands/Island.tsx": $$2,
-    "./islands/IslandCenter.tsx": $$3,
-    "./islands/IslandConditional.tsx": $$4,
-    "./islands/IslandFn.tsx": $$5,
-    "./islands/IslandInsideIsland.tsx": $$6,
-    "./islands/IslandWithProps.tsx": $$7,
+    "./islands/Counter.tsx": $$1,
+    "./islands/FragmentIsland.tsx": $$2,
+    "./islands/Island.tsx": $$3,
+    "./islands/IslandCenter.tsx": $$4,
+    "./islands/IslandConditional.tsx": $$5,
+    "./islands/IslandFn.tsx": $$6,
+    "./islands/IslandInsideIsland.tsx": $$7,
+    "./islands/IslandWithProps.tsx": $$8,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/fixture_island_nesting/islands/Counter.tsx
+++ b/tests/fixture_island_nesting/islands/Counter.tsx
@@ -1,0 +1,10 @@
+import { Signal } from "@preact/signals";
+
+export default function Counter({ count }: { count: Signal<number> }) {
+  return (
+    <div>
+      <p class="count">{count}</p>
+      <button class="counter" onClick={() => count.value++}>update</button>
+    </div>
+  );
+}

--- a/tests/fixture_island_nesting/islands/IslandConditional.tsx
+++ b/tests/fixture_island_nesting/islands/IslandConditional.tsx
@@ -1,9 +1,17 @@
 import { Signal } from "@preact/signals";
+import { ComponentChildren } from "preact";
 
 export interface IslandConditionalProps {
   show: Signal<boolean>;
+  children?: ComponentChildren;
 }
 
-export default function IslandConditional({ show }: IslandConditionalProps) {
-  return show.value ? <>it works</> : null;
+export default function IslandConditional(
+  { show, children }: IslandConditionalProps,
+) {
+  return (
+    <div class="island">
+      {show.value ? <p>island content</p> : <>{children}</>}
+    </div>
+  );
 }

--- a/tests/fixture_island_nesting/routes/island_conditional_lazy.tsx
+++ b/tests/fixture_island_nesting/routes/island_conditional_lazy.tsx
@@ -1,0 +1,16 @@
+import IslandConditional from "../islands/IslandConditional.tsx";
+import BooleanButton from "../islands/BooleanButton.tsx";
+import { signal } from "@preact/signals";
+
+const show = signal(true);
+
+export default function Page() {
+  return (
+    <div id="page">
+      <IslandConditional show={show}>
+        <p>server rendered</p>
+      </IslandConditional>
+      <BooleanButton signal={show} />
+    </div>
+  );
+}

--- a/tests/fixture_island_nesting/routes/island_conditional_lazy_island.tsx
+++ b/tests/fixture_island_nesting/routes/island_conditional_lazy_island.tsx
@@ -1,0 +1,21 @@
+import IslandConditional from "../islands/IslandConditional.tsx";
+import BooleanButton from "../islands/BooleanButton.tsx";
+import { useSignal } from "@preact/signals";
+import Counter from "../islands/Counter.tsx";
+
+export default function Page() {
+  const show = useSignal(true);
+  const count = useSignal(0);
+
+  return (
+    <div id="page">
+      <IslandConditional show={show}>
+        <div>
+          <p class="server">server rendered</p>
+          <Counter count={count} />
+        </div>
+      </IslandConditional>
+      <BooleanButton signal={show} />
+    </div>
+  );
+}

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -478,7 +478,7 @@ Deno.test({
 Deno.test({
   name: "render nested islands with server children conditionally",
 
-  async fn(_t) {
+  async fn() {
     await withPageName(
       "./tests/fixture_island_nesting/main.ts",
       async (page, address) => {
@@ -490,15 +490,12 @@ Deno.test({
       },
     );
   },
-
-  sanitizeOps: false,
-  sanitizeResources: false,
 });
 
 Deno.test({
   name: "revive island in lazy server rendered children conditionally",
 
-  async fn(_t) {
+  async fn() {
     await withPageName(
       "./tests/fixture_island_nesting/main.ts",
       async (page, address) => {
@@ -513,7 +510,4 @@ Deno.test({
       },
     );
   },
-
-  sanitizeOps: false,
-  sanitizeResources: false,
 });

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -478,3 +478,46 @@ Deno.test({
   sanitizeOps: false,
   sanitizeResources: false,
 });
+
+Deno.test({
+  name: "render nested islands with server children conditionally",
+
+  async fn(_t) {
+    await withPageName(
+      "./tests/fixture_island_nesting/main.ts",
+      async (page, address) => {
+        await page.goto(`${address}/island_conditional_lazy`);
+        await waitForText(page, ".island p", "island content");
+
+        await page.click("button");
+        await waitForText(page, ".island p", "server rendered");
+      },
+    );
+  },
+
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "revive island in lazy server rendered children conditionally",
+
+  async fn(_t) {
+    await withPageName(
+      "./tests/fixture_island_nesting/main.ts",
+      async (page, address) => {
+        await page.goto(`${address}/island_conditional_lazy_island`);
+        await waitForText(page, ".island p", "island content");
+
+        await page.click("button");
+        await waitForText(page, ".island .server", "server rendered");
+
+        await page.click("button.counter");
+        await waitForText(page, ".island .count", "1");
+      },
+    );
+  },
+
+  sanitizeOps: false,
+  sanitizeResources: false,
+});

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -406,14 +406,10 @@ Deno.test({
         await delay(100);
         await page.click("button");
 
-        const text = await page.$eval(
-          "#page",
-          (el) => el.textContent,
-        );
         // Button text is matched too, but this allows us
-        // to assert correct ordering. The "it works" should
+        // to assert correct ordering. The "island content" should
         // be left of "Toggle"
-        assertEquals(text, "it worksToggle");
+        await waitForText(page, "#page", "island contentToggle");
       },
     );
   },


### PR DESCRIPTION
This PR address the scenario where a server rendered JSX tree is passed to an island but isn't rendered initially in the client. In that case we cannot reconstruct it from the DOM alone and some form of serialization is needed. This PR stores the not rendered children part in a `<template>` tag so that it can be revived in the client.

This PR is based on #1324.

Fixes #1322 