### PR TITLE
fix: duplicate references for same signals

### DIFF
--- a/tests/fixture/deno.json
+++ b/tests/fixture/deno.json
@@ -5,8 +5,8 @@
     "preact": "https://esm.sh/preact@10.15.1",
     "preact/": "https://esm.sh/preact@10.15.1/",
     "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.0",
-    "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
-    "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.2.3"
+    "@preact/signals": "https://esm.sh/*@preact/signals@1.1.5",
+    "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.3.1"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -43,15 +43,16 @@ import * as $37 from "./routes/middleware_root.ts";
 import * as $38 from "./routes/not_found.ts";
 import * as $39 from "./routes/params.tsx";
 import * as $40 from "./routes/props/[id].tsx";
-import * as $41 from "./routes/state-in-props/_middleware.ts";
-import * as $42 from "./routes/state-in-props/index.tsx";
-import * as $43 from "./routes/state-middleware/_middleware.ts";
-import * as $44 from "./routes/state-middleware/foo/_middleware.ts";
-import * as $45 from "./routes/state-middleware/foo/index.tsx";
-import * as $46 from "./routes/static.tsx";
-import * as $47 from "./routes/status_overwrite.tsx";
-import * as $48 from "./routes/umlaut-äöüß.tsx";
-import * as $49 from "./routes/wildcard.tsx";
+import * as $41 from "./routes/signal_shared.tsx";
+import * as $42 from "./routes/state-in-props/_middleware.ts";
+import * as $43 from "./routes/state-in-props/index.tsx";
+import * as $44 from "./routes/state-middleware/_middleware.ts";
+import * as $45 from "./routes/state-middleware/foo/_middleware.ts";
+import * as $46 from "./routes/state-middleware/foo/index.tsx";
+import * as $47 from "./routes/static.tsx";
+import * as $48 from "./routes/status_overwrite.tsx";
+import * as $49 from "./routes/umlaut-äöüß.tsx";
+import * as $50 from "./routes/wildcard.tsx";
 import * as $$0 from "./islands/Counter.tsx";
 import * as $$1 from "./islands/MultipleCounters.tsx";
 import * as $$2 from "./islands/ReturningNull.tsx";
@@ -105,15 +106,16 @@ const manifest = {
     "./routes/not_found.ts": $38,
     "./routes/params.tsx": $39,
     "./routes/props/[id].tsx": $40,
-    "./routes/state-in-props/_middleware.ts": $41,
-    "./routes/state-in-props/index.tsx": $42,
-    "./routes/state-middleware/_middleware.ts": $43,
-    "./routes/state-middleware/foo/_middleware.ts": $44,
-    "./routes/state-middleware/foo/index.tsx": $45,
-    "./routes/static.tsx": $46,
-    "./routes/status_overwrite.tsx": $47,
-    "./routes/umlaut-äöüß.tsx": $48,
-    "./routes/wildcard.tsx": $49,
+    "./routes/signal_shared.tsx": $41,
+    "./routes/state-in-props/_middleware.ts": $42,
+    "./routes/state-in-props/index.tsx": $43,
+    "./routes/state-middleware/_middleware.ts": $44,
+    "./routes/state-middleware/foo/_middleware.ts": $45,
+    "./routes/state-middleware/foo/index.tsx": $46,
+    "./routes/static.tsx": $47,
+    "./routes/status_overwrite.tsx": $48,
+    "./routes/umlaut-äöüß.tsx": $49,
+    "./routes/wildcard.tsx": $50,
   },
   islands: {
     "./islands/Counter.tsx": $$0,

--- a/tests/fixture/routes/signal_shared.tsx
+++ b/tests/fixture/routes/signal_shared.tsx
@@ -1,0 +1,12 @@
+import { useSignal } from "@preact/signals";
+import Counter from "$fresh/tests/fixture/islands/Counter.tsx";
+
+export default function SignalShared() {
+  const sig = useSignal(1);
+  return (
+    <div>
+      <Counter id="counter-1" count={sig} />
+      <Counter id="counter-2" count={sig} />
+    </div>
+  );
+}

--- a/tests/signal_test.ts
+++ b/tests/signal_test.ts
@@ -1,0 +1,22 @@
+import { waitForText, withPageName } from "./test_utils.ts";
+
+Deno.test({
+  name: "serializes shared signal references",
+  async fn() {
+    await withPageName("./tests/fixture/main.ts", async (page, address) => {
+      await page.goto(`${address}/signal_shared`);
+      await page.waitForSelector("#counter-1");
+
+      await page.click("#b-counter-1");
+      await waitForText(page, "#counter-1 p", "2");
+      await waitForText(page, "#counter-2 p", "2");
+
+      await page.click("#b-counter-2");
+      await waitForText(page, "#counter-1 p", "3");
+      await waitForText(page, "#counter-2 p", "3");
+    });
+  },
+
+  sanitizeOps: false,
+  sanitizeResources: false,
+});


### PR DESCRIPTION
When two islands accessed the same signals we'd create two separate ones instead of pointing to the same signal reference upon deserialization in the client.

Fixes #1488 , Fixes https://github.com/preactjs/signals/issues/389.