### PR TITLE
fix: generate only one random Content-Security-Policy nonce per render

### DIFF
--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -896,3 +896,33 @@ Deno.test({
   sanitizeOps: false,
   sanitizeResources: false,
 });
+
+Deno.test({
+  name: "Generate a single nonce value per page",
+
+  async fn() {
+    await withPageName("./tests/fixture/main.ts", async (page, address) => {
+      await page.goto(address);
+      await page.waitForSelector("p");
+
+      const nonceValues = await page.evaluate(() =>
+        Array.from(
+          new Set(
+            Array.from(document.querySelectorAll("[nonce]")).map((el) =>
+              el.getAttribute("nonce")
+            ),
+          ),
+        )
+      );
+
+      assertEquals(
+        nonceValues.length,
+        1,
+        `Found more than 1 nonce value per render`,
+      );
+    });
+  },
+
+  sanitizeOps: false,
+  sanitizeResources: false,
+});


### PR DESCRIPTION
This pull request modifies the server rendering step to generate only one random Content-Security-Policy (CSP) nonce per each `render(...)` call (when CSP headers are enabled).

Previously a separate nonce was generated during rendering for each module script and the inline script. This was not strictly necessary: [one nonce for every response](https://web.dev/strict-csp/#step-1-decide-if-you-need-a-nonce-or-hash-based-csp) is enough. Having multiple nonces ends up making things (_very theoretically_) easier for an attacker's standpoint, as just one of the multiple nonces has to be guessed to circumvent the CSP.

This pull request also modifies the internal `addImport` helper to skip nonce generation, as those nonces didn't end up being used anywhere.