### PR TITLE
chore(www): use View Transitions API

### DIFF
--- a/www/routes/components.tsx
+++ b/www/routes/components.tsx
@@ -53,6 +53,7 @@ export default function Home(props: PageProps<HomeProps>) {
         <meta property="og:type" content="website" />
         <meta property="og:url" content={props.url.href} />
         <meta property="og:image" content={ogImageUrl} />
+        <meta name="view-transition" content="same-origin" />
       </Head>
       <Header title="components" active="/components" />
 

--- a/www/routes/docs/[...slug].tsx
+++ b/www/routes/docs/[...slug].tsx
@@ -70,6 +70,7 @@ export default function DocsPage(props: PageProps<Data>) {
         <meta property="og:type" content="website" />
         <meta property="og:url" content={props.url.href} />
         <meta property="og:image" content={ogImageUrl} />
+        <meta name="view-transition" content="same-origin" />
       </Head>
       <div class="flex flex-col min-h-screen">
         <Header title="docs" active="/docs" />

--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -51,6 +51,7 @@ export default function MainPage(props: PageProps) {
         <meta property="og:type" content="website" />
         <meta property="og:url" content={props.url.href} />
         <meta property="og:image" content={ogImageUrl} />
+        <meta name="view-transition" content="same-origin" />
       </Head>
 
       <div class="flex flex-col min-h-screen">

--- a/www/routes/showcase.tsx
+++ b/www/routes/showcase.tsx
@@ -20,6 +20,7 @@ export default function ShowcasePage(props: PageProps) {
         <meta property="og:type" content="website" />
         <meta property="og:url" content={props.url.href} />
         <meta property="og:image" content={ogImageUrl} />
+        <meta name="view-transition" content="same-origin" />
       </Head>
       <Header title="showcase" active="/showcase" />
 


### PR DESCRIPTION
This PR enables [View Transition API](https://developer.chrome.com/docs/web-platform/view-transitions/) on fresh.deno.dev.

Watch the video below to see the difference in behavior.

Note: For now, you'll need to enable a flag in Chrome to actually try this feature out. (`chrome://flags/#view-transition-on-navigation`)

**before:**

https://github.com/denoland/fresh/assets/40050810/6ffe6dd0-e7d7-4298-8c84-f38861612cbb

**after:**

https://github.com/denoland/fresh/assets/40050810/a2d48642-3017-47ef-8953-aec9c0ce6241

