### PR TITLE
www: fix spelling error on homepage

### DIFF
--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -250,7 +250,7 @@ function StartJourney() {
       </h2>
       <div class="flex flex-col md:flex-row justify-start items-center gap-4">
         <p class="text(xl gray-600)">
-          Jump right in and build your website with fresh. Lean everything you
+          Jump right in and build your website with fresh. Learn everything you
           need to know in seconds.
         </p>
         <a


### PR DESCRIPTION
At the bottom of the homepage, the call-to-action prompts the user to `Lean everything you need to know in seconds.`

This PR corrects the spelling so that it reads: `Learn everything you need to know in seconds.`