### PR TITLE
fix(search): add explicit target for search button deps

### DIFF
--- a/www/islands/SearchButton.tsx
+++ b/www/islands/SearchButton.tsx
@@ -1,6 +1,6 @@
 import { Head } from "$fresh/runtime.ts";
 import { useEffect, useRef } from "preact/hooks";
-import docsearch from "https://esm.sh/@docsearch/js@3";
+import docsearch from "https://esm.sh/@docsearch/js@3?target=es2020";
 
 export default function SearchButton(props: { class?: string }) {
   const ref = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
closes #1441 (hopefully 🤞 ).

following the discussion in the aforementioned issue, it just might be the case that esm.sh is spitting out the wrong target for our island.

this has been also been a re-appearing issue on `fresh_charts` and `saaskit` when introducing a client-side rendered `chart.js` chart.

for further reference there's also the following issue:
https://github.com/denoland/fresh/issues/1125
