### PR TITLE
Added FAQ Page

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -14,5 +14,8 @@
   },
   "test": {
     "exclude": ["www/"]
+  },
+  "fmt": {
+    "exclude": ["docs/faq.md"]
   }
 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
 ---
 description: |
-    We have colleted various questions you asked 
+    We have collected various questions you asked 
     and combined them with our answers this FAQ.
 ---
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,6 @@
+---
+description: |
+    We have colleted various questions you asked 
+    and combined them with our answers this FAQ.
+---
+

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,19 +4,10 @@ description: |
     and combined them with our answers this FAQ.
 ---
 
-
 [Contributing]: https://deno.land/manual@v1.35.1/references/contributing#submitting-a-pr-to-fresh
 [Discussions]: https://github.com/denoland/fresh/discussions
 [Roadmap]: https://github.com/denoland/fresh/issues/563
 [SaaS]: https://deno.com/saaskit
-
-<!-- 
-https://github.com/denoland/fresh/discussions/190
-https://github.com/denoland/fresh/discussions/191
-https://github.com/denoland/fresh/discussions/203
-https://github.com/denoland/fresh/discussions/325
-https://github.com/denoland/fresh/discussions/341
- -->
 
 <br>
 
@@ -66,6 +57,4 @@ Not yet, it's on the **[Roadmap]**, however not as a top priority.
 #### Is there a **SaaS Template**
 
 Deno has a whole **[Page][SaaS]** dedicate to it.
-
-
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,6 +2,8 @@
 description: |
     We have collected various questions you asked 
     and combined them with our answers this FAQ.
+title : |
+    FAQ
 ---
 
 [Contributing]: https://deno.land/manual@v1.35.1/references/contributing#submitting-a-pr-to-fresh

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,3 +4,68 @@ description: |
     and combined them with our answers this FAQ.
 ---
 
+
+[Contributing]: https://deno.land/manual@v1.35.1/references/contributing#submitting-a-pr-to-fresh
+[Discussions]: https://github.com/denoland/fresh/discussions
+[Roadmap]: https://github.com/denoland/fresh/issues/563
+[SaaS]: https://deno.com/saaskit
+
+<!-- 
+https://github.com/denoland/fresh/discussions/190
+https://github.com/denoland/fresh/discussions/191
+https://github.com/denoland/fresh/discussions/203
+https://github.com/denoland/fresh/discussions/325
+https://github.com/denoland/fresh/discussions/341
+ -->
+
+<br>
+
+## Usage
+
+#### What should I **Learn** before using Fresh
+
+HTML, CSS, TypeScript and Preact
+
+<br>
+
+## Project
+
+#### Is there a **Roadmap**
+
+Currently the roadmap is tracked as a **[GitHub Issue][Roadmap]**.
+
+#### Can I talk to the **Core Maintainer**
+
+You can find **Marvin** on the following platforms:
+
+-   Discord **@marvin_h** for quick questions
+
+-   **[GitHub][Discussions]** for longer form discussions
+
+<br>
+
+## Development
+
+#### Is there a **Contribution Guide**
+
+Not one dedicated to Fresh, only the general **[Deno Guidelines][Contributing]**.
+
+#### Do you accept **Localizations** for documentation
+
+We would like to in the future, however it will need to be properly  
+coordinated to keep the translations maintained and up-to-date.
+
+<br>
+
+## Features
+
+#### Do you offer **i18** support
+
+Not yet, it's on the **[Roadmap]**, however not as a top priority.
+
+#### Is there a **SaaS Template**
+
+Deno has a whole **[Page][SaaS]** dedicate to it.
+
+
+

--- a/www/components/NavigationBar.tsx
+++ b/www/components/NavigationBar.tsx
@@ -17,6 +17,10 @@ export default function NavigationBar(
       href: "/components",
     },
     {
+      name: "FAQ",
+      href: "/faq",
+    },
+    {
       name: "Blog",
       href: "https://deno.com/blog?tag=fresh",
     },

--- a/www/fresh.gen.ts
+++ b/www/fresh.gen.ts
@@ -8,11 +8,12 @@ import * as $2 from "./routes/_middleware.ts";
 import * as $3 from "./routes/components.tsx";
 import * as $4 from "./routes/docs/[...slug].tsx";
 import * as $5 from "./routes/docs/index.tsx";
