### PR TITLE
fix: manifest file encoding non-latin chars

### DIFF
--- a/src/dev/deps.ts
+++ b/src/dev/deps.ts
@@ -5,6 +5,7 @@ export {
   extname,
   fromFileUrl,
   join,
+  posix,
   relative,
   resolve,
   SEP,

--- a/src/dev/mod.ts
+++ b/src/dev/mod.ts
@@ -67,6 +67,17 @@ export async function collect(directory: string): Promise<Manifest> {
   return { routes, islands };
 }
 
+/**
+ * Import specifiers must have forward slashes
+ */
+function toImportSpecifier(file: string) {
+  let specifier = posix.normalize(file).replace(/\\/g, "/");
+  if (!specifier.startsWith(".")) {
+    specifier = "./" + specifier;
+  }
+  return specifier;
+}
+
 export async function generate(directory: string, manifest: Manifest) {
   const { routes, islands } = manifest;
 
@@ -76,14 +87,14 @@ export async function generate(directory: string, manifest: Manifest) {
 
 ${
     routes.map((file, i) =>
-      `import * as $${i} from "./routes/${posix.normalize(file)}";`
+      `import * as $${i} from "${toImportSpecifier(join("routes", file))}";`
     ).join(
       "\n",
     )
   }
 ${
     islands.map((file, i) =>
-      `import * as $$${i} from "./islands/${posix.normalize(file)}";`
+      `import * as $$${i} from "${toImportSpecifier(join("islands", file))}";`
     )
       .join("\n")
   }
@@ -92,7 +103,7 @@ const manifest = {
   routes: {
     ${
     routes.map((file, i) =>
-      `${JSON.stringify(`./routes/${posix.normalize(file)}`)}: $${i},`
+      `${JSON.stringify(`${toImportSpecifier(join("routes", file))}`)}: $${i},`
     )
       .join("\n    ")
   }
@@ -100,7 +111,9 @@ const manifest = {
   islands: {
     ${
     islands.map((file, i) =>
-      `${JSON.stringify(`./islands/${posix.normalize(file)}`)}: $$${i},`
+      `${
+        JSON.stringify(`${toImportSpecifier(join("islands", file))}`)
+      }: $$${i},`
     )
       .join("\n    ")
   }

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -38,7 +38,8 @@ import * as $32 from "./routes/state-in-props/_middleware.ts";
 import * as $33 from "./routes/state-in-props/index.tsx";
 import * as $34 from "./routes/static.tsx";
 import * as $35 from "./routes/status_overwrite.tsx";
-import * as $36 from "./routes/wildcard.tsx";
+import * as $36 from "./routes/umlaut-äöüß.tsx";
+import * as $37 from "./routes/wildcard.tsx";
 import * as $$0 from "./islands/Counter.tsx";
 import * as $$1 from "./islands/MultipleCounters.tsx";
 import * as $$2 from "./islands/ReturningNull.tsx";
@@ -87,7 +88,8 @@ const manifest = {
     "./routes/state-in-props/index.tsx": $33,
     "./routes/static.tsx": $34,
     "./routes/status_overwrite.tsx": $35,
-    "./routes/wildcard.tsx": $36,
+    "./routes/umlaut-äöüß.tsx": $36,
+    "./routes/wildcard.tsx": $37,
   },
   islands: {
     "./islands/Counter.tsx": $$0,

--- a/tests/fixture/routes/umlaut-äöüß.tsx
+++ b/tests/fixture/routes/umlaut-äöüß.tsx
@@ -1,0 +1,3 @@
+export default function Umlaut() {
+  return <h1>it works</h1>;
+}

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -879,3 +879,28 @@ Deno.test("renders error boundary", {
     assertEquals(text, "it works");
   });
 });
+
+Deno.test({
+  name: "Resolves routes with non-latin characters",
+
+  async fn() {
+    await withPageName("./tests/fixture/main.ts", async (page, address) => {
+      // Check that we can navigate to the page
+      await page.goto(`${address}/umlaut-äöüß`);
+      await page.waitForSelector("h1");
+      const text = await page.$eval("h1", (el) => el.textContent);
+      assertEquals(text, "it works");
+
+      // Check the manifest
+      const mod = (await import("./fixture/fresh.gen.ts")).default;
+
+      assert(
+        "./routes/umlaut-äöüß.tsx" in mod.routes,
+        "Umlaut route not found",
+      );
+    });
+  },
+
+  sanitizeOps: false,
+  sanitizeResources: false,
+});


### PR DESCRIPTION
This PR ensures that we don't parse file paths as URLs when traversing the file system. Fixes #1432 on the fresh side, but it seems like something in deploy needs to be changed too.