### PR TITLE
Fix island ordering bug

### DIFF
--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -305,7 +305,14 @@ function _walkInner(
         _walkInner(islands, props, markerStack, vnodeStack, sib.firstChild);
       }
 
-      if (marker !== null && marker.kind === MarkerKind.Slot) {
+      // Pop vnode if current marker is a slot or we are an island marker
+      // that was created inside another island
+      if (
+        marker !== null &&
+        (marker.kind === MarkerKind.Slot ||
+          markerStack.length > 1 &&
+            markerStack[markerStack.length - 2].kind === MarkerKind.Island)
+      ) {
         vnodeStack.pop();
       }
     }

--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -21,8 +21,8 @@ function createRootFragment(
     parentNode: parent,
     firstChild: replaceNode[0],
     childNodes: replaceNode,
-    insertBefore(node: Node, child: Node) {
-      parent.insertBefore(node, child);
+    insertBefore(node: Node, child: Node | null) {
+      parent.insertBefore(node, child ?? endMarker);
     },
     appendChild(child: Node) {
       // We cannot blindly call `.append()` as that would add

--- a/tests/fixture_island_nesting/deno.json
+++ b/tests/fixture_island_nesting/deno.json
@@ -5,8 +5,8 @@
   },
   "imports": {
     "$fresh/": "../../",
-    "preact": "https://esm.sh/preact@10.15.1",
-    "preact/": "https://esm.sh/preact@10.15.1/",
+    "preact": "https://esm.sh/preact@10.16.0",
+    "preact/": "https://esm.sh/preact@10.16.0/",
     "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.0",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
     "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.2.3"

--- a/tests/fixture_island_nesting/fresh.gen.ts
+++ b/tests/fixture_island_nesting/fresh.gen.ts
@@ -4,39 +4,45 @@
 
 import * as $0 from "./routes/index.tsx";
 import * as $1 from "./routes/island_conditional.tsx";
-import * as $2 from "./routes/island_in_island.tsx";
-import * as $3 from "./routes/island_in_island_definition.tsx";
-import * as $4 from "./routes/island_jsx_child.tsx";
-import * as $5 from "./routes/island_jsx_children.tsx";
-import * as $6 from "./routes/island_jsx_island_jsx.tsx";
-import * as $7 from "./routes/island_jsx_text.tsx";
-import * as $8 from "./routes/island_nested_props.tsx";
-import * as $9 from "./routes/island_siblings.tsx";
+import * as $2 from "./routes/island_fn_child.tsx";
+import * as $3 from "./routes/island_in_island.tsx";
+import * as $4 from "./routes/island_in_island_definition.tsx";
+import * as $5 from "./routes/island_jsx_child.tsx";
+import * as $6 from "./routes/island_jsx_children.tsx";
+import * as $7 from "./routes/island_jsx_island_jsx.tsx";
+import * as $8 from "./routes/island_jsx_text.tsx";
+import * as $9 from "./routes/island_nested_props.tsx";
+import * as $10 from "./routes/island_siblings.tsx";
 import * as $$0 from "./islands/BooleanButton.tsx";
-import * as $$1 from "./islands/Island.tsx";
-import * as $$2 from "./islands/IslandConditional.tsx";
-import * as $$3 from "./islands/IslandInsideIsland.tsx";
-import * as $$4 from "./islands/IslandWithProps.tsx";
+import * as $$1 from "./islands/FragmentIsland.tsx";
+import * as $$2 from "./islands/Island.tsx";
+import * as $$3 from "./islands/IslandConditional.tsx";
+import * as $$4 from "./islands/IslandFn.tsx";
+import * as $$5 from "./islands/IslandInsideIsland.tsx";
+import * as $$6 from "./islands/IslandWithProps.tsx";
 
 const manifest = {
   routes: {
     "./routes/index.tsx": $0,
     "./routes/island_conditional.tsx": $1,
-    "./routes/island_in_island.tsx": $2,
-    "./routes/island_in_island_definition.tsx": $3,
-    "./routes/island_jsx_child.tsx": $4,
-    "./routes/island_jsx_children.tsx": $5,
-    "./routes/island_jsx_island_jsx.tsx": $6,
-    "./routes/island_jsx_text.tsx": $7,
-    "./routes/island_nested_props.tsx": $8,
-    "./routes/island_siblings.tsx": $9,
+    "./routes/island_fn_child.tsx": $2,
+    "./routes/island_in_island.tsx": $3,
+    "./routes/island_in_island_definition.tsx": $4,
+    "./routes/island_jsx_child.tsx": $5,
+    "./routes/island_jsx_children.tsx": $6,
+    "./routes/island_jsx_island_jsx.tsx": $7,
+    "./routes/island_jsx_text.tsx": $8,
+    "./routes/island_nested_props.tsx": $9,
+    "./routes/island_siblings.tsx": $10,
   },
   islands: {
     "./islands/BooleanButton.tsx": $$0,
-    "./islands/Island.tsx": $$1,
-    "./islands/IslandConditional.tsx": $$2,
-    "./islands/IslandInsideIsland.tsx": $$3,
-    "./islands/IslandWithProps.tsx": $$4,
+    "./islands/FragmentIsland.tsx": $$1,
+    "./islands/Island.tsx": $$2,
+    "./islands/IslandConditional.tsx": $$3,
+    "./islands/IslandFn.tsx": $$4,
+    "./islands/IslandInsideIsland.tsx": $$5,
+    "./islands/IslandWithProps.tsx": $$6,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/fixture_island_nesting/fresh.gen.ts
+++ b/tests/fixture_island_nesting/fresh.gen.ts
@@ -12,14 +12,16 @@ import * as $6 from "./routes/island_jsx_children.tsx";
 import * as $7 from "./routes/island_jsx_island_jsx.tsx";
 import * as $8 from "./routes/island_jsx_text.tsx";
 import * as $9 from "./routes/island_nested_props.tsx";
-import * as $10 from "./routes/island_siblings.tsx";
+import * as $10 from "./routes/island_order.tsx";
+import * as $11 from "./routes/island_siblings.tsx";
 import * as $$0 from "./islands/BooleanButton.tsx";
 import * as $$1 from "./islands/FragmentIsland.tsx";
 import * as $$2 from "./islands/Island.tsx";
-import * as $$3 from "./islands/IslandConditional.tsx";
-import * as $$4 from "./islands/IslandFn.tsx";
-import * as $$5 from "./islands/IslandInsideIsland.tsx";
-import * as $$6 from "./islands/IslandWithProps.tsx";
+import * as $$3 from "./islands/IslandCenter.tsx";
+import * as $$4 from "./islands/IslandConditional.tsx";
+import * as $$5 from "./islands/IslandFn.tsx";
+import * as $$6 from "./islands/IslandInsideIsland.tsx";
+import * as $$7 from "./islands/IslandWithProps.tsx";
 
 const manifest = {
   routes: {
@@ -33,16 +35,18 @@ const manifest = {
     "./routes/island_jsx_island_jsx.tsx": $7,
     "./routes/island_jsx_text.tsx": $8,
     "./routes/island_nested_props.tsx": $9,
-    "./routes/island_siblings.tsx": $10,
+    "./routes/island_order.tsx": $10,
+    "./routes/island_siblings.tsx": $11,
   },
   islands: {
     "./islands/BooleanButton.tsx": $$0,
     "./islands/FragmentIsland.tsx": $$1,
     "./islands/Island.tsx": $$2,
-    "./islands/IslandConditional.tsx": $$3,
-    "./islands/IslandFn.tsx": $$4,
-    "./islands/IslandInsideIsland.tsx": $$5,
-    "./islands/IslandWithProps.tsx": $$6,
+    "./islands/IslandCenter.tsx": $$3,
+    "./islands/IslandConditional.tsx": $$4,
+    "./islands/IslandFn.tsx": $$5,
+    "./islands/IslandInsideIsland.tsx": $$6,
+    "./islands/IslandWithProps.tsx": $$7,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/fixture_island_nesting/islands/FragmentIsland.tsx
+++ b/tests/fixture_island_nesting/islands/FragmentIsland.tsx
@@ -1,0 +1,8 @@
+export default function FragmentIsland() {
+  return (
+    <>
+      <p>it{" "}</p>
+      <p>works</p>
+    </>
+  );
+}

--- a/tests/fixture_island_nesting/islands/IslandCenter.tsx
+++ b/tests/fixture_island_nesting/islands/IslandCenter.tsx
@@ -1,0 +1,3 @@
+export default function IslandCenter() {
+  return <p class="island">center</p>;
+}

--- a/tests/fixture_island_nesting/islands/IslandFn.tsx
+++ b/tests/fixture_island_nesting/islands/IslandFn.tsx
@@ -1,0 +1,17 @@
+import { VNode } from "preact";
+
+import FragmentIsland from "./FragmentIsland.tsx";
+
+function Foo(props: { children: () => VNode }) {
+  return props.children();
+}
+
+export default function IslandFn() {
+  return (
+    <div class="island">
+      <Foo>
+        {() => <FragmentIsland />}
+      </Foo>
+    </div>
+  );
+}

--- a/tests/fixture_island_nesting/routes/island_fn_child.tsx
+++ b/tests/fixture_island_nesting/routes/island_fn_child.tsx
@@ -1,0 +1,9 @@
+import IslandFn from "../islands/IslandFn.tsx";
+
+export default function Home() {
+  return (
+    <div id="page">
+      <IslandFn />
+    </div>
+  );
+}

--- a/tests/fixture_island_nesting/routes/island_order.tsx
+++ b/tests/fixture_island_nesting/routes/island_order.tsx
@@ -1,0 +1,11 @@
+import IslandCenter from "../islands/IslandCenter.tsx";
+
+export default function IslandOrder() {
+  return (
+    <div id="page">
+      <p>left</p>
+      <IslandCenter />
+      <p>right</p>
+    </div>
+  );
+}

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -460,3 +460,21 @@ Deno.test({
   sanitizeOps: false,
   sanitizeResources: false,
 });
+
+Deno.test({
+  name: "render nested islands in correct order",
+
+  async fn(_t) {
+    await withPageName(
+      "./tests/fixture_island_nesting/main.ts",
+      async (page, address) => {
+        await page.goto(`${address}/island_order`);
+        await page.waitForSelector(".island");
+        await waitForText(page, "#page", "leftcenterright");
+      },
+    );
+  },
+
+  sanitizeOps: false,
+  sanitizeResources: false,
+});

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -442,3 +442,21 @@ Deno.test({
   sanitizeOps: false,
   sanitizeResources: false,
 });
+
+Deno.test({
+  name: "render island inside island when passed as fn child",
+
+  async fn(_t) {
+    await withPageName(
+      "./tests/fixture_island_nesting/main.ts",
+      async (page, address) => {
+        await page.goto(`${address}/island_fn_child`);
+        await page.waitForSelector(".island");
+        await waitForText(page, "#page", "it works");
+      },
+    );
+  },
+
+  sanitizeOps: false,
+  sanitizeResources: false,
+});


### PR DESCRIPTION
Rendering an island that was instantiated inside an island, but was rendered outside of said island in another component, triggered an edge case which would lead to duplicated HTML. We were missing a check for when an island ends up being nested in another one to keep the current vnode stack in sync.

Fixes the duplicate HTML issue mentioned in #1491 .

Before:

<img width="382" alt="Screenshot 2023-07-20 at 21 02 41" src="https://github.com/denoland/fresh/assets/1062408/3acc4ce9-48df-4490-81e9-b9034d65e16d">

After:

<img width="367" alt="Screenshot 2023-07-20 at 21 02 57" src="https://github.com/denoland/fresh/assets/1062408/6163b446-4734-4f64-9808-44e166c3f84e">
