### PR TITLE
fix: Only show update message if current < latest

### DIFF
--- a/src/dev/deps.ts
+++ b/src/dev/deps.ts
@@ -17,6 +17,7 @@ export { walk, WalkError } from "https://deno.land/std@0.193.0/fs/walk.ts";
 export { parse } from "https://deno.land/std@0.193.0/flags/mod.ts";
 export { gte } from "https://deno.land/std@0.193.0/semver/mod.ts";
 export { existsSync } from "https://deno.land/std@0.193.0/fs/mod.ts";
+export * as semver from "https://deno.land/std@0.195.0/semver/mod.ts";
 
 // ts-morph
 export { Node, Project } from "https://deno.land/x/ts_morph@17.0.1/mod.ts";

--- a/src/dev/update_check.ts
+++ b/src/dev/update_check.ts
@@ -1,4 +1,4 @@
-import { colors, join } from "./deps.ts";
+import { colors, join, semver } from "./deps.ts";
 
 export interface CheckFile {
   last_checked: string;
@@ -34,20 +34,6 @@ function getFreshCacheDir(): string | null {
   const home = getHomeDir();
   if (home) return join(home, "fresh");
   return null;
-}
-
-const SEMVER_REG = /^(\d+)\.(\d+)\.(\d+)$/;
-function sortSemver(current: string, latest: string): number {
-  if (current === latest) return 0;
-
-  const currentParts = current.match(SEMVER_REG);
-  const latestParts = latest.match(SEMVER_REG);
-  if (!currentParts || !latestParts) return 0;
-
-  if (+currentParts[0] < +latestParts[0]) return -1;
-  if (+currentParts[1] < +latestParts[1]) return -1;
-  if (+currentParts[2] < +latestParts[2]) return -1;
-  return 1;
 }
 
 async function fetchLatestVersion() {
@@ -126,8 +112,10 @@ export async function updateCheck(
   }
 
   // Only show update message if current version is smaller than latest
+  const currentVersion = semver.parse(checkFile.current_version);
+  const latestVersion = semver.parse(checkFile.latest_version);
   if (
-    sortSemver(checkFile.current_version, checkFile.latest_version) === -1
+    semver.lt(currentVersion, latestVersion)
   ) {
     const current = colors.bold(colors.rgb8(checkFile.current_version, 208));
     const latest = colors.bold(colors.rgb8(checkFile.latest_version, 121));

--- a/tests/cli_update_check_test.ts
+++ b/tests/cli_update_check_test.ts
@@ -188,3 +188,36 @@ Deno.test({
     await Deno.remove(tmpDirName, { recursive: true });
   },
 });
+
+Deno.test({
+  name: "only shows update message when current < latest",
+  async fn() {
+    const tmpDirName = await Deno.makeTempDir();
+
+    const checkFile: CheckFile = {
+      current_version: "9999.999.0",
+      latest_version: "1.2.0",
+      last_checked: new Date().toISOString(),
+    };
+
+    await Deno.writeTextFile(
+      join(tmpDirName, "latest.json"),
+      JSON.stringify(checkFile, null, 2),
+    );
+
+    const out = await new Deno.Command(Deno.execPath(), {
+      args: ["run", "-A", "./tests/fixture_update_check/mod.ts"],
+      env: {
+        HOME: tmpDirName,
+        LATEST_VERSION: versions[0],
+        CURRENT_VERSION: "99999.9999.00",
+      },
+    }).output();
+
+    const decoder = new TextDecoder();
+    const stdout = colors.stripColor(decoder.decode(out.stdout));
+    assertNotMatch(stdout, /Fresh .* is available/);
+
+    await Deno.remove(tmpDirName, { recursive: true });
+  },
+});

--- a/tests/fixture_update_check/mod.ts
+++ b/tests/fixture_update_check/mod.ts
@@ -6,5 +6,15 @@ async function getLatestVersion() {
   return Deno.env.get("LATEST_VERSION") ?? "99.99.999";
 }
 
+// deno-lint-ignore require-await
+async function getCurrentVersion() {
+  return Deno.env.get("CURRENT_VERSION")!;
+}
+
 const interval = +(Deno.env.get("UPDATE_INTERVAL") ?? 1000);
-await updateCheck(interval, () => Deno.env.get("HOME")!, getLatestVersion);
+await updateCheck(
+  interval,
+  () => Deno.env.get("HOME")!,
+  getLatestVersion,
+  Deno.env.has("CURRENT_VERSION") ? getCurrentVersion : undefined,
+);


### PR DESCRIPTION
Noticed that we still had a case where the cache has the old value latest and users may have just upgraded to a newer version than in the cache, that we'd still show the upgrade message. This was because we only checked if `current !== latest`, which doesn't account for the `current > latest`.

Note that this only during the time interval between a new release and the next update check. Once the update check updates the cache we don't run in the situation where `current > latest`. 

To address that I've added a basic semver comparison check.