### PR TITLE
fix: current version not updated in update check

### DIFF
--- a/src/dev/deps.ts
+++ b/src/dev/deps.ts
@@ -11,7 +11,7 @@ export {
   SEP,
   toFileUrl,
 } from "https://deno.land/std@0.193.0/path/mod.ts";
-export { DAY } from "https://deno.land/std@0.193.0/datetime/constants.ts";
+export { DAY, WEEK } from "https://deno.land/std@0.193.0/datetime/constants.ts";
 export * as colors from "https://deno.land/std@0.193.0/fmt/colors.ts";
 export { walk, WalkError } from "https://deno.land/std@0.193.0/fs/walk.ts";
 export { parse } from "https://deno.land/std@0.193.0/flags/mod.ts";

--- a/src/dev/update_check.ts
+++ b/src/dev/update_check.ts
@@ -1,6 +1,6 @@
 import { colors, join } from "./deps.ts";
 
-interface CheckFile {
+export interface CheckFile {
   last_checked: string;
   latest_version: string;
   current_version: string;
@@ -87,6 +87,9 @@ export async function updateCheck(
       throw err;
     }
   }
+
+  // Update current version
+  checkFile.current_version = versions[0];
 
   // Only check in the specificed interval
   if (Date.now() >= new Date(checkFile.last_checked).getTime() + interval) {

--- a/tests/cli_update_check_test.ts
+++ b/tests/cli_update_check_test.ts
@@ -5,6 +5,8 @@ import {
   assertNotMatch,
 } from "$std/testing/asserts.ts";
 import versions from "../versions.json" assert { type: "json" };
+import { CheckFile } from "$fresh/src/dev/update_check.ts";
+import { WEEK } from "$fresh/src/dev/deps.ts";
 
 Deno.test({
   name: "stores update check file in $HOME/fresh",
@@ -78,20 +80,20 @@ Deno.test({
       env: {
         CI: "false",
         HOME: tmpDirName,
-        LATEST_VERSION: "1.30.0",
+        LATEST_VERSION: "999.999.0",
       },
     }).output();
 
     const decoder = new TextDecoder();
 
     const stdout = colors.stripColor(decoder.decode(out.stdout));
-    assertMatch(stdout, /Fresh 1\.30\.0 is available/);
+    assertMatch(stdout, /Fresh 999\.999\.0 is available/);
 
     // Updates check file
     const text = JSON.parse(await Deno.readTextFile(filePath));
     assertEquals(text, {
-      current_version: "1.1.0",
-      latest_version: "1.30.0",
+      current_version: versions[0],
+      latest_version: "999.999.0",
       last_checked: text.last_checked,
     });
 
@@ -150,6 +152,38 @@ Deno.test({
       const stdout = colors.stripColor(decoder.decode(out.stdout));
       assertMatch(stdout, /fetching latest version/);
     });
+
+    await Deno.remove(tmpDirName, { recursive: true });
+  },
+});
+
+Deno.test({
+  name: "updates current version in cache file",
+  async fn() {
+    const tmpDirName = await Deno.makeTempDir();
+
+    const checkFile: CheckFile = {
+      current_version: "1.2.0",
+      latest_version: "1.2.0",
+      last_checked: new Date(Date.now() - WEEK).toISOString(),
+    };
+
+    await Deno.writeTextFile(
+      join(tmpDirName, "latest.json"),
+      JSON.stringify(checkFile, null, 2),
+    );
+
+    const out = await new Deno.Command(Deno.execPath(), {
+      args: ["run", "-A", "./tests/fixture_update_check/mod.ts"],
+      env: {
+        HOME: tmpDirName,
+        LATEST_VERSION: versions[0],
+      },
+    }).output();
+
+    const decoder = new TextDecoder();
+    const stdout = colors.stripColor(decoder.decode(out.stdout));
+    assertNotMatch(stdout, /Fresh .* is available/);
 
     await Deno.remove(tmpDirName, { recursive: true });
   },


### PR DESCRIPTION
Discovered an issue with the update check logic which caused the current version never to be updated once it was written into the cache file.

@lino-levan I think this is the same issue you were seeing yesterday.