### PR TITLE
feat: improve Hero responsiveness

### DIFF
--- a/www/components/gallery/Hero.tsx
+++ b/www/components/gallery/Hero.tsx
@@ -3,7 +3,7 @@ import IconChevronRight from "https://deno.land/x/tabler_icons_tsx@0.0.3/tsx/che
 export default function Hero() {
   return (
     <div
-      class="w-full flex px-8 h-96 justify-center items-center flex-col gap-8 bg-cover bg-center bg-no-repeat bg-gray-100 rounded-xl text-white"
+      class="w-full flex px-8 py-10 min-h-[24em] justify-center items-center flex-col gap-8 bg-cover bg-center bg-no-repeat bg-gray-100 rounded-xl text-white"
       style="background-image:linear-gradient(rgba(0, 0, 40, 0.8),rgba(0, 0, 40, 0.8)), url('/gallery/hero-bg.webp');"
     >
       <div class="space-y-4 text-center">
@@ -14,7 +14,7 @@ export default function Hero() {
         </p>
       </div>
 
-      <div>
+      <div class="flex flex-col md:flex-row items-center">
         <a
           href="#"
           class="block mt-4 text-blue-500 cursor-pointer inline-flex items-center group text-blue-800 bg-white px-8 py-2 rounded-md hover:bg-blue-50 font-bold"


### PR DESCRIPTION
The [Hero component example](https://fresh.deno.dev/components) doesn't respond well to smaller display view widths. This PR aims to improve that behavior by forcing a minimum height and enforcing minimum vertical padding.

Additionally, the buttons will start as a column and will extend to a row on the device width of `md` or larger, just like the other components on the Fresh Components page.