### PR TITLE
docs: add "Handling complex routes" example

### DIFF
--- a/docs/examples/handling-complex-routes.md
+++ b/docs/examples/handling-complex-routes.md
@@ -36,15 +36,16 @@ Now if we hit the server with a request like
 show the following:
 
 ```
-module: 'bestModule'
-version: '1.33.7'
-path: 'qqqqqqq'
+{
+  module: "bestModule",
+  version: "1.33.7",
+  path: "asdf"
+}
 ```
 
 ## Complex Route Config
 
-Let's look at something a bit more complex. Issue 587 brings up the following
-example:
+Let's look at something a bit more complex:
 
 ```ts
 import { HandlerContext, RouteConfig } from "$fresh/server.ts";

--- a/docs/examples/handling-complex-routes.md
+++ b/docs/examples/handling-complex-routes.md
@@ -1,0 +1,86 @@
+---
+description: |
+  Sometimes URL based routing isn't enough.
+---
+
+The page on [routing](/concepts/routing) hints at complex routing based on URL
+patterns using a `RouteConfig` object. Let's dive into this in a bit more
+detail.
+
+A `RouteConfig` has a `routeOverride` string property, which makes use of the
+[URL Pattern API](https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API).
+Here you can define named groups, wildcards, regex groups, and other bits.
+
+## Simple Route Config
+
+Let's look at the example from the routing page more closely. We'll flesh out
+the handler so that we end up with something like the following:
+
+```ts
+import { HandlerContext, RouteConfig } from "$fresh/server.ts";
+
+export const handler = {
+  GET(_req: Request, { params }: HandlerContext) {
+    console.log(params);
+    return new Response(params.path);
+  },
+};
+
+export const config: RouteConfig = {
+  routeOverride: "/x/:module@:version/:path*",
+};
+```
+
+Now if we hit the server with a request like
+`http://localhost:8000/x/bestModule@1.33.7/asdf`, then logging the params will
+show the following:
+
+```
+module: 'bestModule'
+version: '1.33.7'
+path: 'qqqqqqq'
+```
+
+## Complex Route Config
+
+Let's look at something a bit more complex. Issue 587 brings up the following
+example:
+
+```ts
+import { HandlerContext, RouteConfig } from "$fresh/server.ts";
+
+export const handler = {
+  GET(_req: Request, { params }: HandlerContext) {
+    console.log(params);
+    return new Response(params.path);
+  },
+};
+
+export const config: RouteConfig = {
+  routeOverride: "/api/db/:resource(jobs?|bar)/:id(\\d+)?",
+};
+```
+
+Values are available via `params.resource` and `params.id`.
+
+Here are some example URLs that match this:
+
+- /api/db/bar/1
+- /api/db/jobs/1
+- /api/db/job/1
+- /api/db/job
+- /api/db/jobs
+- /api/db/bar
+
+Here are some that don't:
+
+- /api/db/other/123
+- /api/db/jobs/abc
+- /api/db
+
+## Regex
+
+At this point is should be clear that this is essentially an exercise in
+understanding regex. There are [numerous](https://regexr.com/)
+[resources](https://regex101.com/) [available](https://chat.openai.com/) for
+getting assistance with regex.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -16,3 +16,4 @@ like to see here, please open
 - [Using Fresh canary version](./examples/using-fresh-canary-version)
 - [Dealing with CORS](./examples/dealing-with-cors)
 - [Creating a CRUD API](./examples/creating-a-crud-api)
+- [Handling complex routes](./examples/handling-complex-routes)

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -49,7 +49,8 @@
       ["init-the-server", "Initializing the server"],
       ["using-fresh-canary-version", "Using Fresh canary version"],
       ["dealing-with-cors", "Dealing with CORS"],
-      ["creating-a-crud-api", "Creating a CRUD API"]
+      ["creating-a-crud-api", "Creating a CRUD API"],
+      ["handling-complex-routes", "Handling complex routes"]
     ]
   }
 }


### PR DESCRIPTION
In my quest for understanding, I wanted to understand how `RouteConfig` works. I noticed there wasn't an example about using `routeOverride`, so I decided to document what I learned. I've included two sample routes in increasing order of complexity. Let me know if I'm missing something or if there are any changes. Nothing suggestion is too nitpicky!