### PR TITLE
fix(showcase): reorder to have blank entry at the bottom

### DIFF
--- a/www/data/showcase.json
+++ b/www/data/showcase.json
@@ -342,15 +342,15 @@
     "image": "uspb"
   },
   {
-    "title": "Do not remove this, it's for prevent conflicting by trailing comma",
-    "link": "",
-    "github": "",
-    "image": ""
-  },
-  {
     "title": "Battleship",
     "link": "https://battleship.deno.dev",
     "github": "karelklima/battleship",
     "image": "battleship"
+  },
+  {
+    "title": "Do not remove this, it's for preventing conflicts by trailing comma",
+    "link": "",
+    "github": "",
+    "image": ""
   }
 ]


### PR DESCRIPTION
Looks like the battleship entry (which is very cool!) displaced the special blank entry at the bottom. This reorders things correctly. I also snuck in a very small change to the blank entry to improve the grammar:
`... for prevent conflicting by ...` -> `... for preventing conflicts by ...`