-import * as $6 from "./routes/gfm.css.ts";
-import * as $7 from "./routes/index.tsx";
-import * as $8 from "./routes/raw.ts";
-import * as $9 from "./routes/showcase.tsx";
-import * as $10 from "./routes/update.tsx";
+import * as $6 from "./routes/faq.tsx";
+import * as $7 from "./routes/gfm.css.ts";
+import * as $8 from "./routes/index.tsx";
+import * as $9 from "./routes/raw.ts";
+import * as $10 from "./routes/showcase.tsx";
+import * as $11 from "./routes/update.tsx";
 import * as $$0 from "./islands/ComponentGallery.tsx";
 import * as $$1 from "./islands/CopyArea.tsx";
 import * as $$2 from "./islands/Counter.tsx";
@@ -28,11 +29,12 @@ const manifest = {
     "./routes/components.tsx": $3,
     "./routes/docs/[...slug].tsx": $4,
     "./routes/docs/index.tsx": $5,
-    "./routes/gfm.css.ts": $6,
-    "./routes/index.tsx": $7,
-    "./routes/raw.ts": $8,
-    "./routes/showcase.tsx": $9,
-    "./routes/update.tsx": $10,
+    "./routes/faq.tsx": $6,
+    "./routes/gfm.css.ts": $7,
+    "./routes/index.tsx": $8,
+    "./routes/raw.ts": $9,
+    "./routes/showcase.tsx": $10,
+    "./routes/update.tsx": $11,
   },
   islands: {
     "./islands/ComponentGallery.tsx": $$0,

--- a/www/routes/faq.tsx
+++ b/www/routes/faq.tsx
@@ -63,10 +63,9 @@ function FAQ(props: PageProps<Data>) {
 }
 
 function Content(props: { markdown: string }) {
-  
-    let html = gfm.render(props.markdown);
+  let html = gfm.render(props.markdown);
 
-    html += `
+  html += `
     
         <style>
 
@@ -75,7 +74,7 @@ function Content(props: { markdown: string }) {
             }
 
         </style>
-    `
+    `;
 
   return (
     <div class="flex justify-center">
@@ -85,7 +84,7 @@ function Content(props: { markdown: string }) {
         </h1>
         <div
           class="mt-6 markdown-body"
-          dangerouslySetInnerHTML={{ __html : html }}
+          dangerouslySetInnerHTML={{ __html: html }}
         />
       </main>
     </div>

--- a/www/routes/faq.tsx
+++ b/www/routes/faq.tsx
@@ -1,6 +1,3 @@
-export default FAQ;
-export { handler };
-
 import { Handlers, PageProps } from "$fresh/server.ts";
 import { frontMatter, gfm } from "../utils/markdown.ts";
 import { asset, Head } from "$fresh/runtime.ts";
@@ -15,7 +12,7 @@ interface Data {
   };
 }
 
-const handler = {
+export const handler: Handlers<Data> = {
   async GET(_req, ctx) {
     const url = new URL(`../../docs/faq.md`, import.meta.url);
     const fileContent = await Deno.readTextFile(url);
@@ -30,9 +27,9 @@ const handler = {
 
     return ctx.render(data);
   },
-} satisfies Handlers;
+};
 
-function FAQ(props: PageProps<Data>) {
+export default function FAQ(props: PageProps<Data>) {
   const ogImageUrl = new URL(asset("/home-og.png"), props.url).href;
   let description = "Fresh Document";
 
@@ -40,13 +37,19 @@ function FAQ(props: PageProps<Data>) {
     description = String(props.data.page.data.description);
   }
 
+  let title = "FAQ";
+
+  if (props.data.page.data.title) {
+    title = String(props.data.page.data.title);
+  }
+
   return (
     <>
       <Head>
-        <title>FAQ</title>
+        <title>{title}</title>
         <link rel="stylesheet" href={asset("/gfm.css")} />
         <meta name="description" content={description} />
-        <meta property="og:title" content="FAQ" />
+        <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
         <meta property="og:type" content="website" />
         <meta property="og:url" content={props.url.href} />
@@ -55,14 +58,14 @@ function FAQ(props: PageProps<Data>) {
       </Head>
       <div class="flex flex-col min-h-screen">
         <Header title="docs" active="/faq" />
-        <Content markdown={props.data.page.markdown} />
+        <Content markdown={props.data.page.markdown} title={title} />
         <Footer />
       </div>
     </>
   );
 }
 
-function Content(props: { markdown: string }) {
+function Content(props: { markdown: string; title: string }) {
   let html = gfm.render(props.markdown);
 
   html += `
@@ -80,7 +83,7 @@ function Content(props: { markdown: string }) {
     <div class="flex justify-center">
       <main class="py-6 max-w-[700px] min-w-[min(60%,700px)]">
         <h1 class="text(4xl gray-900) tracking-tight font-extrabold mt-6 md:mt-0">
-          FAQ
+          {props.title}
         </h1>
         <div
           class="mt-6 markdown-body"

--- a/www/routes/faq.tsx
+++ b/www/routes/faq.tsx
@@ -1,0 +1,80 @@
+export default FAQ;
+export { handler };
+
+import { Handlers, PageProps } from "$fresh/server.ts";
+import { frontMatter, gfm } from "../utils/markdown.ts";
+import { asset, Head } from "$fresh/runtime.ts";
+
+import Footer from "../components/Footer.tsx";
+import Header from "../components/Header.tsx";
+
+interface Data {
+  page: {
+    markdown: string;
+    data: Record<string, unknown>;
+  };
+}
+
+const handler = {
+  async GET(_req, ctx) {
+    const url = new URL(`../../docs/faq.md`, import.meta.url);
+    const fileContent = await Deno.readTextFile(url);
+    const { body, attrs } = frontMatter<Record<string, unknown>>(fileContent);
+
+    const data = {
+      page: {
+        markdown: body,
+        data: attrs ?? {},
+      },
+    } satisfies Data;
+
+    return ctx.render(data);
+  },
+} satisfies Handlers;
+
+function FAQ(props: PageProps<Data>) {
+  const ogImageUrl = new URL(asset("/home-og.png"), props.url).href;
+  let description = "Fresh Document";
+
+  if (props.data.page.data.description) {
+    description = String(props.data.page.data.description);
+  }
+
+  return (
+    <>
+      <Head>
+        <title>FAQ</title>
+        <link rel="stylesheet" href={asset("/gfm.css")} />
+        <meta name="description" content={description} />
+        <meta property="og:title" content="FAQ" />
+        <meta property="og:description" content={description} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={props.url.href} />
+        <meta property="og:image" content={ogImageUrl} />
+        <meta name="view-transition" content="same-origin" />
+      </Head>
+      <div class="flex flex-col min-h-screen">
+        <Header title="docs" active="/faq" />
+        <Content markdown={props.data.page.markdown} />
+        <Footer />
+      </div>
+    </>
+  );
+}
+
+function Content(props: { markdown: string }) {
+  const html = gfm.render(props.markdown);
+  return (
+    <div class="flex justify-center">
+      <main class="py-6 max-w-[700px]">
+        <h1 class="text(4xl gray-900) tracking-tight font-extrabold mt-6 md:mt-0">
+          FAQ
+        </h1>
+        <div
+          class="mt-6 markdown-body"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </main>
+    </div>
+  );
+}

--- a/www/routes/faq.tsx
+++ b/www/routes/faq.tsx
@@ -63,16 +63,29 @@ function FAQ(props: PageProps<Data>) {
 }
 
 function Content(props: { markdown: string }) {
-  const html = gfm.render(props.markdown);
+  
+    let html = gfm.render(props.markdown);
+
+    html += `
+    
+        <style>
+
+            .markdown-body h4 strong {
+                color : #c35b62 ;
+            }
+
+        </style>
+    `
+
   return (
     <div class="flex justify-center">
-      <main class="py-6 max-w-[700px]">
+      <main class="py-6 max-w-[700px] min-w-[min(60%,700px)]">
         <h1 class="text(4xl gray-900) tracking-tight font-extrabold mt-6 md:mt-0">
           FAQ
         </h1>
         <div
           class="mt-6 markdown-body"
-          dangerouslySetInnerHTML={{ __html: html }}
+          dangerouslySetInnerHTML={{ __html : html }}
         />
       </main>
     </div>


### PR DESCRIPTION
<br>

> As with any bigger open source project I'm quite 
> concerned about the count of issues / discussions.
>
> While Fresh is still on the 'lower' side, 
> I can easily see it getting worse quickly.
>
> To this end I would like to propose - for one -
> to extract questions and answers from both
> places into a dedicated FAQ and with it,
> close the source tickets / discussions.

### Steps

- [x] Add FAQ route
- [x] Collect questions & answers
- [x] Process and write them out
- [ ] Close source issues / discussions 

### To Be Closed

Discussions that can be closed once the FAQ is merged.

- #190 
- #191
- #203 
- #325 
- #341

<br>

![image](https://github.com/denoland/fresh/assets/73050054/d37a07fd-00e0-4bed-9571-8b54d01275fc)


<br>