### PR TITLE
feat(init.ts): enable lint rules for fresh apps

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -509,6 +509,11 @@ const config = {
     start: "deno run -A --watch=static/,routes/ dev.ts",
     update: "deno run -A -r https://fresh.deno.dev/update .",
   },
+  lint: {
+    rules: {
+      tags: ["fresh", "recommended"],
+    },
+  },
   imports: {} as Record<string, string>,
   compilerOptions: {
     jsx: "react-jsx",


### PR DESCRIPTION
`deno lint` now supports rules for fresh apps, such as `fresh-handler-export` and `fresh-server-event-handlers`.  This change enables those rules in the project generated by `init.ts`.