### PR TITLE
fix: allow string based event handlers in SSR

### DIFF
--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -586,21 +586,19 @@ options.vnode = (vnode) => {
         );
       };
     }
-  } else if (typeof vnode.type === "string") {
+  } else if (typeof vnode.type === "string" && vnode.props !== null) {
     // Work around `preact/debug` string event handler error which
     // errors when an event handler gets a string. This makes sense
     // on the client where this is a common vector for XSS. On the
     // server when the string was not created through concatenation
     // it is fine. Internally, `preact/debug` only checks for the
     // lowercase variant.
-    if (vnode.props !== null) {
-      const props = vnode.props as Record<string, unknown>;
-      for (const key in props) {
-        const value = props[key];
-        if (key.startsWith("on") && typeof value === "string") {
-          delete props[key];
-          props["ON" + key.slice(2)] = value;
-        }
+    const props = vnode.props as Record<string, unknown>;
+    for (const key in props) {
+      const value = props[key];
+      if (key.startsWith("on") && typeof value === "string") {
+        delete props[key];
+        props["ON" + key.slice(2)] = value;
       }
     }
   }

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -586,7 +586,25 @@ options.vnode = (vnode) => {
         );
       };
     }
+  } else if (typeof vnode.type === "string") {
+    // Work around `preact/debug` string event handler error which
+    // errors when an event handler gets a string. This makes sense
+    // on the client where this is a common vector for XSS. On the
+    // server when the string was not created through concatenation
+    // it is fine. Internally, `preact/debug` only checks for the
+    // lowercase variant.
+    if (vnode.props !== null) {
+      const props = vnode.props as Record<string, unknown>;
+      for (const key in props) {
+        const value = props[key];
+        if (key.startsWith("on") && typeof value === "string") {
+          delete props[key];
+          props["ON" + key.slice(2)] = value;
+        }
+      }
+    }
   }
+
   if (originalHook) originalHook(vnode);
 };
 

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -13,57 +13,60 @@ import * as $7 from "./routes/assetsCaching/index.tsx";
 import * as $8 from "./routes/books/[id].tsx";
 import * as $9 from "./routes/connInfo.ts";
 import * as $10 from "./routes/error_boundary.tsx";
