### PR TITLE
www: add versioning to docs

### DIFF
--- a/docs/canary/the-canary-version/index.md
+++ b/docs/canary/the-canary-version/index.md
@@ -1,0 +1,15 @@
+---
+description: |
+  Learn more about Fresh canary releases
+---
+
+The canary version represents the current development state of Fresh. It's
+intended for testing work in progress features before it lands in a stable
+release. Whenever new code is merged into the `main` branch on
+[GitHub](https://github.com/denoland/fresh) a new canary version is created that
+matches the hash of the git commit.
+
+With the addition of new features that are not yet in a stable release, we need
+a place to update our documentation. That's what this section of the
+documentation is about. It contains all information about unreleased features
+and changes that will land in a stable release.

--- a/docs/toc.ts
+++ b/docs/toc.ts
@@ -1,66 +1,161 @@
-type RawTableOfContents = Record<string, RawTableOfContentsEntry>;
+import FRESH_VERSIONS from "../versions.json" assert { type: "json" };
+
+type RawTableOfContents = Record<
+  string,
+  {
+    label: string;
+    content: Record<string, RawTableOfContentsEntry>;
+  }
+>;
 
 interface RawTableOfContentsEntry {
   title: string;
-  pages?: [string, string][];
+  link?: string;
+  pages?: [string, string, string?][];
 }
 
 const toc: RawTableOfContents = {
-  "introduction": {
-    "title": "Introduction",
+  canary: {
+    label: "canary",
+    content: {
+      "the-canary-version": {
+        title: "The canary version",
+      },
+      introduction: {
+        title: "Introduction",
+        link: "latest",
+      },
+      "getting-started": {
+        title: "Getting Started",
+        link: "latest",
+        pages: [
+          ["create-a-project", "Create a project", "link:latest"],
+          ["running-locally", "Running locally", "link:latest"],
+          ["create-a-route", "Create a route", "link:latest"],
+          ["dynamic-routes", "Dynamic routes", "link:latest"],
+          ["custom-handlers", "Custom handlers", "link:latest"],
+          ["fetching-data", "Fetching data", "link:latest"],
+          ["form-submissions", "Form submissions", "link:latest"],
+          ["adding-interactivity", "Adding interactivity", "link:latest"],
+          ["deploy-to-production", "Deploy to production", "link:latest"],
+        ],
+      },
+      concepts: {
+        title: "Concepts",
+        link: "latest",
+        pages: [
+          ["architecture", "Architecture", "link:latest"],
+          ["routes", "Routes", "link:latest"],
+          ["forms", "Forms", "link:latest"],
+          ["islands", "Interactive islands", "link:latest"],
+          ["static-files", "Static files", "link:latest"],
+          ["middleware", "Route middleware", "link:latest"],
+          ["error-pages", "Error pages", "link:latest"],
+          ["routing", "Routing", "link:latest"],
+          ["data-fetching", "Data fetching", "link:latest"],
+          ["deployment", "Deployment", "link:latest"],
+          ["plugins", "Plugins", "link:latest"],
+          ["updating", "Updating Fresh", "link:latest"],
+          ["app-wrapper", "Application wrapper", "link:latest"],
+          ["server-configuration", "Server configuration", "link:latest"],
+        ],
+      },
+      integrations: {
+        title: "Integrations",
+        link: "latest",
+      },
+      examples: {
+        title: "Examples",
+        link: "latest",
+        pages: [
+          ["modifying-the-head", "Modifying the <head>", "link:latest"],
+          ["setting-the-language", "Setting the language", "link:latest"],
+          ["writing-tests", "Writing tests", "link:latest"],
+          [
+            "changing-the-src-dir",
+            "Changing the source directory",
+            "link:latest",
+          ],
+          ["using-twind-v1", "Using Twind v1", "link:latest"],
+          ["init-the-server", "Initializing the server", "link:latest"],
+          [
+            "using-fresh-canary-version",
+            "Using Fresh canary version",
+            "link:latest",
+          ],
+          ["dealing-with-cors", "Dealing with CORS", "link:latest"],
+          ["creating-a-crud-api", "Creating a CRUD API", "link:latest"],
+          ["handling-complex-routes", "Handling complex routes", "link:latest"],
+          ["rendering-markdown", "Rendering markdown", "link:latest"],
+          [
+            "sharing-state-between-islands",
+            "Sharing state between islands",
+            "link:latest",
+          ],
+        ],
+      },
+    },
   },
-  "getting-started": {
-    "title": "Getting Started",
-    "pages": [
-      ["create-a-project", "Create a project"],
-      ["running-locally", "Running locally"],
-      ["create-a-route", "Create a route"],
-      ["dynamic-routes", "Dynamic routes"],
-      ["custom-handlers", "Custom handlers"],
-      ["fetching-data", "Fetching data"],
-      ["form-submissions", "Form submissions"],
-      ["adding-interactivity", "Adding interactivity"],
-      ["deploy-to-production", "Deploy to production"],
-    ],
-  },
-  "concepts": {
-    "title": "Concepts",
-    "pages": [
-      ["architecture", "Architecture"],
-      ["routes", "Routes"],
-      ["forms", "Forms"],
-      ["islands", "Interactive islands"],
-      ["static-files", "Static files"],
-      ["middleware", "Route middleware"],
-      ["error-pages", "Error pages"],
-      ["routing", "Routing"],
-      ["data-fetching", "Data fetching"],
-      ["deployment", "Deployment"],
-      ["plugins", "Plugins"],
-      ["updating", "Updating Fresh"],
-      ["app-wrapper", "Application wrapper"],
-      ["server-configuration", "Server configuration"],
-    ],
-  },
-  "integrations": {
-    "title": "Integrations",
-  },
-  "examples": {
-    "title": "Examples",
-    "pages": [
-      ["modifying-the-head", "Modifying the <head>"],
-      ["setting-the-language", "Setting the language"],
-      ["writing-tests", "Writing tests"],
-      ["changing-the-src-dir", "Changing the source directory"],
-      ["using-twind-v1", "Using Twind v1"],
-      ["init-the-server", "Initializing the server"],
-      ["using-fresh-canary-version", "Using Fresh canary version"],
-      ["dealing-with-cors", "Dealing with CORS"],
-      ["creating-a-crud-api", "Creating a CRUD API"],
-      ["handling-complex-routes", "Handling complex routes"],
-      ["rendering-markdown", "Rendering markdown"],
-      ["sharing-state-between-islands", "Sharing state between islands"],
-    ],
+  latest: {
+    label: FRESH_VERSIONS[0],
+    content: {
+      introduction: {
+        title: "Introduction",
+      },
+      "getting-started": {
+        title: "Getting Started",
+        pages: [
+          ["create-a-project", "Create a project"],
+          ["running-locally", "Running locally"],
+          ["create-a-route", "Create a route"],
+          ["dynamic-routes", "Dynamic routes"],
+          ["custom-handlers", "Custom handlers"],
+          ["fetching-data", "Fetching data"],
+          ["form-submissions", "Form submissions"],
+          ["adding-interactivity", "Adding interactivity"],
+          ["deploy-to-production", "Deploy to production"],
+        ],
+      },
+      concepts: {
+        title: "Concepts",
+        pages: [
+          ["architecture", "Architecture"],
+          ["routes", "Routes"],
+          ["forms", "Forms"],
+          ["islands", "Interactive islands"],
+          ["static-files", "Static files"],
+          ["middleware", "Route middleware"],
+          ["error-pages", "Error pages"],
+          ["routing", "Routing"],
+          ["data-fetching", "Data fetching"],
+          ["deployment", "Deployment"],
+          ["plugins", "Plugins"],
+          ["updating", "Updating Fresh"],
+          ["app-wrapper", "Application wrapper"],
+          ["server-configuration", "Server configuration"],
+        ],
+      },
+      integrations: {
+        title: "Integrations",
+      },
+      examples: {
+        title: "Examples",
+        pages: [
+          ["modifying-the-head", "Modifying the <head>"],
+          ["setting-the-language", "Setting the language"],
+          ["writing-tests", "Writing tests"],
+          ["changing-the-src-dir", "Changing the source directory"],
+          ["using-twind-v1", "Using Twind v1"],
+          ["init-the-server", "Initializing the server"],
+          ["using-fresh-canary-version", "Using Fresh canary version"],
+          ["dealing-with-cors", "Dealing with CORS"],
+          ["creating-a-crud-api", "Creating a CRUD API"],
+          ["handling-complex-routes", "Handling complex routes"],
+          ["rendering-markdown", "Rendering markdown"],
+          ["sharing-state-between-islands", "Sharing state between islands"],
+        ],
+      },
+    },
   },
 };
 

--- a/www/components/DocsSidebar.tsx
+++ b/www/components/DocsSidebar.tsx
@@ -1,13 +1,20 @@
-import { Head } from "$fresh/runtime.ts";
 import {
   CATEGORIES,
   TableOfContentsCategory,
   TableOfContentsCategoryEntry,
 } from "../data/docs.ts";
 import SearchButton from "../islands/SearchButton.tsx";
+import VersionSelect from "../islands/VersionSelect.tsx";
+import { type VersionLink } from "../routes/docs/[...slug].tsx";
 
-export default function DocsSidebar(props: { path: string; mobile?: boolean }) {
-  const id = String(Math.random()).replaceAll(".", "");
+export default function DocsSidebar(
+  props: {
+    path: string;
+    mobile?: boolean;
+    versionLinks: VersionLink[];
+    selectedVersion: string;
+  },
+) {
   return (
     <>
       {props.mobile
@@ -47,8 +54,15 @@ export default function DocsSidebar(props: { path: string; mobile?: boolean }) {
         )
         : <SearchButton />}
 
+      <div class="mb-4">
+        <VersionSelect
+          selectedVersion={props.selectedVersion}
+          versions={props.versionLinks}
+        />
+      </div>
+
       <ol class="list-decimal list-inside font-semibold nested">
-        {CATEGORIES.map((category) => (
+        {CATEGORIES[props.selectedVersion].map((category) => (
           <SidebarCategory path={props.path} category={category} />
         ))}
       </ol>

--- a/www/data/docs.ts
+++ b/www/data/docs.ts
@@ -19,42 +19,83 @@ export interface TableOfContentsCategoryEntry {
   href: string;
 }
 
-export const TABLE_OF_CONTENTS: Record<string, TableOfContentsEntry> = {};
-export const CATEGORIES: TableOfContentsCategory[] = [];
+export const TABLE_OF_CONTENTS: Record<
+  string,
+  Record<string, TableOfContentsEntry>
+> = {};
+export const CATEGORIES: Record<string, TableOfContentsCategory[]> = {};
 
-for (const parent in toc) {
-  const rawEntry = toc[parent];
-  const href = `/docs/${parent}`;
-  const file = `docs/${parent}/index.md`;
-  const entry = {
-    slug: parent,
-    title: rawEntry.title,
-    href,
-    file,
-  };
-  TABLE_OF_CONTENTS[parent] = entry;
-  const category: TableOfContentsCategory = {
-    title: rawEntry.title,
-    href,
-    entries: [],
-  };
-  CATEGORIES.push(category);
-  const filteredPages = rawEntry.pages?.filter(([title, page]) =>
-    title != null && page != null
-  );
-  if (filteredPages) {
-    for (const [id, title] of filteredPages) {
-      const slug = `${parent}/${id}`;
-      const href = `/docs/${slug}`;
-      const file = `docs/${slug}.md`;
-      const entry = { slug, title, category: parent, href, file };
-      TABLE_OF_CONTENTS[slug] = entry;
-      category.entries.push({
-        title,
-        href,
-      });
+export const VERSIONS = Object.keys(toc);
+export const CANARY_VERSION = toc.canary ? "canary" : "";
+export const LATEST_VERSION =
+  VERSIONS.find((version) => version !== "canary") ?? "";
+
+for (const version in toc) {
+  const RAW_VERSION = toc[version];
+  const versionSlug = version === LATEST_VERSION ? "" : `/${version}`;
+  TABLE_OF_CONTENTS[version] = {};
+  CATEGORIES[version] = [];
+
+  for (const parent in RAW_VERSION.content) {
+    const rawEntry = RAW_VERSION.content[parent];
+
+    // Allow versioned documentation to stack on each other. This should
+    // only be used for canary versions. This avoids having us to copy
+    // all documentation content and backport changes.
+    const fileVersion = rawEntry.link ?? version;
+    const versionFilePath = fileVersion === LATEST_VERSION
+      ? ""
+      : `/${fileVersion}`;
+
+    const href = `/docs${versionSlug}/${parent}`;
+    const file = `docs${versionFilePath}/${parent}/index.md`;
+
+    const entry = {
+      slug: parent,
+      title: rawEntry.title,
+      href,
+      file,
+    };
+    TABLE_OF_CONTENTS[version][parent] = entry;
+    const category: TableOfContentsCategory = {
+      title: rawEntry.title,
+      href,
+      entries: [],
+    };
+    CATEGORIES[version].push(category);
+    if (rawEntry.pages) {
+      for (const [id, title, linkedVersion] of rawEntry.pages) {
+        const slug = `${parent}/${id}`;
+
+        // Allow stacked documentation
+        const pageVersion = linkedVersion
+          ? linkedVersion.slice("link:".length)
+          : version;
+        const versionFilePath = !pageVersion || pageVersion === LATEST_VERSION
+          ? ""
+          : `/${pageVersion}`;
+
+        const href = `/docs${versionSlug}/${slug}`;
+
+        const file = `docs${versionFilePath}/${slug}.md`;
+        const entry = { slug, title, category: parent, href, file };
+        TABLE_OF_CONTENTS[version][slug] = entry;
+        category.entries.push({
+          title,
+          href,
+        });
+      }
     }
   }
 }
 
-export const SLUGS = Object.keys(TABLE_OF_CONTENTS);
+export function getFirstPageUrl(version: string) {
+  const group = TABLE_OF_CONTENTS[version];
+  if (group) {
+    for (const slug in group) {
+      return group[slug].href;
+    }
+  }
+
+  throw new Error(`Could not find version "${version}"`);
+}

--- a/www/fresh.gen.ts
+++ b/www/fresh.gen.ts
@@ -7,16 +7,18 @@ import * as $1 from "./routes/_500.tsx";
 import * as $2 from "./routes/_middleware.ts";
 import * as $3 from "./routes/components.tsx";
 import * as $4 from "./routes/docs/[...slug].tsx";
-import * as $5 from "./routes/gfm.css.ts";
-import * as $6 from "./routes/index.tsx";
-import * as $7 from "./routes/raw.ts";
-import * as $8 from "./routes/showcase.tsx";
-import * as $9 from "./routes/update.tsx";
+import * as $5 from "./routes/docs/index.tsx";
+import * as $6 from "./routes/gfm.css.ts";
+import * as $7 from "./routes/index.tsx";
+import * as $8 from "./routes/raw.ts";
+import * as $9 from "./routes/showcase.tsx";
+import * as $10 from "./routes/update.tsx";
 import * as $$0 from "./islands/ComponentGallery.tsx";
 import * as $$1 from "./islands/CopyArea.tsx";
 import * as $$2 from "./islands/Counter.tsx";
 import * as $$3 from "./islands/LemonDrop.tsx";
 import * as $$4 from "./islands/SearchButton.tsx";
+import * as $$5 from "./islands/VersionSelect.tsx";
 
 const manifest = {
   routes: {
@@ -25,11 +27,12 @@ const manifest = {
     "./routes/_middleware.ts": $2,
     "./routes/components.tsx": $3,
     "./routes/docs/[...slug].tsx": $4,
-    "./routes/gfm.css.ts": $5,
-    "./routes/index.tsx": $6,
-    "./routes/raw.ts": $7,
-    "./routes/showcase.tsx": $8,
-    "./routes/update.tsx": $9,
+    "./routes/docs/index.tsx": $5,
+    "./routes/gfm.css.ts": $6,
+    "./routes/index.tsx": $7,
+    "./routes/raw.ts": $8,
+    "./routes/showcase.tsx": $9,
+    "./routes/update.tsx": $10,
   },
   islands: {
     "./islands/ComponentGallery.tsx": $$0,
@@ -37,6 +40,7 @@ const manifest = {
     "./islands/Counter.tsx": $$2,
     "./islands/LemonDrop.tsx": $$3,
     "./islands/SearchButton.tsx": $$4,
+    "./islands/VersionSelect.tsx": $$5,
   },
   baseUrl: import.meta.url,
 };

--- a/www/islands/VersionSelect.tsx
+++ b/www/islands/VersionSelect.tsx
@@ -1,0 +1,62 @@
+// Copyright 2022-2023 the Deno authors. All rights reserved. MIT license.
+
+import { IS_BROWSER } from "$fresh/runtime.ts";
+import { type VersionLink } from "../routes/docs/[...slug].tsx";
+
+export default function VersionSelect(
+  { versions, selectedVersion }: {
+    versions: VersionLink[];
+    selectedVersion: string;
+  },
+) {
+  const selectedIsLatest = selectedVersion === "latest";
+  const selectedIsCanary = selectedVersion === "canary";
+
+  return (
+    <>
+      <div class="relative">
+        <label htmlFor="version" class="sr-only">
+          Version
+        </label>
+        {selectedIsLatest && (
+          <div class="flex absolute pointer-events-none select-none w-full h-full items-center justify-end pr-8">
+            <div class="rounded-full px-2 py-1 text-xs tag-label bg-[#056CF025] text-blue-600">
+              Latest
+            </div>
+          </div>
+        )}
+        {selectedIsCanary && (
+          <div class="flex absolute pointer-events-none select-none w-full h-full items-center justify-end pr-8">
+            <div class="rounded-full px-2 py-1 text-xs tag-label bg-[#F0900525] text-yellow-600">
+              🚧 Preview
+            </div>
+          </div>
+        )}
+        <select
+          id="version"
+          class={`rounded-md block border border-gray-300 appearance-none bg-white form-select-bg font-semibold ${
+            selectedIsLatest ? "pr-22" : "pr-10"
+          } py-2 pl-3 w-full h-full leading-none sm:(text-sm leading-5) focus:(outline-none border-blue-300) hover:bg-gray-100`}
+          value={selectedVersion}
+          onChange={(e) => {
+            if (e.currentTarget.value !== selectedVersion) {
+              const entry = versions.find((entry) =>
+                entry.value === e.currentTarget.value
+              );
+              if (entry) {
+                location.href = entry.href;
+              }
+            }
+          }}
+          disabled={!IS_BROWSER}
+        >
+          {versions.map((entry) => (
+            <option key={entry.value} value={entry.value}>
+              {entry.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    </>
+  );
+}

--- a/www/main_test.ts
+++ b/www/main_test.ts
@@ -1,12 +1,15 @@
-import { assertEquals } from "$std/testing/asserts.ts";
+import { assertArrayIncludes, assertEquals } from "$std/testing/asserts.ts";
 import { delay } from "$std/async/delay.ts";
-import { startFreshServer } from "../tests/test_utils.ts";
+import { startFreshServer, withPageName } from "../tests/test_utils.ts";
+import { dirname, join } from "$std/path/mod.ts";
+
+const dir = dirname(import.meta.url);
 
 Deno.test("CORS should not set on GET /fresh-badge.svg", {
   sanitizeResources: false,
 }, async () => {
   const { serverProcess, lines, address } = await startFreshServer({
-    args: ["run", "-A", "./main.ts"],
+    args: ["run", "-A", join(dir, "./main.ts")],
   });
 
   const res = await fetch(`${address}/fresh-badge.svg`);
@@ -18,4 +21,59 @@ Deno.test("CORS should not set on GET /fresh-badge.svg", {
   serverProcess.kill("SIGTERM");
   // await for the server to close
   await delay(100);
+});
+
+Deno.test("shows version selector", {
+  sanitizeResources: false,
+}, async () => {
+  await withPageName(join(dir, "./main.ts"), async (page, address) => {
+    await page.goto(`${address}/docs`);
+    await page.waitForSelector("#version");
+
+    // Check that we redirected to the first page
+    assertEquals(page.url(), `${address}/docs/introduction`);
+
+    // Wait for version selector to be enabled
+    await page.waitForSelector("#version:not([disabled])");
+
+    const options = await page.$eval("#version", (el: HTMLSelectElement) => {
+      return Array.from(el.options).map((option) => ({
+        value: option.value,
+        label: option.textContent,
+      }));
+    });
+
+    assertEquals(options.length, 2);
+    assertArrayIncludes(options, [
+      {
+        value: "canary",
+        label: "canary",
+      },
+      {
+        value: "1.2",
+        label: "1.2.x",
+      },
+    ]);
+
+    const selectValue = await page.$eval(
+      "#version",
+      (el: HTMLSelectElement) => el.value,
+    );
+    assertEquals(selectValue, "1.2");
+
+    // Go to canary page
+    await Promise.all([
+      page.waitForNavigation(),
+      page.select("#version", "canary"),
+    ]);
+
+    await page.waitForSelector("#version:not([disabled])");
+    const selectValue2 = await page.$eval(
+      "#version",
+      (el: HTMLSelectElement) => el.value,
+    );
+    assertEquals(selectValue2, "canary");
+
+    assertEquals(page.url(), `${address}/docs/canary/introduction`);
+  });
 });

--- a/www/routes/docs/index.tsx
+++ b/www/routes/docs/index.tsx
@@ -1,0 +1,19 @@
+import { MultiHandler } from "$fresh/server.ts";
+
+export const handler: MultiHandler<void> = {
+  GET(_req, ctx) {
+    const slug = ctx.params.slug;
+
+    if (slug === "concepts/architechture") {
+      return new Response("", {
+        status: 307,
+        headers: { location: "/docs/concepts/architecture" },
+      });
+    }
+
+    return new Response("", {
+      status: 307,
+      headers: { location: "/docs/introduction" },
+    });
+  },
+};

--- a/www/twind.config.ts
+++ b/www/twind.config.ts
@@ -17,7 +17,7 @@ export default {
   plugins: {
     // Basic workaround for old twind version not supporting
     // the `basis-*` keyword
-    "basis": (parts) => {
+    basis: (parts) => {
       let value;
       const arr = parts[0].split("/");
       if (arr.length === 2) {
@@ -27,6 +27,20 @@ export default {
       }
       return {
         "flex-basis": value,
+      };
+    },
+    "rounded-full": () => {
+      return {
+        "border-radius": "9999px",
+      };
+    },
+    "form-select-bg": () => {
+      return {
+        "background-image":
+          `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none'%3e%3cpath d='M7 7l3-3 3 3m0 6l-3 3-3-3' stroke='%239fa6b2' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3e%3c/svg%3e")`,
+        "background-position": "right 0.5rem center",
+        "background-size": "1.5em 1.5em",
+        "background-repeat": "no-repeat",
       };
     },
   },


### PR DESCRIPTION
This PR adds versioning to our documentation. We ran into the scenario where we're documenting a feature that landed in `main`, but wasn't released in a stable version. This led to confusion because the docs didn't match the released version.

I've went a bit back and forth on the various approaches to versioning and I think I landed on a way that's best for our project and least maintenance intensive. In particular I wanted to avoid a situation where we need to copy all content files and have to backport updates between them. That should only be necessary when we do breaking changes like release Fresh 2.0 or something.

To resolve that the versioning follows the one chosen by https://eslint.org/docs/latest/ . Their strategy is to have one current version and one canary. There are no other versions. They implemented it in a way that the repo only contains the canary version and each release copies the canary version to a release version that's then pulled from some storage during the CI step. I very much like the overall approach of having one current and one canary version, but I wanted to avoid the CI logic and keep things simple.

Instead we have simply two version folders: One current and for canary. The canary folder can inherit pages from the current folder, which avoids us having to sync content.

tl;dr:
- Links are all the same as without this PR. Canary versions have `/canary` suffix
- Canary docs can inherit pages from current docs to not have to copy everything over

<img width="446" alt="Screenshot 2023-07-03 at 16 40 51" src="https://github.com/denoland/fresh/assets/1062408/688fffd2-a6c9-468e-a44a-f2bba18c127f">
<img width="428" alt="Screenshot 2023-07-03 at 16 40 55" src="https://github.com/denoland/fresh/assets/1062408/835921fe-c404-466b-b2b5-a7c7f790009b">

TODO:
- Add tests
- Rename `1.2` to something else but show the version in the version selector.

Fixes #1392 