### PR TITLE
feat(starter): always initialize _app.tsx

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -401,8 +401,18 @@ html {
 }
 `;
 
-const NO_TWIND_APP_WRAPPER = `
-import { AppProps } from "$fresh/server.ts";
+const APP_WRAPPER = useTwind
+  ? `import { AppProps } from "$fresh/server.ts";
+
+export default function App({ Component }: AppProps) {
+  return (
+    <>
+      <Component />
+    </>
+  );
+}
+`
+  : `import { AppProps } from "$fresh/server.ts";
 import { Head } from "$fresh/runtime.ts";
 
 export default function App({ Component }: AppProps) {
@@ -422,12 +432,12 @@ if (!useTwind) {
     join(resolvedDirectory, "static", "styles.css"),
     NO_TWIND_STYLES,
   );
-
-  await Deno.writeTextFile(
-    join(resolvedDirectory, "routes", "_app.tsx"),
-    NO_TWIND_APP_WRAPPER,
-  );
 }
+
+await Deno.writeTextFile(
+  join(resolvedDirectory, "routes", "_app.tsx"),
+  APP_WRAPPER,
+);
 
 const STATIC_LOGO =
   `<svg width="40" height="40" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -53,6 +53,7 @@ Deno.test({
       `/main.ts`,
       `/routes/greet/[name].tsx`,
       `/routes/api/joke.ts`,
+      `/routes/_app.tsx`,
       `/routes/index.tsx`,
       `/static/logo.svg`,
     ];
@@ -138,6 +139,7 @@ Deno.test({
       "/main.ts",
       "/routes/greet/[name].tsx",
       "/routes/api/joke.ts",
+      "/routes/_app.tsx",
       "/routes/index.tsx",
       "/static/logo.svg",
       "/.vscode/settings.json",


### PR DESCRIPTION
https://github.com/denoland/fresh/pull/1320 introduced `_app.tsx` when not using twind. This PR makes it so that `_app.tsx` is always initialized. There was recently a [discussion](https://discord.com/channels/684898665143206084/991511118524715139/1124360575074455604) in discord about this, and there's some confusion about layouts/templates. I thought I would take a look, and was surprised to see that we _do_ initialize `_app.tsx`, but not in all cases.

When using twind, we now produce a nice boring `_app.tsx` for people like this:
```tsx
import { AppProps } from "$fresh/server.ts";

export default function App({ Component }: AppProps) {
  return (
    <>
      <Component />
    </>
  );
}
```

Additionally, I noticed that there was a blank line at the top of `_app.tsx` when not using twind; I removed that line here.