### PR TITLE
chore: don't run tests in parallel on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: set "PUPPETEER_PRODUCT=chrome" && deno run -A --unstable https://deno.land/x/puppeteer@16.2.0/install.ts
 
       - name: Run tests
-        run: deno test -A --parallel
+        run: deno test -A
 
       - name: Type check init script
         run: deno check --remote init.ts


### PR DESCRIPTION
Trying out if the windows CI gets more stable when we don't run our tests in parallel.