### PR TITLE
Fix a typographical error and additionally improve grammar within the main page.

### DIFF
--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -208,8 +208,8 @@ function Example() {
           <p class="text-gray-600 mb-4">
             Fresh optimizes the page by only shipping JavaScript for areas that
             need it. The rest is completely static HTML rendered by the server.
-            This means browser need to load less code and can display your page
-            quicker.
+            This means the browser needs to load less code and can display pages
+            more quickly.
           </p>
         </div>
         <div class="md:basis-1/2">


### PR DESCRIPTION
1. Improves immediately with a typo fix.
2. Further improves the base English by making the tense if that's what you'd call it match previous usages of "the server", and uses better phrasing for the sentence. 

The revised version improves the sentence structure by replacing "your page" with "pages" to make it more general. Additionally, "quicker" is changed to "more quickly" to maintain consistency with previous sentences and grammatical correctness.
