### PR TITLE
Allow prebuilding an ESBuild snapshot

### DIFF
--- a/src/build/esbuild.ts
+++ b/src/build/esbuild.ts
@@ -163,7 +163,7 @@ export class EsbuildSnapshot implements BuildSnapshot {
   }
 
   get paths(): string[] {
-    return Object.keys(this.#files);
+    return [...this.#files.keys()];
   }
 
   read(path: string): Uint8Array | null {

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -111,6 +111,7 @@ export class ServerContext {
     jsxConfig: JSXConfig,
     dev: boolean = isDevMode(),
     routerOptions: RouterOptions,
+    snapshot?: BuildSnapshot,
   ) {
     this.#routes = routes;
     this.#islands = islands;
@@ -122,7 +123,7 @@ export class ServerContext {
     this.#error = error;
     this.#plugins = plugins;
     this.#dev = dev;
-    this.#builder = new EsbuildBuilder({
+    this.#builder = snapshot ?? new EsbuildBuilder({
       buildID: BUILD_ID,
       entrypoints: collectEntrypoints(this.#dev, this.#islands, this.#plugins),
       configPath,
@@ -377,6 +378,7 @@ export class ServerContext {
       jsxConfig,
       dev,
       opts.router ?? DEFAULT_ROUTER_OPTIONS,
+      opts.snapshot,
     );
   }
 
@@ -436,7 +438,7 @@ export class ServerContext {
     return this.#builder;
   }
 
-  async #buildSnapshot() {
+  async buildSnapshot() {
     if ("build" in this.#builder) {
       const builder = this.#builder;
       this.#builder = builder.build();
@@ -870,7 +872,7 @@ export class ServerContext {
    */
   #bundleAssetRoute = (): router.MatchHandler => {
     return async (_req, _ctx, params) => {
-      const snapshot = await this.#buildSnapshot();
+      const snapshot = await this.buildSnapshot();
       const contents = snapshot.read(params.path);
       if (!contents) return new Response(null, { status: 404 });
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -2,6 +2,7 @@ import { ComponentChildren, ComponentType, VNode } from "preact";
 import { ServeInit } from "./deps.ts";
 import * as router from "./router.ts";
 import { InnerRenderFunction, RenderContext } from "./render.ts";
+import { BuildSnapshot } from "../build/mod.ts";
 
 // --- APPLICATION CONFIGURATION ---
 
@@ -12,6 +13,10 @@ export interface FreshOptions {
   plugins?: Plugin[];
   staticDir?: string;
   router?: RouterOptions;
+  /**
+   * Pass a snapshot if you want to skip building assests with ESBuild during runtime.
+   */
+  snapshot?: BuildSnapshot;
 }
 
 export interface RouterOptions {


### PR DESCRIPTION
These changes allow users to define a build step where they can prebuild the assets prior to running the server. An attempt to solve https://github.com/denoland/fresh/issues/1062

I thought that a good first step would be to expose the necessary functionality to support prebuilding the assets. Users are free to implement their own snapshot persistence strategies (at least for now).

<details> 
<summary>Generate a snapshot example</summary>

```ts
// build.ts
import manifest from "@/fresh.gen.ts";
import * as base64 from "$std/encoding/base64.ts";
import { ServerContext } from "$fresh/server.ts";

const ctx = await ServerContext.fromManifest(manifest, {});
// Bundle assets
const snapshot = await ctx.buildSnapshot();

// Prepare a JSON
const files: Record<string, string> = {};
for (const p of snapshot.paths) {
  const data = snapshot.read(p) as Uint8Array;
  const v = base64.encode(data);
  files[p] = v;
}

const deps: Record<string, string[]> = {};
for (const p of snapshot.paths) {
  const v = snapshot.dependencies(p);
  deps[p] = v;
}

const content = JSON.stringify(
  { files, deps },
  null,
  2,
);

// Write to disc
await Deno.writeTextFile("snapshot.json", content);
```

```ts
// main.ts
import { start } from "$fresh/server.ts";
import manifest from "@/fresh.gen.ts";

import { BuildSnapshot } from "$fresh/src/build/mod.ts";
import * as base64 from "$std/encoding/base64.ts";

// Load the snapshot
const snapshotText = await Deno.readTextFile("snapshot.json");
const snapshotJson = JSON.parse(snapshotText);

// Implement BuildSnapshot interface
export const snapshot: BuildSnapshot = {
  get paths() {
    return Object.keys(snapshotJson.files);
  },

  read(path: string): Uint8Array | null {
    const v = snapshotJson.files[path];
    if (!v) {
      return null;
    }

    return base64.decode(v);
  },

  dependencies(path: string): string[] {
    return snapshotJson.deps[path] ?? [];
  },
};

// Pass snapshot to the server
await start(manifest, {
  snapshot,
});
```

Now before deployment you can run `deno run -A build.ts` which will generate a `snapshot.json` file that could be used in `main.ts` to load a build snapshot and skip ESBuild phase at runtime.

Use this import URL:

```diff
-    "$fresh/": "https://deno.land/x/fresh@1.2.0/",
+    "$fresh/": "https://raw.githubusercontent.com/zaynetro/fresh/prebuild-js/",
```
</details>

<details> 
<summary>Local development changes</summary>

It is pretty straightforward to update `dev.ts` to support generating a snapshot during development automatically.

We need a new file that will first build the snapshot and then start the server.

```ts
// local-main.ts

await import("@/build.ts");
await import("@/main.ts");
```

Then in your `dev.ts` file update which module to import:

```diff
-await dev(import.meta.url, "./dev.ts");
+await dev(import.meta.url, "./local-main.ts");
```
</details>

I have successfully deployed the changes to Deno Deploy and fly.io. Both show a significant improvement in speed.

Compare:

* Before: https://tall-chicken-56-e4ne5kmyttpg.deno.dev/sudoku/x-wing  (assets fail to load after ~19s)
* After: https://tall-chicken-56-w80p7wmfbwkg.deno.dev/sudoku/x-wing  (assets are loaded in ~40ms)

