### PR TITLE
fix: async route typing

### DIFF
--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -135,13 +135,15 @@ export interface RouteModule {
   config?: RouteConfig;
 }
 
-export type AsyncRoute<T> = (
+// deno-lint-ignore no-explicit-any
+export type AsyncRoute<T = any, S = Record<string, unknown>> = (
   req: Request,
-  ctx: RouteContext<T>,
+  ctx: RouteContext<T, S>,
 ) => Promise<ComponentChildren | Response>;
-export type PageComponent<T> =
-  | ComponentType<PageProps<T>>
-  | AsyncRoute<T>
+// deno-lint-ignore no-explicit-any
+export type PageComponent<T = any, S = Record<string, unknown>> =
+  | ComponentType<PageProps<T, S>>
+  | AsyncRoute<T, S>
   // deno-lint-ignore no-explicit-any
   | ((props: any) => VNode<any> | ComponentChildren);
 


### PR DESCRIPTION
The `ctx.state` type can now be passed in an async route component. I omitted tests, as this is just a matter of typing. Happy to add some if they're deemed needed.

Fixes #1509
Related https://github.com/denoland/saaskit/pull/393#issuecomment-1647142200