-import * as $11 from "./routes/evil.tsx";
-import * as $12 from "./routes/failure.ts";
-import * as $13 from "./routes/index.tsx";
-import * as $14 from "./routes/intercept.tsx";
-import * as $15 from "./routes/intercept_args.tsx";
-import * as $16 from "./routes/islands/index.tsx";
-import * as $17 from "./routes/islands/multiple_island_exports.tsx";
-import * as $18 from "./routes/islands/returning_null.tsx";
-import * as $19 from "./routes/islands/root_fragment.tsx";
-import * as $20 from "./routes/islands/root_fragment_conditional_first.tsx";
-import * as $21 from "./routes/layeredMdw/_middleware.ts";
-import * as $22 from "./routes/layeredMdw/layer2-no-mw/without_mw.ts";
-import * as $23 from "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts";
-import * as $24 from "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts";
-import * as $25 from "./routes/layeredMdw/layer2-with-params/_middleware.ts";
-import * as $26 from "./routes/layeredMdw/layer2/_middleware.ts";
-import * as $27 from "./routes/layeredMdw/layer2/abc.ts";
-import * as $28 from "./routes/layeredMdw/layer2/index.ts";
-import * as $29 from "./routes/layeredMdw/layer2/layer3/[id].ts";
-import * as $30 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
-import * as $31 from "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx";
-import * as $32 from "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts";
-import * as $33 from "./routes/layeredMdw/nesting/[tenant]/_middleware.ts";
-import * as $34 from "./routes/layeredMdw/nesting/_middleware.ts";
-import * as $35 from "./routes/middleware-error-handler/_middleware.ts";
-import * as $36 from "./routes/middleware-error-handler/index.tsx";
-import * as $37 from "./routes/middleware_root.ts";
-import * as $38 from "./routes/movies/[foo].json.ts";
-import * as $39 from "./routes/movies/[foo]@[bar].ts";
-import * as $40 from "./routes/not_found.ts";
-import * as $41 from "./routes/params.tsx";
-import * as $42 from "./routes/props/[id].tsx";
-import * as $43 from "./routes/signal_shared.tsx";
-import * as $44 from "./routes/state-in-props/_middleware.ts";
-import * as $45 from "./routes/state-in-props/index.tsx";
-import * as $46 from "./routes/state-middleware/_middleware.ts";
-import * as $47 from "./routes/state-middleware/foo/_middleware.ts";
-import * as $48 from "./routes/state-middleware/foo/index.tsx";
-import * as $49 from "./routes/static.tsx";
-import * as $50 from "./routes/status_overwrite.tsx";
-import * as $51 from "./routes/umlaut-äöüß.tsx";
-import * as $52 from "./routes/wildcard.tsx";
+import * as $11 from "./routes/event_handler_string.tsx";
+import * as $12 from "./routes/event_handler_string_island.tsx";
+import * as $13 from "./routes/evil.tsx";
+import * as $14 from "./routes/failure.ts";
+import * as $15 from "./routes/index.tsx";
+import * as $16 from "./routes/intercept.tsx";
+import * as $17 from "./routes/intercept_args.tsx";
+import * as $18 from "./routes/islands/index.tsx";
+import * as $19 from "./routes/islands/multiple_island_exports.tsx";
+import * as $20 from "./routes/islands/returning_null.tsx";
+import * as $21 from "./routes/islands/root_fragment.tsx";
+import * as $22 from "./routes/islands/root_fragment_conditional_first.tsx";
+import * as $23 from "./routes/layeredMdw/_middleware.ts";
+import * as $24 from "./routes/layeredMdw/layer2-no-mw/without_mw.ts";
+import * as $25 from "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts";
+import * as $26 from "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts";
+import * as $27 from "./routes/layeredMdw/layer2-with-params/_middleware.ts";
+import * as $28 from "./routes/layeredMdw/layer2/_middleware.ts";
+import * as $29 from "./routes/layeredMdw/layer2/abc.ts";
+import * as $30 from "./routes/layeredMdw/layer2/index.ts";
+import * as $31 from "./routes/layeredMdw/layer2/layer3/[id].ts";
+import * as $32 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
+import * as $33 from "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx";
+import * as $34 from "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts";
+import * as $35 from "./routes/layeredMdw/nesting/[tenant]/_middleware.ts";
+import * as $36 from "./routes/layeredMdw/nesting/_middleware.ts";
+import * as $37 from "./routes/middleware-error-handler/_middleware.ts";
+import * as $38 from "./routes/middleware-error-handler/index.tsx";
+import * as $39 from "./routes/middleware_root.ts";
+import * as $40 from "./routes/movies/[foo].json.ts";
+import * as $41 from "./routes/movies/[foo]@[bar].ts";
+import * as $42 from "./routes/not_found.ts";
+import * as $43 from "./routes/params.tsx";
+import * as $44 from "./routes/props/[id].tsx";
+import * as $45 from "./routes/signal_shared.tsx";
+import * as $46 from "./routes/state-in-props/_middleware.ts";
+import * as $47 from "./routes/state-in-props/index.tsx";
+import * as $48 from "./routes/state-middleware/_middleware.ts";
+import * as $49 from "./routes/state-middleware/foo/_middleware.ts";
+import * as $50 from "./routes/state-middleware/foo/index.tsx";
+import * as $51 from "./routes/static.tsx";
+import * as $52 from "./routes/status_overwrite.tsx";
+import * as $53 from "./routes/umlaut-äöüß.tsx";
+import * as $54 from "./routes/wildcard.tsx";
 import * as $$0 from "./islands/Counter.tsx";
 import * as $$1 from "./islands/MultipleCounters.tsx";
 import * as $$2 from "./islands/ReturningNull.tsx";
 import * as $$3 from "./islands/RootFragment.tsx";
 import * as $$4 from "./islands/RootFragmentWithConditionalFirst.tsx";
