### PR TITLE
fix: twind including unused CSS rules

### DIFF
--- a/plugins/twind/shared.ts
+++ b/plugins/twind/shared.ts
@@ -1,6 +1,8 @@
 import { JSX, options as preactOptions, VNode } from "preact";
 import { Configuration, setup as twSetup, Sheet, tw } from "twind";
 
+type PreactOptions = typeof preactOptions & { __b?: (vnode: VNode) => void };
+
 export const STYLE_ELEMENT_ID = "__FRSH_TWIND";
 
 export interface Options extends Omit<Configuration, "mode" | "sheet"> {
@@ -25,9 +27,13 @@ export function setup(options: Options, sheet: Sheet) {
   };
   twSetup(config);
 
-  const originalHook = preactOptions.vnode;
-  // deno-lint-ignore no-explicit-any
-  preactOptions.vnode = (vnode: VNode<JSX.DOMAttributes<any>>) => {
+  // Hook into options._diff which is called whenever a new comparison
+  // starts in Preact.
+  const originalHook = (preactOptions as PreactOptions).__b;
+  (preactOptions as PreactOptions).__b = (
+    // deno-lint-ignore no-explicit-any
+    vnode: VNode<JSX.DOMAttributes<any>>,
+  ) => {
     if (typeof vnode.type === "string" && typeof vnode.props === "object") {
       const { props } = vnode;
       const classes: string[] = [];

--- a/plugins/twindv1/shared.ts
+++ b/plugins/twindv1/shared.ts
@@ -6,6 +6,8 @@ import {
   TwindConfig,
 } from "https://esm.sh/@twind/core@1.1.3";
 
+type PreactOptions = typeof preactOptions & { __b?: (vnode: VNode) => void };
+
 export const STYLE_ELEMENT_ID = "__FRSH_TWIND";
 
 export interface Options extends TwindConfig {
@@ -25,9 +27,13 @@ declare module "preact" {
 export function setup({ selfURL: _selfURL, ...config }: Options, sheet: Sheet) {
   twSetup(config, sheet);
 
-  const originalHook = preactOptions.vnode;
-  // deno-lint-ignore no-explicit-any
-  preactOptions.vnode = (vnode: VNode<JSX.DOMAttributes<any>>) => {
+  // Hook into options._diff which is called whenever a new comparison
+  // starts in Preact.
+  const originalHook = (preactOptions as PreactOptions).__b;
+  (preactOptions as PreactOptions).__b = (
+    // deno-lint-ignore no-explicit-any
+    vnode: VNode<JSX.DOMAttributes<any>>,
+  ) => {
     if (typeof vnode.type === "string" && typeof vnode.props === "object") {
       const { props } = vnode;
       const classes: string[] = [];

--- a/tests/fixture_twind_hydrate/fresh.gen.ts
+++ b/tests/fixture_twind_hydrate/fresh.gen.ts
@@ -6,6 +6,7 @@ import * as $0 from "./routes/check-duplication.tsx";
 import * as $1 from "./routes/insert-cssrules.tsx";
 import * as $2 from "./routes/static.tsx";
 import * as $3 from "./routes/unused.tsx";
+import * as $4 from "./routes/unused_tw.tsx";
 import * as $$0 from "./islands/CheckDuplication.tsx";
 import * as $$1 from "./islands/InsertCssrules.tsx";
 
@@ -15,6 +16,7 @@ const manifest = {
     "./routes/insert-cssrules.tsx": $1,
     "./routes/static.tsx": $2,
     "./routes/unused.tsx": $3,
+    "./routes/unused_tw.tsx": $4,
   },
   islands: {
     "./islands/CheckDuplication.tsx": $$0,

--- a/tests/fixture_twind_hydrate/fresh.gen.ts
+++ b/tests/fixture_twind_hydrate/fresh.gen.ts
@@ -5,6 +5,7 @@
 import * as $0 from "./routes/check-duplication.tsx";
 import * as $1 from "./routes/insert-cssrules.tsx";
 import * as $2 from "./routes/static.tsx";
+import * as $3 from "./routes/unused.tsx";
 import * as $$0 from "./islands/CheckDuplication.tsx";
 import * as $$1 from "./islands/InsertCssrules.tsx";
 
@@ -13,6 +14,7 @@ const manifest = {
     "./routes/check-duplication.tsx": $0,
     "./routes/insert-cssrules.tsx": $1,
     "./routes/static.tsx": $2,
+    "./routes/unused.tsx": $3,
   },
   islands: {
     "./islands/CheckDuplication.tsx": $$0,

--- a/tests/fixture_twind_hydrate/routes/unused.tsx
+++ b/tests/fixture_twind_hydrate/routes/unused.tsx
@@ -1,0 +1,4 @@
+export default function Unused() {
+  const _unused = <div class="text-red-600" />;
+  return <h1>ready</h1>;
+}

--- a/tests/fixture_twind_hydrate/routes/unused_tw.tsx
+++ b/tests/fixture_twind_hydrate/routes/unused_tw.tsx
@@ -1,0 +1,9 @@
+import { tw } from "https://esm.sh/@twind/core@1.1.3";
+
+export default function Unused() {
+  // @ts-ignore twind types are wrong
+  tw`text-green-500`;
+  const _unused = <div class="text-red-600" />;
+  // @ts-ignore twind types are wrong
+  return <h1 class={tw`text-blue-500`}>ready</h1>;
+}

--- a/tests/twind_test.ts
+++ b/tests/twind_test.ts
@@ -1,3 +1,4 @@
+import { assertEquals } from "https://deno.land/std@0.190.0/testing/asserts.ts";
 import { assert, delay, puppeteer } from "./deps.ts";
 
 import { cmpStringArray } from "./fixture_twind_hydrate/utils/utils.ts";
@@ -308,6 +309,41 @@ Deno.test({
         assert(
           !hasUnusedRules,
           "Unused CSS class '.text-red-600' found.",
+        );
+      },
+    );
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "Always includes classes from tw-helper",
+  async fn() {
+    await withPageName(
+      "./tests/fixture_twind_hydrate/main.ts",
+      async (page, address) => {
+        await page.goto(`${address}/unused_tw`);
+        await page.waitForSelector("#__FRSH_TWIND");
+
+        const styles = await page.$eval(
+          "#__FRSH_TWIND",
+          (el: HTMLStyleElement) => {
+            const text = el.textContent!;
+            return {
+              "text-red-600": text.includes(".text-red-600"),
+              "text-green-500": text.includes("text-green-500"),
+              "text-blue-500": text.includes("text-blue-500"),
+            };
+          },
+        );
+        assertEquals(
+          styles,
+          {
+            "text-red-600": false,
+            "text-green-500": true,
+            "text-blue-500": true,
+          },
         );
       },
     );

--- a/tests/twind_test.ts
+++ b/tests/twind_test.ts
@@ -1,7 +1,7 @@
 import { assert, delay, puppeteer } from "./deps.ts";
 
 import { cmpStringArray } from "./fixture_twind_hydrate/utils/utils.ts";
-import { startFreshServer } from "./test_utils.ts";
+import { startFreshServer, withPageName } from "./test_utils.ts";
 
 /**
  * Start the server with the main file.
@@ -291,4 +291,27 @@ Deno.test({
 
     await server.terminate();
   },
+});
+
+Deno.test({
+  name: "Excludes classes from unused vnodes",
+  async fn() {
+    await withPageName(
+      "./tests/fixture_twind_hydrate/main.ts",
+      async (page, address) => {
+        await page.goto(`${address}/unused`);
+        await page.waitForSelector("#__FRSH_TWIND");
+
+        const hasUnusedRules = await page.$eval("#__FRSH_TWIND", (el) => {
+          return el.textContent.includes(".text-red-600");
+        });
+        assert(
+          !hasUnusedRules,
+          "Unused CSS class '.text-red-600' found.",
+        );
+      },
+    );
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
 });


### PR DESCRIPTION
While working on #1388 I noticed that our twind plugins add CSS classes based on vnode creation instead of when a vnode is actually used during rendering. Just because a vnode was created, doesn't mean that it will be used. Common scenarios where that's not the case is conditional rendering.

```jsx
let vnode = <div class="text-red-600" />
if (someCondition) {
  vnode = <div class="text-blue-600" />
}
```

This will make #1388 easier as the rendering there is still synchronous under the hood and we can keep track of local state synchronously.

Whilst `options.__b` (=`options._diff`) was initially not intended to be a public render hook for Preact, it has been stable since the original 10.x release a couple of years ago. Problem is that changing that now in itself would be a breaking change. We should expose it through typings or something else though at some point 👀 