### PR TITLE
fix: init banner not colored in ansi256 terminals

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -1,4 +1,4 @@
-import { basename, join, parse, resolve } from "./src/dev/deps.ts";
+import { basename, colors, join, parse, resolve } from "./src/dev/deps.ts";
 import { error } from "./src/dev/error.ts";
 import { collect, ensureMinDenoVersion, generate } from "./src/dev/mod.ts";
 import {
@@ -42,11 +42,14 @@ const flags = parse(Deno.args, {
   default: { "force": null, "twind": null, "vscode": null },
 });
 
+console.log();
 console.log(
-  `\n%c  🍋 Fresh: the next-gen web framework.  %c\n`,
-  "background-color: #86efac; color: black; font-weight: bold",
-  "",
+  colors.bgRgb8(
+    colors.black(colors.bold(" 🍋 Fresh: The next-gen web framework. ")),
+    121,
+  ),
 );
+console.log();
 
 let unresolvedDirectory = Deno.args[0];
 if (flags._.length !== 1) {

--- a/src/dev/deps.ts
+++ b/src/dev/deps.ts
@@ -11,6 +11,7 @@ export {
   SEP,
   toFileUrl,
 } from "https://deno.land/std@0.193.0/path/mod.ts";
+export * as colors from "https://deno.land/std@0.193.0/fmt/colors.ts";
 export { walk, WalkError } from "https://deno.land/std@0.193.0/fs/walk.ts";
 export { parse } from "https://deno.land/std@0.193.0/flags/mod.ts";
 export { gte } from "https://deno.land/std@0.193.0/semver/mod.ts";

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -7,6 +7,7 @@ export {
   toFileUrl,
 } from "https://deno.land/std@0.193.0/path/mod.ts";
 export { walk } from "https://deno.land/std@0.193.0/fs/walk.ts";
+export * as colors from "https://deno.land/std@0.193.0/fmt/colors.ts";
 export {
   type Handler as ServeHandler,
   serve,

--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -1,7 +1,6 @@
 import { ServerContext } from "./context.ts";
-import * as colors from "https://deno.land/std@0.193.0/fmt/colors.ts";
 export { Status } from "./deps.ts";
-import { serve } from "./deps.ts";
+import { colors, serve } from "./deps.ts";
 import {
   AppModule,
   ErrorPageModule,


### PR DESCRIPTION
This basically uses the same fix as #1377 and #1323 for the init script.

Before:

<img width="505" alt="Screenshot 2023-07-12 at 22 18 29" src="https://github.com/denoland/fresh/assets/1062408/e77c3110-d3e2-479e-8381-c67c39e216fa">


After:

<img width="446" alt="Screenshot 2023-07-12 at 22 18 38" src="https://github.com/denoland/fresh/assets/1062408/debda939-bdce-4890-8dfb-265a4e1b8328">
