### PR TITLE
ref: Make default error page container flexible to fit all content

### DIFF
--- a/src/server/default_error_page.ts
+++ b/src/server/default_error_page.ts
@@ -33,7 +33,6 @@ export default function DefaultErrorPage(props: ErrorPageProps) {
           background: "#f9fafb",
           margin: 16,
           minWidth: "300px",
-          width: "50%",
         },
       },
       h("p", {


### PR DESCRIPTION
Flex container will take care of the rest; centering, padding, and making it not expand unnecessarily.

Too wide container (centered):
<img width="1728" alt="image" src="https://github.com/denoland/fresh/assets/1523305/8d4ee8fa-0854-4eaa-8ef5-d869742d69dc">

Too narrow container (padded):
<img width="666" alt="image" src="https://github.com/denoland/fresh/assets/1523305/48b2ab40-9943-4068-a376-222b1cc2919c">

Fixes https://github.com/denoland/fresh/issues/1344