### PR TITLE
chore: make test more timing resilient

### DIFF
--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -90,7 +90,10 @@ Deno.test({
       );
       await buttonPlus?.click();
 
-      await delay(100);
+      await page.waitForFunction(() => {
+        return document.querySelector("body > div > div > div > p")!
+          .textContent === "4";
+      }, {});
 
       counterValue = await counter?.evaluate((el) => el.textContent);
       assert(counterValue === "4");
@@ -183,7 +186,10 @@ Deno.test({
       );
       await buttonPlus?.click();
 
-      await delay(100);
+      await page.waitForFunction(() => {
+        return document.querySelector("body > div > div > div > p")!
+          .textContent === "4";
+      }, {});
 
       counterValue = await counter?.evaluate((el) => el.textContent);
       assert(counterValue === "4");

--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -102,7 +102,7 @@ Deno.test({
 
       await lines.cancel();
       serverProcess.kill("SIGTERM");
-      await delay(100);
+      await serverProcess.status;
     });
 
     await retry(() => Deno.remove(tmpDirName, { recursive: true }));
@@ -198,7 +198,7 @@ Deno.test({
 
       await lines.cancel();
       serverProcess.kill("SIGTERM");
-      await delay(100);
+      await serverProcess.status;
     });
 
     await retry(() => Deno.remove(tmpDirName, { recursive: true }));
@@ -328,7 +328,7 @@ Deno.test({
 
       await lines.cancel();
       serverProcess.kill("SIGTERM");
-      await delay(100);
+      await serverProcess.status;
     });
 
     await retry(() => Deno.remove(tmpDirName, { recursive: true }));

--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -12,7 +12,11 @@ import {
   puppeteer,
   retry,
 } from "./deps.ts";
-import { startFreshServer, waitForText } from "./test_utils.ts";
+import {
+  clickWhenListenerReady,
+  startFreshServer,
+  waitForText,
+} from "./test_utils.ts";
 
 const assertFileExistence = async (files: string[], dirname: string) => {
   for (const filePath of files) {
@@ -85,10 +89,10 @@ Deno.test({
       let counterValue = await counter?.evaluate((el) => el.textContent);
       assert(counterValue === "3");
 
-      const buttonPlus = await page.$(
+      await clickWhenListenerReady(
+        page,
         "body > div > div > div > button:nth-child(3)",
       );
-      await buttonPlus?.click();
 
       await waitForText(page, "body > div > div > div > p", "4");
 

--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -12,7 +12,7 @@ import {
   puppeteer,
   retry,
 } from "./deps.ts";
-import { startFreshServer } from "./test_utils.ts";
+import { startFreshServer, waitForText } from "./test_utils.ts";
 
 const assertFileExistence = async (files: string[], dirname: string) => {
   for (const filePath of files) {
@@ -90,10 +90,7 @@ Deno.test({
       );
       await buttonPlus?.click();
 
-      await page.waitForFunction(() => {
-        return document.querySelector("body > div > div > div > p")!
-          .textContent === "4";
-      }, {});
+      await waitForText(page, "body > div > div > div > p", "4");
 
       counterValue = await counter?.evaluate((el) => el.textContent);
       assert(counterValue === "4");
@@ -186,10 +183,7 @@ Deno.test({
       );
       await buttonPlus?.click();
 
-      await page.waitForFunction(() => {
-        return document.querySelector("body > div > div > div > p")!
-          .textContent === "4";
-      }, {});
+      await waitForText(page, "body > div > div > div > p", "4");
 
       counterValue = await counter?.evaluate((el) => el.textContent);
       assert(counterValue === "4");

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -5,7 +5,11 @@ import {
   delay,
   Page,
 } from "./deps.ts";
-import { withPageName } from "./test_utils.ts";
+import {
+  clickWhenListenerReady,
+  waitForText,
+  withPageName,
+} from "./test_utils.ts";
 
 Deno.test({
   name: "island tests",
@@ -14,24 +18,11 @@ Deno.test({
       async function counterTest(counterId: string, originalValue: number) {
         const pElem = await page.waitForSelector(`#${counterId} > p`);
 
-        let value = await pElem?.evaluate((el) => el.textContent);
+        const value = await pElem?.evaluate((el) => el.textContent);
         assert(value === `${originalValue}`, `${counterId} first value`);
 
-        const buttonPlus = (await page.$(`#b-${counterId}`))!;
-        await buttonPlus.click();
-
-        await page.waitForFunction(
-          (id, value) => {
-            return document.querySelector(`#${id} > p`)!.textContent ===
-              String(value + 1);
-          },
-          { timeout: 2000 },
-          counterId,
-          originalValue,
-        );
-
-        value = await pElem?.evaluate((el) => el.textContent);
-        assert(value === `${originalValue + 1}`, `${counterId} click`);
+        await clickWhenListenerReady(page, `#b-${counterId}`);
+        await waitForText(page, `#${counterId} > p`, String(originalValue + 1));
       }
 
       await page.goto(`${address}/islands`, {
@@ -74,16 +65,11 @@ Deno.test({
       async function counterTest(counterId: string, originalValue: number) {
         const pElem = await page.waitForSelector(`#${counterId} > p`);
 
-        let value = await pElem?.evaluate((el) => el.textContent);
+        const value = await pElem?.evaluate((el) => el.textContent);
         assert(value === `${originalValue}`, `${counterId} first value`);
 
-        const buttonPlus = await page.$(`#b-${counterId}`);
-        await buttonPlus?.click();
-
-        await delay(100);
-
-        value = await pElem?.evaluate((el) => el.textContent);
-        assert(value === `${originalValue + 1}`, `${counterId} click`);
+        await clickWhenListenerReady(page, `#b-${counterId}`);
+        await waitForText(page, `#${counterId} > p`, String(originalValue + 1));
       }
 
       await page.goto(`${address}/islands/multiple_island_exports`, {
@@ -149,21 +135,10 @@ Deno.test({
 
       await page.waitForSelector(clickableSelector);
 
-      const contentBeforeClick = await getIslandParentTextContent();
-      assert(contentBeforeClick === "HelloWorld");
+      await waitForText(page, `#island-parent`, "HelloWorld");
 
-      await page.click(clickableSelector);
-      await delay(100);
-
-      const contentAfterClick = await getIslandParentTextContent();
-      assert(contentAfterClick === "HelloWorldI'm rendered now");
-
-      async function getIslandParentTextContent() {
-        return await page.$eval(
-          "#island-parent",
-          (el: Element) => el.textContent,
-        );
-      }
+      await clickWhenListenerReady(page, clickableSelector);
+      await waitForText(page, `#island-parent`, "HelloWorldI'm rendered now");
     });
   },
 
@@ -186,24 +161,20 @@ Deno.test({
       const clickableSelector = "#root-fragment-conditional-first-click-me";
       await page.waitForSelector(clickableSelector);
 
-      const contentBeforeClick = await getIslandParentTextContent(page);
-      assert(contentBeforeClick === "HelloWorld");
+      await waitForText(page, "#island-parent", "HelloWorld");
 
-      await page.click(clickableSelector);
-      await delay(100);
-
-      const contentAfterClick = await getIslandParentTextContent(page);
-      assert(contentAfterClick === "I'm rendered on topHelloWorld");
+      await clickWhenListenerReady(page, clickableSelector);
+      await waitForText(
+        page,
+        "#island-parent",
+        "I'm rendered on topHelloWorld",
+      );
     });
   },
 
   sanitizeOps: false,
   sanitizeResources: false,
 });
-
-async function getIslandParentTextContent(page: Page) {
-  return await page.$eval("#island-parent", (el: Element) => el.textContent);
-}
 
 Deno.test({
   name: "island that returns `null`",
@@ -252,10 +223,7 @@ Deno.test({
           waitUntil: "networkidle2",
         });
         await page.waitForSelector("#foo");
-
-        await delay(100);
-        const text = await page.$eval("#foo", (el) => el.textContent);
-        assertEquals(text, "it works");
+        await waitForText(page, "#foo", "it works");
       },
     );
   },
@@ -275,10 +243,7 @@ Deno.test({
           waitUntil: "networkidle2",
         });
         await page.waitForSelector(".island");
-
-        await delay(100);
-        const text = await page.$eval(".island", (el) => el.textContent);
-        assertEquals(text, "it works");
+        await waitForText(page, ".island", "it works");
       },
     );
   },
@@ -344,13 +309,7 @@ Deno.test({
           waitUntil: "networkidle2",
         });
         await page.waitForSelector(".island");
-
-        await delay(100);
-        const text = await page.$eval(
-          ".island .island p",
-          (el) => el.textContent,
-        );
-        assertEquals(text, "it works");
+        await waitForText(page, ".island .island p", "it works");
       },
     );
   },
@@ -371,17 +330,11 @@ Deno.test({
         });
         await page.waitForSelector(".island");
 
-        await delay(100);
-        const text = await page.$eval(
-          ".island .island p",
-          (el) => el.textContent,
-        );
-        assertEquals(text, "it works");
+        await waitForText(page, ".island .island p", "it works");
 
         // Check that there is no duplicated content which could happen
         // when islands aren't initialized correctly
-        const pageText = await page.$eval("#page", (el) => el.textContent);
-        assertEquals(pageText, "it works");
+        await waitForText(page, "#page", "it works");
       },
     );
   },
@@ -403,12 +356,11 @@ Deno.test({
         });
         await page.waitForSelector(".island");
 
-        await delay(100);
-        const text = await page.$eval(
+        await waitForText(
+          page,
           ".island .server .island .server p",
-          (el) => el.textContent,
+          "it works",
         );
-        assertEquals(text, "it works");
       },
     );
   },
@@ -429,18 +381,8 @@ Deno.test({
         });
         await page.waitForSelector(".island");
 
-        await delay(100);
-        const text = await page.$eval(
-          ".island .a",
-          (el) => el.textContent,
-        );
-        assertEquals(text, "it works");
-
-        const text2 = await page.$eval(
-          ".island + .island .b",
-          (el) => el.textContent,
-        );
-        assertEquals(text2, "it works");
+        await waitForText(page, ".island .a", "it works");
+        await waitForText(page, ".island + .island .b", "it works");
       },
     );
   },
@@ -492,12 +434,7 @@ Deno.test({
         });
         await page.waitForSelector(".island");
 
-        await delay(100);
-        const text = await page.$eval(
-          ".island .island p",
-          (el) => el.textContent,
-        );
-        assertEquals(text, "it works");
+        await waitForText(page, ".island .island p", "it works");
       },
     );
   },

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -17,10 +17,18 @@ Deno.test({
         let value = await pElem?.evaluate((el) => el.textContent);
         assert(value === `${originalValue}`, `${counterId} first value`);
 
-        const buttonPlus = await page.$(`#b-${counterId}`);
-        await buttonPlus?.click();
+        const buttonPlus = (await page.$(`#b-${counterId}`))!;
+        await buttonPlus.click();
 
-        await delay(100);
+        await page.waitForFunction(
+          (id, value) => {
+            return document.querySelector(`#${id} > p`)!.textContent ===
+              String(value + 1);
+          },
+          { timeout: 2000 },
+          counterId,
+          originalValue,
+        );
 
         value = await pElem?.evaluate((el) => el.textContent);
         assert(value === `${originalValue + 1}`, `${counterId} click`);

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -60,6 +60,50 @@ export async function startFreshServerExpectErrors(
   return output;
 }
 
+/**
+ * Click on an element once it has an attached click listener
+ */
+export async function clickWhenListenerReady(page: Page, selector: string) {
+  await page.waitForSelector(selector);
+  await page.waitForFunction(
+    (sel) => {
+      const el = document.querySelector(sel)!;
+
+      // Wait for Preact to have attached either a captured or non-captured
+      // click event
+      // deno-lint-ignore no-explicit-any
+      const preactListener = (el as any).l as Record<string, unknown> | null;
+      if (
+        !preactListener || typeof preactListener !== "object" ||
+        (!preactListener.clickfalse && !preactListener.clicktrue)
+      ) {
+        return false;
+      }
+
+      return true;
+    },
+    {},
+    selector,
+  );
+  await page.click(selector);
+}
+
+export async function waitForText(
+  page: Page,
+  selector: string,
+  text: string,
+) {
+  await page.waitForSelector(selector);
+  await page.waitForFunction(
+    (sel, value) => {
+      return document.querySelector(sel)!.textContent === value;
+    },
+    { timeout: 2000 },
+    selector,
+    String(text),
+  );
+}
+
 async function spawnServer(
   options: Deno.CommandOptions,
   expectErrors = false,


### PR DESCRIPTION
This test case is causing flakyness on windows. The previous `delay(100)` is too sensitive to timing differences.

There is a longer backstory to this and something `puppeteer` hasn't addressed in the past years. For context: I worked on a [custom e2e test runner](https://github.com/boxine/pentf) based on `puppeteer` for a client a couple of years back (around 2019-ish). At the time playwright wasn't really a thing so `puppeteer` was the only option.

A common source of problems in e2e testing is that it's not obvious when an element _can_ be safely clicked. Sure, you can always simulate a click on a DOM node, but that doesn't account for the framework potentially not having attached an event listener yet. It's an internal race condition as to when the click is fired. The [cypress blog](https://www.cypress.io/blog/2019/01/22/when-can-the-test-click/) has a good post about the problem. To work around that I've added a `clickWhenListenerReady` helper function that waits until Preact has added a listener before firing the click.

Then there is a very related race condition in that firing the click doesn't mean that the changes have been immediately applied to the DOM. The framework (here Preact) might do some scheduling or maybe something inside puppeteer or even Chrome took a bit longer. It's hard to pinpoint where exactly the issue is, but this leads to cases where the click has fired but the new value has not been written to the DOM yet. A much more reliable way is to instead wait until the expected string is present in the DOM.

I did a couple of local runs on windows and with the changes in this PR I get way less flukes.