-import * as $$5 from "./islands/Test.tsx";
-import * as $$6 from "./islands/folder/Counter.tsx";
-import * as $$7 from "./islands/folder/subfolder/Counter.tsx";
-import * as $$8 from "./islands/kebab-case-counter-test.tsx";
+import * as $$5 from "./islands/StringEventIsland.tsx";
+import * as $$6 from "./islands/Test.tsx";
+import * as $$7 from "./islands/folder/Counter.tsx";
+import * as $$8 from "./islands/folder/subfolder/Counter.tsx";
+import * as $$9 from "./islands/kebab-case-counter-test.tsx";
 
 const manifest = {
   routes: {
@@ -78,48 +81,50 @@ const manifest = {
     "./routes/books/[id].tsx": $8,
     "./routes/connInfo.ts": $9,
     "./routes/error_boundary.tsx": $10,
-    "./routes/evil.tsx": $11,
-    "./routes/failure.ts": $12,
-    "./routes/index.tsx": $13,
-    "./routes/intercept.tsx": $14,
-    "./routes/intercept_args.tsx": $15,
-    "./routes/islands/index.tsx": $16,
-    "./routes/islands/multiple_island_exports.tsx": $17,
-    "./routes/islands/returning_null.tsx": $18,
-    "./routes/islands/root_fragment.tsx": $19,
-    "./routes/islands/root_fragment_conditional_first.tsx": $20,
-    "./routes/layeredMdw/_middleware.ts": $21,
-    "./routes/layeredMdw/layer2-no-mw/without_mw.ts": $22,
-    "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts": $23,
-    "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts": $24,
-    "./routes/layeredMdw/layer2-with-params/_middleware.ts": $25,
-    "./routes/layeredMdw/layer2/_middleware.ts": $26,
-    "./routes/layeredMdw/layer2/abc.ts": $27,
-    "./routes/layeredMdw/layer2/index.ts": $28,
-    "./routes/layeredMdw/layer2/layer3/[id].ts": $29,
-    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $30,
-    "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx": $31,
-    "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts": $32,
-    "./routes/layeredMdw/nesting/[tenant]/_middleware.ts": $33,
-    "./routes/layeredMdw/nesting/_middleware.ts": $34,
-    "./routes/middleware-error-handler/_middleware.ts": $35,
-    "./routes/middleware-error-handler/index.tsx": $36,
-    "./routes/middleware_root.ts": $37,
-    "./routes/movies/[foo].json.ts": $38,
-    "./routes/movies/[foo]@[bar].ts": $39,
-    "./routes/not_found.ts": $40,
-    "./routes/params.tsx": $41,
-    "./routes/props/[id].tsx": $42,
-    "./routes/signal_shared.tsx": $43,
-    "./routes/state-in-props/_middleware.ts": $44,
-    "./routes/state-in-props/index.tsx": $45,
-    "./routes/state-middleware/_middleware.ts": $46,
-    "./routes/state-middleware/foo/_middleware.ts": $47,
-    "./routes/state-middleware/foo/index.tsx": $48,
-    "./routes/static.tsx": $49,
-    "./routes/status_overwrite.tsx": $50,
-    "./routes/umlaut-äöüß.tsx": $51,
-    "./routes/wildcard.tsx": $52,
+    "./routes/event_handler_string.tsx": $11,
+    "./routes/event_handler_string_island.tsx": $12,
+    "./routes/evil.tsx": $13,
+    "./routes/failure.ts": $14,
+    "./routes/index.tsx": $15,
+    "./routes/intercept.tsx": $16,
+    "./routes/intercept_args.tsx": $17,
+    "./routes/islands/index.tsx": $18,
+    "./routes/islands/multiple_island_exports.tsx": $19,
+    "./routes/islands/returning_null.tsx": $20,
+    "./routes/islands/root_fragment.tsx": $21,
+    "./routes/islands/root_fragment_conditional_first.tsx": $22,
+    "./routes/layeredMdw/_middleware.ts": $23,
+    "./routes/layeredMdw/layer2-no-mw/without_mw.ts": $24,
+    "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts": $25,
+    "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts": $26,
+    "./routes/layeredMdw/layer2-with-params/_middleware.ts": $27,
+    "./routes/layeredMdw/layer2/_middleware.ts": $28,
+    "./routes/layeredMdw/layer2/abc.ts": $29,
+    "./routes/layeredMdw/layer2/index.ts": $30,
+    "./routes/layeredMdw/layer2/layer3/[id].ts": $31,
+    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $32,
+    "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx": $33,
+    "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts": $34,
+    "./routes/layeredMdw/nesting/[tenant]/_middleware.ts": $35,
+    "./routes/layeredMdw/nesting/_middleware.ts": $36,
+    "./routes/middleware-error-handler/_middleware.ts": $37,
+    "./routes/middleware-error-handler/index.tsx": $38,
+    "./routes/middleware_root.ts": $39,
+    "./routes/movies/[foo].json.ts": $40,
+    "./routes/movies/[foo]@[bar].ts": $41,
+    "./routes/not_found.ts": $42,
+    "./routes/params.tsx": $43,
+    "./routes/props/[id].tsx": $44,
+    "./routes/signal_shared.tsx": $45,
+    "./routes/state-in-props/_middleware.ts": $46,
+    "./routes/state-in-props/index.tsx": $47,
+    "./routes/state-middleware/_middleware.ts": $48,
+    "./routes/state-middleware/foo/_middleware.ts": $49,
+    "./routes/state-middleware/foo/index.tsx": $50,
+    "./routes/static.tsx": $51,
+    "./routes/status_overwrite.tsx": $52,
+    "./routes/umlaut-äöüß.tsx": $53,
+    "./routes/wildcard.tsx": $54,
   },
   islands: {
     "./islands/Counter.tsx": $$0,
@@ -127,10 +132,11 @@ const manifest = {
     "./islands/ReturningNull.tsx": $$2,
     "./islands/RootFragment.tsx": $$3,
     "./islands/RootFragmentWithConditionalFirst.tsx": $$4,
-    "./islands/Test.tsx": $$5,
-    "./islands/folder/Counter.tsx": $$6,
-    "./islands/folder/subfolder/Counter.tsx": $$7,
-    "./islands/kebab-case-counter-test.tsx": $$8,
+    "./islands/StringEventIsland.tsx": $$5,
+    "./islands/Test.tsx": $$6,
+    "./islands/folder/Counter.tsx": $$7,
+    "./islands/folder/subfolder/Counter.tsx": $$8,
+    "./islands/kebab-case-counter-test.tsx": $$9,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/fixture/islands/StringEventIsland.tsx
+++ b/tests/fixture/islands/StringEventIsland.tsx
@@ -1,0 +1,9 @@
+export default function StringEventIsland() {
+  return (
+    <button // @ts-ignore - we don't officialy recommend this, but lots of
+     // apps pre Fresh 1.2 use string based click handlers.
+    onClick="document.querySelector('p').textContent = 'it works'">
+      click me
+    </button>
+  );
+}

--- a/tests/fixture/routes/event_handler_string.tsx
+++ b/tests/fixture/routes/event_handler_string.tsx
@@ -1,0 +1,12 @@
+export default function Page() {
+  return (
+    <div>
+      <p>it doesn't work</p>
+      <button // @ts-ignore - we don't officialy recommend this, but lots of
+       // apps pre Fresh 1.2 use string based click handlers.
+      onClick="document.querySelector('p').textContent = 'it works'">
+        click me
+      </button>
+    </div>
+  );
+}

--- a/tests/fixture/routes/event_handler_string_island.tsx
+++ b/tests/fixture/routes/event_handler_string_island.tsx
@@ -1,0 +1,10 @@
+import StringEventIsland from "$fresh/tests/fixture/islands/StringEventIsland.tsx";
+
+export default function Page() {
+  return (
+    <div>
+      <p>it doesn't work</p>
+      <StringEventIsland />
+    </div>
+  );
+}

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -5,6 +5,7 @@ import {
   assertStringIncludes,
   delay,
   puppeteer,
+  retry,
 } from "./deps.ts";
 import manifest from "./fixture/fresh.gen.ts";
 import options from "./fixture/options.ts";
@@ -12,7 +13,6 @@ import { BUILD_ID } from "../src/server/build_id.ts";
 import {
   parseHtml,
   startFreshServer,
-  waitFor,
   waitForText,
   withPageName,
 } from "./test_utils.ts";
@@ -986,7 +986,7 @@ Deno.test({
       await page.click("button");
       await waitForText(page, "p", "it works");
 
-      await waitFor(() => {
+      await retry(() => {
         for (const item of logs) {
           if (/property should be a function/.test(item.message)) {
             return true;

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -9,7 +9,12 @@ import {
 import manifest from "./fixture/fresh.gen.ts";
 import options from "./fixture/options.ts";
 import { BUILD_ID } from "../src/server/build_id.ts";
-import { parseHtml, startFreshServer, withPageName } from "./test_utils.ts";
+import {
+  parseHtml,
+  startFreshServer,
+  waitForText,
+  withPageName,
+} from "./test_utils.ts";
 import { assertMatch } from "https://deno.land/std@0.193.0/testing/asserts.ts";
 
 const ctx = await ServerContext.fromManifest(manifest, options);
@@ -939,6 +944,40 @@ Deno.test({
         1,
         `Found more than 1 nonce value per render`,
       );
+    });
+  },
+
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "support string based event handlers during SSR",
+  async fn() {
+    await withPageName("./tests/fixture/main.ts", async (page, address) => {
+      await page.goto(`${address}/event_handler_string`);
+      await page.waitForSelector("p");
+      await page.click("button");
+
+      await waitForText(page, "p", "it works");
+    });
+  },
+
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "DON'T support string based event handlers during SSR",
+  async fn() {
+    await withPageName("./tests/fixture/main.ts", async (page, address) => {
+      await page.goto(`${address}/event_handler_string_island`);
+      console.log(await page.content());
+      await page.waitForSelector("p");
+      await page.click("button");
+
+      await delay(200);
+      await waitForText(page, "p", "it works");
     });
   },
 

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -137,24 +137,3 @@ async function spawnServer(
 
   return { serverProcess, lines, address };
 }
-
-/**
- * Wait until the passed function returns a truthy value or the time runs out
- */
-export async function waitFor(
-  fn: () => unknown | Promise<unknown>,
-  {
-    message = "waitFor failed",
-    timeout = 10000,
-    checkEvery = 200,
-  } = {},
-) {
-  for (let remaining = timeout; remaining > 0; remaining -= checkEvery) {
-    const res = await fn();
-    if (res) return res;
-
-    await delay(checkEvery);
-  }
-
-  throw new Error(`${message}, waited ${timeout}ms`);
-}

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -137,3 +137,24 @@ async function spawnServer(
 
   return { serverProcess, lines, address };
 }
+
+/**
+ * Wait until the passed function returns a truthy value or the time runs out
+ */
+export async function waitFor(
+  fn: () => unknown | Promise<unknown>,
+  {
+    message = "waitFor failed",
+    timeout = 10000,
+    checkEvery = 200,
+  } = {},
+) {
+  for (let remaining = timeout; remaining > 0; remaining -= checkEvery) {
+    const res = await fn();
+    if (res) return res;
+
+    await delay(checkEvery);
+  }
+
+  throw new Error(`${message}, waited ${timeout}ms`);
+}


### PR DESCRIPTION
We don't officially recommend it as string based event handlers are only safe when it's a static string to avoid any form of injections. The fresh linting preset will throw an error if it's not a static string already, but `preact/debug` still throws on these. At runtime we can't really differentiate where a string was coming from, but user's must actively bypass TS warnings AND the linting rule, which to me seems like an adequate guardrail.

Fixes #1309