### PR TITLE
fix(test): cli_test now retries to move files

### DIFF
--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -376,20 +376,22 @@ Deno.test("fresh-update", async function fn(t) {
     try {
       Deno.mkdirSync(tmpDirName + "/src");
       names.forEach((x) => {
-        Deno.rename(path.join(tmpDirName, x), path.join(tmpDirName, "src", x));
+        Deno.renameSync(
+          path.join(tmpDirName, x),
+          path.join(tmpDirName, "src", x),
+        );
       });
       await updateAndVerify(
         /The manifest has been generated for (?!0 routes and 0 islands)\d+ routes and \d+ islands./,
       );
     } finally {
-      // converted to for loop because forEach doesn't wait for promises
-      // needed to add retry here on the rename operations to fix random failures
-      for (const x of names) {
-        await retry(() =>
-          Deno.rename(path.join(tmpDirName, "src", x), path.join(tmpDirName, x))
+      names.forEach((x) => {
+        Deno.renameSync(
+          path.join(tmpDirName, "src", x),
+          path.join(tmpDirName, x),
         );
-      }
-      await retry(() => Deno.remove(tmpDirName + "/src", { recursive: true }));
+      });
+      Deno.removeSync(tmpDirName + "/src", { recursive: true });
     }
   });
 

--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -382,9 +382,13 @@ Deno.test("fresh-update", async function fn(t) {
         /The manifest has been generated for (?!0 routes and 0 islands)\d+ routes and \d+ islands./,
       );
     } finally {
-      names.forEach((x) => {
-        Deno.rename(path.join(tmpDirName, "src", x), path.join(tmpDirName, x));
-      });
+      // converted to for loop because forEach doesn't wait for promises
+      // needed to add retry here on the rename operations to fix random failures
+      for (const x of names) {
+        await retry(() =>
+          Deno.rename(path.join(tmpDirName, "src", x), path.join(tmpDirName, x))
+        );
+      }
       await retry(() => Deno.remove(tmpDirName + "/src", { recursive: true }));
     }
   });


### PR DESCRIPTION
closes https://github.com/denoland/fresh/issues/1371

```
Test run completed. 100 runs, 0 failures.
```

If anyone is curious about the file in `deno run --unstable --allow-run flaky_test_tester.ts`, it looks like this:
```ts
async function main() {
  const runs = 100;
  let failures = 0;

  for (let i = 0; i < runs; i++) {
    console.log(`Run #${i + 1}`);

    const command = new Deno.Command("deno", {
      args: ["task", "test"],
    });

    const result = await command.output();

    const textDecoder = new TextDecoder();
    const stdout = textDecoder.decode(result.stdout);
    const stderr = textDecoder.decode(result.stderr);

    await Deno.writeTextFile(`run${i + 1}.log`, stdout);

    if (!result.success) {
      console.log("Test failed with error:", stderr);
      failures++;
    }
  }

  console.log(`Test run completed. ${runs} runs, ${failures} failures.`);
}

main();
```