### PR TITLE
feat(server): multiple island exports

### DIFF
--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -47,8 +47,11 @@ function isElementNode(node: Node): node is HTMLElement {
   return node.nodeType === Node.ELEMENT_NODE;
 }
 
-// deno-lint-ignore no-explicit-any
-export function revive(islands: Record<string, ComponentType>, props: any[]) {
+export function revive(
+  islands: Record<string, Record<string, ComponentType>>,
+  // deno-lint-ignore no-explicit-any
+  props: any[],
+) {
   _walkInner(
     islands,
     props,
@@ -127,7 +130,7 @@ interface Marker {
  * fashion over an HTMLElement's children list.
  */
 function _walkInner(
-  islands: Record<string, ComponentType>,
+  islands: Record<string, Record<string, ComponentType>>,
   // deno-lint-ignore no-explicit-any
   props: any[],
   markerStack: Marker[],
@@ -253,7 +256,7 @@ function _walkInner(
         }
       } else if (comment.startsWith("frsh")) {
         // We're opening a new island
-        const [id, n] = comment.slice(5).split(":");
+        const [id, exportName, n] = comment.slice(5).split(":");
         const islandProps = props[Number(n)];
 
         markerStack.push({
@@ -262,7 +265,7 @@ function _walkInner(
           text: comment,
           kind: MarkerKind.Island,
         });
-        const vnode = h(islands[id], islandProps);
+        const vnode = h(islands[id][exportName], islandProps);
         vnodeStack.push(vnode);
       }
     } else if (isTextNode(sib)) {

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -281,14 +281,21 @@ export class ServerContext {
       }
       const path = url.substring(baseUrl.length).substring("islands".length);
       const baseRoute = path.substring(1, path.length - extname(path).length);
-      const name = sanitizeIslandName(baseRoute);
-      const id = name.toLowerCase();
-      if (typeof module.default !== "function") {
-        throw new TypeError(
-          `Islands must default export a component ('${self}').`,
-        );
+
+      for (const [exportName, exportedFunction] of Object.entries(module)) {
+        if (typeof exportedFunction !== "function") {
+          continue;
+        }
+        const name = sanitizeIslandName(baseRoute);
+        const id = `${name}_${exportName}`.toLowerCase();
+        islands.push({
+          id,
+          name,
+          url,
+          component: exportedFunction,
+          exportName,
+        });
       }
-      islands.push({ id, name, url, component: module.default });
     }
 
     const staticFiles: StaticFile[] = [];

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -350,8 +350,9 @@ export async function render<Data>(
     let islandRegistry = "";
     for (const island of ENCOUNTERED_ISLANDS) {
       const url = addImport(`island-${island.id}.js`);
-      script += `import ${island.name} from "${url}";`;
-      islandRegistry += `${island.id}:${island.name},`;
+      script +=
+        `import * as ${island.name}_${island.exportName} from "${url}";`;
+      islandRegistry += `${island.id}:${island.name}_${island.exportName},`;
     }
     script += `revive({${islandRegistry}}, STATE[0]);`;
   }
@@ -536,7 +537,7 @@ options.vnode = (vnode) => {
 
         return wrapWithMarker(
           child,
-          `frsh-${island.id}:${ISLAND_PROPS.length - 1}`,
+          `frsh-${island.id}:${island.exportName}:${ISLAND_PROPS.length - 1}`,
         );
       };
     }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -262,7 +262,7 @@ export interface Middleware<State = Record<string, unknown>> {
 
 export interface IslandModule {
   // deno-lint-ignore no-explicit-any
-  default: ComponentType<any>;
+  [key: string]: ComponentType<any>;
 }
 
 export interface Island {
@@ -270,6 +270,7 @@ export interface Island {
   name: string;
   url: string;
   component: ComponentType<unknown>;
+  exportName: string;
 }
 
 // --- PLUGINS ---

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -18,33 +18,35 @@ import * as $12 from "./routes/index.tsx";
 import * as $13 from "./routes/intercept.tsx";
 import * as $14 from "./routes/intercept_args.tsx";
 import * as $15 from "./routes/islands/index.tsx";
-import * as $16 from "./routes/islands/returning_null.tsx";
-import * as $17 from "./routes/islands/root_fragment.tsx";
-import * as $18 from "./routes/islands/root_fragment_conditional_first.tsx";
-import * as $19 from "./routes/layeredMdw/_middleware.ts";
-import * as $20 from "./routes/layeredMdw/layer2-no-mw/without_mw.ts";
-import * as $21 from "./routes/layeredMdw/layer2/_middleware.ts";
-import * as $22 from "./routes/layeredMdw/layer2/abc.ts";
-import * as $23 from "./routes/layeredMdw/layer2/index.ts";
-import * as $24 from "./routes/layeredMdw/layer2/layer3/[id].ts";
-import * as $25 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
-import * as $26 from "./routes/middleware_root.ts";
-import * as $27 from "./routes/not_found.ts";
-import * as $28 from "./routes/params.tsx";
-import * as $29 from "./routes/props/[id].tsx";
-import * as $30 from "./routes/state-in-props/_middleware.ts";
-import * as $31 from "./routes/state-in-props/index.tsx";
-import * as $32 from "./routes/static.tsx";
-import * as $33 from "./routes/status_overwrite.tsx";
-import * as $34 from "./routes/wildcard.tsx";
+import * as $16 from "./routes/islands/multiple_island_exports.tsx";
+import * as $17 from "./routes/islands/returning_null.tsx";
+import * as $18 from "./routes/islands/root_fragment.tsx";
+import * as $19 from "./routes/islands/root_fragment_conditional_first.tsx";
+import * as $20 from "./routes/layeredMdw/_middleware.ts";
+import * as $21 from "./routes/layeredMdw/layer2-no-mw/without_mw.ts";
+import * as $22 from "./routes/layeredMdw/layer2/_middleware.ts";
+import * as $23 from "./routes/layeredMdw/layer2/abc.ts";
+import * as $24 from "./routes/layeredMdw/layer2/index.ts";
+import * as $25 from "./routes/layeredMdw/layer2/layer3/[id].ts";
+import * as $26 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
+import * as $27 from "./routes/middleware_root.ts";
+import * as $28 from "./routes/not_found.ts";
+import * as $29 from "./routes/params.tsx";
+import * as $30 from "./routes/props/[id].tsx";
+import * as $31 from "./routes/state-in-props/_middleware.ts";
+import * as $32 from "./routes/state-in-props/index.tsx";
+import * as $33 from "./routes/static.tsx";
+import * as $34 from "./routes/status_overwrite.tsx";
+import * as $35 from "./routes/wildcard.tsx";
 import * as $$0 from "./islands/Counter.tsx";
-import * as $$1 from "./islands/ReturningNull.tsx";
-import * as $$2 from "./islands/RootFragment.tsx";
-import * as $$3 from "./islands/RootFragmentWithConditionalFirst.tsx";
-import * as $$4 from "./islands/Test.tsx";
-import * as $$5 from "./islands/folder/Counter.tsx";
-import * as $$6 from "./islands/folder/subfolder/Counter.tsx";
-import * as $$7 from "./islands/kebab-case-counter-test.tsx";
+import * as $$1 from "./islands/MultipleCounters.tsx";
+import * as $$2 from "./islands/ReturningNull.tsx";
+import * as $$3 from "./islands/RootFragment.tsx";
+import * as $$4 from "./islands/RootFragmentWithConditionalFirst.tsx";
+import * as $$5 from "./islands/Test.tsx";
+import * as $$6 from "./islands/folder/Counter.tsx";
+import * as $$7 from "./islands/folder/subfolder/Counter.tsx";
+import * as $$8 from "./islands/kebab-case-counter-test.tsx";
 
 const manifest = {
   routes: {
@@ -64,35 +66,37 @@ const manifest = {
     "./routes/intercept.tsx": $13,
     "./routes/intercept_args.tsx": $14,
     "./routes/islands/index.tsx": $15,
-    "./routes/islands/returning_null.tsx": $16,
-    "./routes/islands/root_fragment.tsx": $17,
-    "./routes/islands/root_fragment_conditional_first.tsx": $18,
-    "./routes/layeredMdw/_middleware.ts": $19,
-    "./routes/layeredMdw/layer2-no-mw/without_mw.ts": $20,
-    "./routes/layeredMdw/layer2/_middleware.ts": $21,
-    "./routes/layeredMdw/layer2/abc.ts": $22,
-    "./routes/layeredMdw/layer2/index.ts": $23,
-    "./routes/layeredMdw/layer2/layer3/[id].ts": $24,
-    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $25,
-    "./routes/middleware_root.ts": $26,
-    "./routes/not_found.ts": $27,
-    "./routes/params.tsx": $28,
-    "./routes/props/[id].tsx": $29,
-    "./routes/state-in-props/_middleware.ts": $30,
-    "./routes/state-in-props/index.tsx": $31,
-    "./routes/static.tsx": $32,
-    "./routes/status_overwrite.tsx": $33,
-    "./routes/wildcard.tsx": $34,
+    "./routes/islands/multiple_island_exports.tsx": $16,
+    "./routes/islands/returning_null.tsx": $17,
+    "./routes/islands/root_fragment.tsx": $18,
+    "./routes/islands/root_fragment_conditional_first.tsx": $19,
+    "./routes/layeredMdw/_middleware.ts": $20,
+    "./routes/layeredMdw/layer2-no-mw/without_mw.ts": $21,
+    "./routes/layeredMdw/layer2/_middleware.ts": $22,
+    "./routes/layeredMdw/layer2/abc.ts": $23,
+    "./routes/layeredMdw/layer2/index.ts": $24,
+    "./routes/layeredMdw/layer2/layer3/[id].ts": $25,
+    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $26,
+    "./routes/middleware_root.ts": $27,
+    "./routes/not_found.ts": $28,
+    "./routes/params.tsx": $29,
+    "./routes/props/[id].tsx": $30,
+    "./routes/state-in-props/_middleware.ts": $31,
+    "./routes/state-in-props/index.tsx": $32,
+    "./routes/static.tsx": $33,
+    "./routes/status_overwrite.tsx": $34,
+    "./routes/wildcard.tsx": $35,
   },
   islands: {
     "./islands/Counter.tsx": $$0,
-    "./islands/ReturningNull.tsx": $$1,
-    "./islands/RootFragment.tsx": $$2,
-    "./islands/RootFragmentWithConditionalFirst.tsx": $$3,
-    "./islands/Test.tsx": $$4,
-    "./islands/folder/Counter.tsx": $$5,
-    "./islands/folder/subfolder/Counter.tsx": $$6,
-    "./islands/kebab-case-counter-test.tsx": $$7,
+    "./islands/MultipleCounters.tsx": $$1,
+    "./islands/ReturningNull.tsx": $$2,
+    "./islands/RootFragment.tsx": $$3,
+    "./islands/RootFragmentWithConditionalFirst.tsx": $$4,
+    "./islands/Test.tsx": $$5,
+    "./islands/folder/Counter.tsx": $$6,
+    "./islands/folder/subfolder/Counter.tsx": $$7,
+    "./islands/kebab-case-counter-test.tsx": $$8,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/fixture/islands/MultipleCounters.tsx
+++ b/tests/fixture/islands/MultipleCounters.tsx
@@ -1,0 +1,30 @@
+import type { Signal } from "@preact/signals";
+import { IS_BROWSER } from "$fresh/runtime.ts";
+
+interface CounterProps {
+  count: Signal<number>;
+  id: string;
+}
+
+export default function CounterZero(props: CounterProps) {
+  return (
+    <div id={props.id}>
+      <p>{props.count}</p>
+      <button
+        id={`b-${props.id}`}
+        onClick={() => props.count.value += 1}
+        disabled={!IS_BROWSER}
+      >
+        +1
+      </button>
+    </div>
+  );
+}
+
+export function CounterOne(props: CounterProps) {
+  return CounterZero(props);
+}
+
+export function CounterTwo(props: CounterProps) {
+  return CounterZero(props);
+}

--- a/tests/fixture/routes/islands/multiple_island_exports.tsx
+++ b/tests/fixture/routes/islands/multiple_island_exports.tsx
@@ -1,0 +1,15 @@
+import { useSignal } from "@preact/signals";
+import CounterZero from "../../islands/MultipleCounters.tsx";
+import { CounterOne, CounterTwo } from "../../islands/MultipleCounters.tsx";
+import SubfolderCounter from "../../islands/folder/subfolder/Counter.tsx";
+
+export default function Home() {
+  return (
+    <div>
+      <CounterZero id="counter0" count={useSignal(4)} />
+      <CounterOne id="counter1" count={useSignal(3)} />
+      <CounterTwo id="counter2" count={useSignal(10)} />
+      <SubfolderCounter id="counter3" count={useSignal(4)} />
+    </div>
+  );
+}

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -22,7 +22,7 @@ Deno.test("/ page prerender", async () => {
   assertEquals(resp.headers.get("server"), "fresh test server");
   const body = await resp.text();
   assertStringIncludes(body, `<html lang="en">`);
-  assertStringIncludes(body, "test.js");
+  assertStringIncludes(body, "test_default.js");
   assertStringIncludes(body, "<p>Hello!</p>");
   assertStringIncludes(body, "<p>Viewing JIT render.</p>");
   assertStringIncludes(body, `>{"v":[[{"message":"Hello!"}],[]]}</script>`);
@@ -637,7 +637,7 @@ Deno.test("experimental Deno.serve", {
     assertEquals(resp.headers.get("server"), "fresh test server");
     const body = await resp.text();
     assertStringIncludes(body, `<html lang="en">`);
-    assertStringIncludes(body, "test.js");
+    assertStringIncludes(body, "test_default.js");
     assertStringIncludes(body, "<p>Hello!</p>");
     assertStringIncludes(body, "<p>Viewing JIT render.</p>");
     assertStringIncludes(body, `>{"v":[[{"message":"Hello!"}],[]]}</script>`);


### PR DESCRIPTION
closes https://github.com/denoland/fresh/issues/1394

I'm not sure if there's a good reason we had this code:
```ts
throw new TypeError(
  `Islands must default export a component ('${self}').`,
);
```
other than the fact that we just didn't get around to improving it. If so, then consider this the improvement 😄 

This stuff was all a bit confusing at first, but I suppose it makes sense now. The basic approach is to start keeping track of the `exportName` for the island, and looping over all the exports of the module. Then we need to pass the `exportName` out to the client as well.

This change has the breaking effect of changing the client code we emit. This is visible in the diff to `main_test` where the asserted name goes from `test.js` to `test_default.js`. But this isn't part of the API, so people shouldn't be doing anything with this. If they are, they'll have to switch 😅 

Here's an example of some islands (from the test case):
```ts
{
  id: "multiplecounters_default",
  name: "MultipleCounters",
  url: "file:///Users/reed/code/fresh/tests/fixture/islands/MultipleCounters.tsx",
  component: [Function: CounterZero],
  exportName: "default"
}
{
  id: "multiplecounters_counterone",
  name: "MultipleCounters",
  url: "file:///Users/reed/code/fresh/tests/fixture/islands/MultipleCounters.tsx",
  component: [Function: CounterOne],
  exportName: "CounterOne"
}
{
  id: "multiplecounters_countertwo",
  name: "MultipleCounters",
  url: "file:///Users/reed/code/fresh/tests/fixture/islands/MultipleCounters.tsx",
  component: [Function: CounterTwo],
  exportName: "CounterTwo"
}
{
  id: "folder_subfolder_counter_default",
  name: "Folder_subfolder_Counter",
  url: "file:///Users/reed/code/fresh/tests/fixture/islands/folder/subfolder/Counter.tsx",
  component: [Function: Counter],
  exportName: "default"
}
```

With the above islands, we now emit html (what's the right way to say this?) like this:
```html
<!--frsh-multiplecounters_default:default:0-->
<div id="counter0">
    <p>4</p>
    <button id="b-counter0" disabled>+1</button>
</div>
<!--/frsh-multiplecounters_default:default:0-->
<!--frsh-multiplecounters_counterone:CounterOne:1-->
<div id="counter1">
    <p>3</p>
    <button id="b-counter1" disabled>+1</button>
</div>
<!--/frsh-multiplecounters_counterone:CounterOne:1-->
<!--frsh-multiplecounters_countertwo:CounterTwo:2-->
<div id="counter2">
    <p>10</p>
    <button id="b-counter2" disabled>+1</button>
</div>
<!--/frsh-multiplecounters_countertwo:CounterTwo:2-->
<!--frsh-folder_subfolder_counter_default:default:3-->
<div id="counter3">
    <p>4</p>
    <button id="b-counter3" disabled>+1</button>
</div>
<!--/frsh-folder_subfolder_counter_default:default:3-->
```
Note this is coming from the change to the comment generation:
```ts
`frsh-${island.id}:${island.exportName}:${ISLAND_PROPS.length - 1}`
```
We now pass out the `exportName` to enable the lookup within the module. It looks a bit silly for default exports, because the `id` also has `default` in it as well. Open to suggestions here. I went around in circles trying to simplify this, but eventually just left it.

Finally we get a script like this:
```js
import * as MultipleCounters_default from "/_frsh/js/48d9737696c04a606a9f9aaddd5b8b17411852dd/island-multiplecounters_default.js";import * as MultipleCounters_CounterOne from "/_frsh/js/48d9737696c04a606a9f9aaddd5b8b17411852dd/island-multiplecounters_counterone.js";import * as MultipleCounters_CounterTwo from "/_frsh/js/48d9737696c04a606a9f9aaddd5b8b17411852dd/island-multiplecounters_countertwo.js";import * as Folder_subfolder_Counter_default from "/_frsh/js/48d9737696c04a606a9f9aaddd5b8b17411852dd/island-folder_subfolder_counter_default.js";revive({multiplecounters_default:MultipleCounters_default,multiplecounters_counterone:MultipleCounters_CounterOne,multiplecounters_countertwo:MultipleCounters_CounterTwo,folder_subfolder_counter_default:Folder_subfolder_Counter_default,}, STATE[0]);
```
(Oh, you don't find that easy to read? Me too. Please help. When testing this I manually went and inserted `\n` to the necessary places in `render.ts` so the client code looks nice. Seems like a good use case for the dev tools issue, where Bartek writes: `Currently Fresh's server doesn't know if it's running in dev mode or not, the dev script is a thin wrapper that generates the manifest and watches for file changes.`)

So the formatted version is like this:
```js
import * as MultipleCounters_default from "/_frsh/js/48d9737696c04a606a9f9aaddd5b8b17411852dd/island-multiplecounters_default.js";
import * as MultipleCounters_CounterOne from "/_frsh/js/48d9737696c04a606a9f9aaddd5b8b17411852dd/island-multiplecounters_counterone.js";
import * as MultipleCounters_CounterTwo from "/_frsh/js/48d9737696c04a606a9f9aaddd5b8b17411852dd/island-multiplecounters_countertwo.js";
import * as Folder_subfolder_Counter_default from "/_frsh/js/48d9737696c04a606a9f9aaddd5b8b17411852dd/island-folder_subfolder_counter_default.js";
revive({multiplecounters_default:MultipleCounters_default,multiplecounters_counterone:MultipleCounters_CounterOne,multiplecounters_countertwo:MultipleCounters_CounterTwo,folder_subfolder_counter_default:Folder_subfolder_Counter_default,}, STATE[0]);
```

And with that I think everything is covered, and there should be enough examples to understand what's going on. I am very happy to receive suggestions on how to simplify this, since I spent far too long trying various things.