### PR TITLE
fix: Prevent deserialize break on safari < 15.4

### DIFF
--- a/src/runtime/deserializer.ts
+++ b/src/runtime/deserializer.ts
@@ -56,7 +56,7 @@ export function deserialize(
         (o, k) => k === null ? o : o[k],
         v,
       );
-      parent[refPath.slice(-1)[0]!] = target;
+      parent[refPath[refPath.length - 1]!] = target;
     }
   }
   return v;

--- a/src/runtime/deserializer.ts
+++ b/src/runtime/deserializer.ts
@@ -56,7 +56,7 @@ export function deserialize(
         (o, k) => k === null ? o : o[k],
         v,
       );
-      parent[refPath.at(-1)!] = target;
+      parent[refPath.slice(-1)[0]!] = target;
     }
   }
   return v;


### PR DESCRIPTION
## The problem
The `Array.prototype.at` is only available at safari >= 15.4 [caniuse](https://caniuse.com/?search=Array.prototype.at)
![image](https://github.com/denoland/fresh/assets/15680320/3f351eb6-f84c-404e-ab10-35584fef55be). So, the hydration breaks in older browsers.

Preview: https://deco-sites-fashion-nfcj5n1zeycg.deno.dev/

## The solution
This PR changes the `.at(-1)` to `[array.length - 1]`.
