### PR TITLE
feat: add `fresh` lint preset on update

### DIFF
--- a/update.ts
+++ b/update.ts
@@ -60,6 +60,20 @@ if (denoJson.importMap) {
   await Deno.remove(IMPORT_MAP_PATH);
 }
 
+// Add fresh lint preset
+if (!denoJson.lint) {
+  denoJson.lint = {};
+}
+if (!denoJson.lint.rules) {
+  denoJson.lint.rules = {};
+}
+if (!denoJson.lint.rules.tags) {
+  denoJson.lint.rules.tags = [];
+}
+if (!denoJson.lint.rules.tags.includes("fresh")) {
+  denoJson.lint.rules.tags.push("fresh");
+}
+
 freshImports(denoJson.imports);
 if (denoJson.imports["twind"]) {
   twindImports(denoJson.imports);

--- a/update.ts
+++ b/update.ts
@@ -19,7 +19,7 @@ const help = `fresh-update
 Update a Fresh project. This updates dependencies and optionally performs code
 mods to update a project's source code to the latest recommended patterns.
 
-To upgrade a projecct in the current directory, run:
+To upgrade a project in the current directory, run:
   fresh-update .
 
 USAGE:

--- a/update.ts
+++ b/update.ts
@@ -73,6 +73,9 @@ if (!denoJson.lint.rules.tags) {
 if (!denoJson.lint.rules.tags.includes("fresh")) {
   denoJson.lint.rules.tags.push("fresh");
 }
+if (!denoJson.lint.rules.tags.includes("recommended")) {
+  denoJson.lint.rules.tags.push("recommended");
+}
 
 freshImports(denoJson.imports);
 if (denoJson.imports["twind"]) {


### PR DESCRIPTION
Running the update script should add the `fresh` linting preset if not present.