### PR TITLE
www: hopefully fix agolia search exceptions

### DIFF
--- a/src/build/deps.ts
+++ b/src/build/deps.ts
@@ -6,15 +6,15 @@ export {
 export { escape as regexpEscape } from "https://deno.land/std@0.190.0/regexp/escape.ts";
 
 // -- esbuild --
-// @deno-types="https://deno.land/x/esbuild@v0.17.19/mod.d.ts"
-import * as esbuildWasm from "https://deno.land/x/esbuild@v0.17.19/wasm.js";
-import * as esbuildNative from "https://deno.land/x/esbuild@v0.17.19/mod.js";
+// @deno-types="https://deno.land/x/esbuild@v0.18.11/mod.d.ts"
+import * as esbuildWasm from "https://deno.land/x/esbuild@v0.18.11/wasm.js";
+import * as esbuildNative from "https://deno.land/x/esbuild@v0.18.11/mod.js";
 // @ts-ignore trust me
 // deno-lint-ignore no-deprecated-deno-api
 const esbuild: typeof esbuildWasm = Deno.run === undefined
   ? esbuildWasm
   : esbuildNative;
-const esbuildWasmURL = new URL("./esbuild_v0.17.19.wasm", import.meta.url).href;
+const esbuildWasmURL = new URL("./esbuild_v0.18.11.wasm", import.meta.url).href;
 export { esbuild, esbuildWasm as esbuildTypes, esbuildWasmURL };
 
 export { denoPlugins } from "https://deno.land/x/esbuild_deno_loader@0.8.1/mod.ts";


### PR DESCRIPTION
Using the search on the production instance throws a couple of exceptions when using it.

<img width="589" alt="Screenshot 2023-07-03 at 22 31 19" src="https://github.com/denoland/fresh/assets/1062408/2d6929d7-dff5-4ea6-8359-b0178994d7db">

Took a while to investigate, because I couldn't reproduce it locally at first. So what's happening is that we use the native `esbuild` binary locally, but use the `wasm` build on deploy. The wasm build of the `esbuild` version we used seems to have a bug and messes up a variable somewhere. Forcing that to be used locally allowed me to reproduce the error. I couldn't pinpoint to exactly where it was going wrong, but simply updating `esbuild` resolves this.