### PR TITLE
fix: update import map to satisfy vs code

### DIFF
--- a/.vscode/import_map.json
+++ b/.vscode/import_map.json
@@ -13,6 +13,7 @@
     "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.2.3",
     "@preact/signals-core@1.2.3": "https://esm.sh/@preact/signals-core@1.2.3",
     "@preact/signals-core@1.3.0": "https://esm.sh/@preact/signals-core@1.3.0",
-    "$std/": "https://deno.land/std@0.190.0/"
+    "$std/": "https://deno.land/std@0.190.0/",
+    "$ga4": "https://raw.githubusercontent.com/denoland/ga4/main/mod.ts"
   }
 }


### PR DESCRIPTION
As I was working on 1381 I needed to debug something in `www`. So I went to `www/dev.ts`, hit F5, and was promptly greeted with the following lovely message:
```
/usr/local/bin/deno run --import-map ./.vscode/import_map.json --inspect-wait --allow-all ./www/dev.ts
The manifest has been generated for 10 routes and 5 islands.
mod.ts:129
Uncaught TypeError TypeError: Relative import path "$ga4" not prefixed with / or ./ or ../ and not in import map from "file:///Users/reed/code/fresh/www/routes/_middleware.ts"Debugger listening on ws://127.0.0.1:9229/ws/52d919e4-6c10-464f-acfc-b4613faf48e5
Visit chrome://inspect to connect to the debugger.
Deno is waiting for debugger to connect.
Debugger session started.
error: Uncaught (in promise) TypeError: Relative import path "$ga4" not prefixed with / or ./ or ../ and not in import map from "file:///Users/reed/code/fresh/www/routes/_middleware.ts"
    at file:///Users/reed/code/fresh/www/routes/_middleware.ts:3:54
  await import(entrypoint);
  ^
    at async dev (file:///Users/reed/code/fresh/src/dev/mod.ts:158:3)
    at async file:///Users/reed/code/fresh/www/dev.ts:5:1
Process exited with code 1
```

Of course it happily starts from the command line, but vs code is special. But if we update the `.vscode/import_map.json` like so, then it will happily start. This also makes the dreaded red squiggles in `www/routes/_middleware.ts` go away.