### PR TITLE
feat(server): workers in islands

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -21,6 +21,7 @@ import {
   ServeHandlerInfo,
   UnknownPage,
   UnknownRenderFunction,
+  Worker,
 } from "./types.ts";
 import { render as internalRender } from "./render.ts";
 import {
@@ -93,6 +94,7 @@ export async function getServerContext(state: InternalFreshState) {
       config.dev,
       extractResult.islands,
       config.plugins,
+      extractResult.workers,
     ),
     configPath,
     dev: config.dev,
@@ -685,6 +687,7 @@ function collectEntrypoints(
   dev: boolean,
   islands: Island[],
   plugins: Plugin[],
+  workers: Worker[],
 ): Record<string, string> {
   const entrypointBase = "../runtime/entrypoints";
   const entryPoints: Record<string, string> = {
@@ -715,6 +718,10 @@ function collectEntrypoints(
     for (const [name, url] of Object.entries(plugin.entrypoints ?? {})) {
       entryPoints[`plugin-${plugin.name}-${name}`] = url;
     }
+  }
+
+  for (const worker of workers) {
+    entryPoints[`worker-${worker.id}`] = worker.url;
   }
 
   return entryPoints;

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -442,6 +442,11 @@ export interface Island {
   exportName: string;
 }
 
+export interface Worker {
+  id: string;
+  url: string;
+}
+
 // --- PLUGINS ---
 
 export interface Plugin<State = Record<string, unknown>> {

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -82,11 +82,13 @@ import * as $static from "./routes/static.tsx";
 import * as $status_overwrite from "./routes/status_overwrite.tsx";
 import * as $umlaut_äöüß from "./routes/umlaut-äöüß.tsx";
 import * as $wildcard from "./routes/wildcard.tsx";
+import * as $worker from "./routes/worker.tsx";
 import * as $Counter from "./islands/Counter.tsx";
 import * as $Foo_Bar from "./islands/Foo.Bar.tsx";
 import * as $FormIsland from "./islands/FormIsland.tsx";
 import * as $Greeter from "./islands/Greeter.tsx";
 import * as $HookIsland from "./islands/HookIsland.tsx";
+import * as $IslandWithWorkers from "./islands/IslandWithWorkers.tsx";
 import * as $MultipleCounters from "./islands/MultipleCounters.tsx";
 import * as $ReturningNull from "./islands/ReturningNull.tsx";
 import * as $RootFragment from "./islands/RootFragment.tsx";
@@ -94,6 +96,7 @@ import * as $RootFragmentWithConditionalFirst from "./islands/RootFragmentWithCo
 import * as $StringEventIsland from "./islands/StringEventIsland.tsx";
 import * as $Test from "./islands/Test.tsx";
 import * as $folder_Counter from "./islands/folder/Counter.tsx";
+import * as $folder_SomeRandomName from "./islands/folder/SomeRandomName.tsx";
 import * as $folder_subfolder_Counter from "./islands/folder/subfolder/Counter.tsx";
 import * as $kebab_case_counter_test from "./islands/kebab-case-counter-test.tsx";
 import * as $route_groups_islands_islands_Counter from "./routes/route-groups-islands/(_islands)/Counter.tsx";
@@ -200,6 +203,7 @@ const manifest = {
     "./routes/status_overwrite.tsx": $status_overwrite,
     "./routes/umlaut-äöüß.tsx": $umlaut_äöüß,
     "./routes/wildcard.tsx": $wildcard,
+    "./routes/worker.tsx": $worker,
   },
   islands: {
     "./islands/Counter.tsx": $Counter,
@@ -207,6 +211,7 @@ const manifest = {
     "./islands/FormIsland.tsx": $FormIsland,
     "./islands/Greeter.tsx": $Greeter,
     "./islands/HookIsland.tsx": $HookIsland,
+    "./islands/IslandWithWorkers.tsx": $IslandWithWorkers,
     "./islands/MultipleCounters.tsx": $MultipleCounters,
     "./islands/ReturningNull.tsx": $ReturningNull,
     "./islands/RootFragment.tsx": $RootFragment,
@@ -215,6 +220,7 @@ const manifest = {
     "./islands/StringEventIsland.tsx": $StringEventIsland,
     "./islands/Test.tsx": $Test,
     "./islands/folder/Counter.tsx": $folder_Counter,
+    "./islands/folder/SomeRandomName.tsx": $folder_SomeRandomName,
     "./islands/folder/subfolder/Counter.tsx": $folder_subfolder_Counter,
     "./islands/kebab-case-counter-test.tsx": $kebab_case_counter_test,
     "./routes/route-groups-islands/(_islands)/Counter.tsx":

--- a/tests/fixture/islands/IslandWithWorkers.tsx
+++ b/tests/fixture/islands/IslandWithWorkers.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "preact/hooks";
+import useWorker from "../utils/useWorker.ts";
+
+export default function IslandWithWorkers() {
+  const firstWorkerRef = useRef<Worker | null>(null);
+  const secondWorkerRef = useWorker("../workers/secondWorker.ts");
+
+  useEffect(() => {
+    firstWorkerRef.current = new Worker(
+      new URL("../workers/myFirstWorker.ts", import.meta.url),
+      { type: "module" },
+    );
+
+    if (firstWorkerRef.current) {
+      firstWorkerRef.current.postMessage("send first message to myFirstWorker");
+      firstWorkerRef.current.onmessage = ({ data }) => {
+        console.log("received in main for first worker:", data);
+      };
+    }
+
+    if (secondWorkerRef.current) {
+      secondWorkerRef.current.postMessage("message to secondWorker");
+      secondWorkerRef.current.onmessage = ({ data }) => {
+        console.log("received in main for second worker:", data);
+      };
+    }
+
+    return () => {
+      if (firstWorkerRef.current) {
+        firstWorkerRef.current.terminate();
+      }
+      firstWorkerRef.current = null;
+
+      if (secondWorkerRef.current) {
+        secondWorkerRef.current.terminate();
+      }
+      secondWorkerRef.current = null;
+    };
+  }, []);
+
+  return <div>hello from the first island</div>;
+}

--- a/tests/fixture/islands/folder/SomeRandomName.tsx
+++ b/tests/fixture/islands/folder/SomeRandomName.tsx
@@ -1,0 +1,6 @@
+import useWorker from "../../utils/useWorker.ts";
+
+export default function SomeRandomName() {
+  useWorker("../../workers/doStuff.ts");
+  return <div>hello from the second island</div>;
+}

--- a/tests/fixture/routes/worker.tsx
+++ b/tests/fixture/routes/worker.tsx
@@ -1,0 +1,11 @@
+import IslandWithWorkers from "../islands/IslandWithWorkers.tsx";
+import SomeRandomName from "../islands/folder/SomeRandomName.tsx";
+
+export default function Home() {
+  return (
+    <div>
+      <IslandWithWorkers />
+      <SomeRandomName />
+    </div>
+  );
+}

--- a/tests/fixture/utils/useWorker.ts
+++ b/tests/fixture/utils/useWorker.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from "preact/hooks";
+
+export default function useWorker(workerPath: string) {
+  const workerRef = useRef<Worker | null>(null);
+
+  useEffect(() => {
+    workerRef.current = new Worker(new URL(workerPath, location.href), {
+      type: "module",
+    });
+
+    const worker = workerRef.current;
+
+    if (worker) {
+      worker.postMessage("hook helped here");
+      worker.onmessage = ({ data }) => {
+        console.log("this is from the hook:", data);
+      };
+    }
+
+    return () => {
+      if (worker) {
+        worker.terminate();
+      }
+      workerRef.current = null;
+    };
+  }, [workerPath]);
+
+  return workerRef;
+}

--- a/tests/fixture/workers/doStuff.ts
+++ b/tests/fixture/workers/doStuff.ts
@@ -1,0 +1,4 @@
+self.onmessage = ({ data }) => {
+  console.log("doStuff says:", data);
+  self.postMessage("doStuff reporting for duty");
+};

--- a/tests/fixture/workers/myFirstWorker.ts
+++ b/tests/fixture/workers/myFirstWorker.ts
@@ -1,0 +1,4 @@
+self.onmessage = ({ data }) => {
+  console.log("myFirstWorker received message:", data);
+  self.postMessage("hello from myFirstWorker");
+};

--- a/tests/fixture/workers/secondWorker.ts
+++ b/tests/fixture/workers/secondWorker.ts
@@ -1,0 +1,4 @@
+self.onmessage = ({ data }) => {
+  console.log("secondWorker received message:", data);
+  self.postMessage("sending from secondWorker");
+};

--- a/tests/workers_test.ts
+++ b/tests/workers_test.ts
@@ -1,0 +1,43 @@
+import { assert } from "./deps.ts";
+import { withPageName } from "./test_utils.ts";
+
+Deno.test({
+  name: "IslandWithWorker - Web Worker Execution",
+  async fn(t) {
+    await withPageName("./tests/fixture/main.ts", async (page, address) => {
+      const workerMessages: string[] = [];
+
+      page.on("console", (msg) => {
+        workerMessages.push(msg.text());
+      });
+
+      await page.goto(`${address}/worker`, {
+        waitUntil: "networkidle2",
+      });
+
+      await t.step("Web worker status", () => {
+        const expectedMessages = [
+          "secondWorker received message: hook helped here",
+          "secondWorker received message: message to secondWorker",
+          "received in main for second worker: sending from secondWorker",
+          "received in main for second worker: sending from secondWorker",
+          "myFirstWorker received message: send first message to myFirstWorker",
+          "received in main for first worker: hello from myFirstWorker",
+          "doStuff says: hook helped here",
+          "this is from the hook: doStuff reporting for duty",
+        ];
+
+        const missingMessages = expectedMessages.filter(
+          (expectedMessage) => !workerMessages.includes(expectedMessage),
+        );
+
+        assert(
+          missingMessages.length === 0,
+          `The following messages are missing in workerMessages: ${
+            missingMessages.join(", ")
+          }`,
+        );
+      });
+    });
+  },
+});


### PR DESCRIPTION
closes https://github.com/denoland/fresh/issues/1398

Or, at least it attempts to. Not entirely sure what the desired functionality is here. I'd appreciate guidance on some sensible tests and clarification around how we intend this to be used. I improved my test case from the comment I posted last night on the issue. You can see it [here](https://github.com/denoland/fresh/commit/e4b6576021ff74f0d34a0cf1fc77d678bb6f6c38). I support two forms of worker import rewriting right now.
1.  do it manually, e.g. `new URL("../workers/myFirstWorker.ts", import.meta.url),`
2. use the new hook, e.g. `useWorker("../../workers/doStuff.ts");`

This is still a bit hacky, since I had to declare a global state in order to share the current request url with the esbuild plugin.  You can see that in `bundleAssetRoute` where I do this:
```tsx
sharedState = {
  reqUrl: req.url,
};
```
I then use it later like:
```tsx
const url = sharedState.reqUrl;
```
Otherwise I don't know how to rewrite the `new URL(.....)` and `useWorker(....)` calls to point to the correct value in the server, since we append that randomNonce to our URLs. Maybe I'm misunderstanding something.

As always looking into a new section of code was very illuminating, although I think I need a bit of help here in order to get this over the line.