### PR TITLE
fix(server): properly sanitize island names

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -931,7 +931,7 @@ function toPascalCase(text: string): string {
 }
 
 function sanitizeIslandName(name: string): string {
-  const fileName = name.replace("/", "");
+  const fileName = name.replace(/\//g, "_");
   return toPascalCase(fileName);
 }
 

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -931,7 +931,7 @@ function toPascalCase(text: string): string {
 }
 
 function sanitizeIslandName(name: string): string {
-  const fileName = name.replace(/\//g, "_");
+  const fileName = name.replaceAll("/", "_");
   return toPascalCase(fileName);
 }
 

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -43,7 +43,8 @@ import * as $$2 from "./islands/RootFragment.tsx";
 import * as $$3 from "./islands/RootFragmentWithConditionalFirst.tsx";
 import * as $$4 from "./islands/Test.tsx";
 import * as $$5 from "./islands/folder/Counter.tsx";
-import * as $$6 from "./islands/kebab-case-counter-test.tsx";
+import * as $$6 from "./islands/folder/subfolder/Counter.tsx";
+import * as $$7 from "./islands/kebab-case-counter-test.tsx";
 
 const manifest = {
   routes: {
@@ -90,7 +91,8 @@ const manifest = {
     "./islands/RootFragmentWithConditionalFirst.tsx": $$3,
     "./islands/Test.tsx": $$4,
     "./islands/folder/Counter.tsx": $$5,
-    "./islands/kebab-case-counter-test.tsx": $$6,
+    "./islands/folder/subfolder/Counter.tsx": $$6,
+    "./islands/kebab-case-counter-test.tsx": $$7,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/fixture/islands/folder/subfolder/Counter.tsx
+++ b/tests/fixture/islands/folder/subfolder/Counter.tsx
@@ -1,0 +1,22 @@
+import type { Signal } from "@preact/signals";
+import { IS_BROWSER } from "$fresh/runtime.ts";
+
+interface CounterProps {
+  count: Signal<number>;
+  id: string;
+}
+
+export default function Counter(props: CounterProps) {
+  return (
+    <div id={props.id}>
+      <p>{props.count}</p>
+      <button
+        id={`b-${props.id}`}
+        onClick={() => props.count.value += 1}
+        disabled={!IS_BROWSER}
+      >
+        +1
+      </button>
+    </div>
+  );
+}

--- a/tests/fixture/routes/islands/index.tsx
+++ b/tests/fixture/routes/islands/index.tsx
@@ -1,6 +1,7 @@
 import { useSignal } from "@preact/signals";
 import Counter from "../../islands/Counter.tsx";
 import FolderCounter from "../../islands/folder/Counter.tsx";
+import SubfolderCounter from "../../islands/folder/subfolder/Counter.tsx";
 import KebabCaseFileNameTest from "../../islands/kebab-case-counter-test.tsx";
 import Test from "../../islands/Test.tsx";
 
@@ -10,6 +11,7 @@ export default function Home() {
       <Counter id="counter1" count={useSignal(3)} />
       <Counter id="counter2" count={useSignal(10)} />
       <FolderCounter id="folder-counter" count={useSignal(3)} />
+      <SubfolderCounter id="subfolder-counter" count={useSignal(3)} />
       <KebabCaseFileNameTest
         id="kebab-case-file-counter"
         count={useSignal(5)}

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -30,10 +30,11 @@ Deno.test({
         waitUntil: "networkidle2",
       });
 
-      await t.step("Ensure 4 islands on 1 page are revived", async () => {
+      await t.step("Ensure 5 islands on 1 page are revived", async () => {
         await counterTest("counter1", 3);
         await counterTest("counter2", 10);
         await counterTest("folder-counter", 3);
+        await counterTest("subfolder-counter", 3);
         await counterTest("kebab-case-file-counter", 5);
       });
 


### PR DESCRIPTION
closes https://github.com/denoland/fresh/issues/1391

This was interesting to debug. I was able to reproduce the case and saw the following in the `sources` tab:
```js
const ST = document.getElementById("__FRSH_STATE").textContent;const STATE = JSON.parse(ST).v;import { revive } from "/_frsh/js/546c8cc610e5f6749bbb353f6c3518c35ac0ff22/main.js";import Firstsecond/DoubleNested from "/_frsh/js/546c8cc610e5f6749bbb353f6c3518c35ac0ff22/island-firstsecond/doublenested.js";revive({firstsecond/doublenested:Firstsecond/DoubleNested,}, STATE[0]);
```

That's not good, variables shouldn't have slashes in them!

After a bit of hunting, eventually found this block:
```ts
const path = url.substring(baseUrl.length).substring("islands".length);
const baseRoute = path.substring(1, path.length - extname(path).length);
const name = sanitizeIslandName(baseRoute);
const id = name.toLowerCase();
if (typeof module.default !== "function") {
  throw new TypeError(
    `Islands must default export a component ('${self}').`,
  );
}
islands.push({ id, name, url, component: module.default });
```
which is making the actual islands.

Turns out we're not sanitizing correctly.
```ts
function sanitizeIslandName(name: string): string {
  const fileName = name.replace("/", "");
  return toPascalCase(fileName);
}
```
This is only going to strip the first slash. After 1185 was merged, we might have many slashes. I applied a fix, and then I got the following:
```js
const ST = document.getElementById("__FRSH_STATE").textContent;const STATE = JSON.parse(ST).v;import { revive } from "/_frsh/js/2e0bfa95a39161dcd4b0c6dd1bb7d0c02fadf6a5/main.js";import First_second_DoubleNested from "/_frsh/js/2e0bfa95a39161dcd4b0c6dd1bb7d0c02fadf6a5/island-first_second_doublenested.js";revive({first_second_doublenested:First_second_DoubleNested,}, STATE[0]);
```
This looks better and makes the errors go away in the browser's console. Adding a test case and reverting my fix causes the test to fail. Reapplying the fix causes the new test to pass. 🙌 