### PR TITLE
fix: parse multiple route params in same part

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1013,6 +1013,14 @@ export function pathToPattern(path: string): string {
         return `:${part.slice(4, part.length - 1)}*`;
       }
 
+      // Disallow neighbouring params like `/[id][bar].tsx` because
+      // it's ambigious where the `id` param ends and `bar` begins.
+      if (part.includes("][")) {
+        throw new SyntaxError(
+          `Invalid route pattern: "${path}". A parameter cannot be followed by another parameter without any charactes in between.`,
+        );
+      }
+
       // Case: /[id].tsx
       // Case: /[id]@[bar].tsx
       // Case: /[id]-asdf.tsx
@@ -1023,13 +1031,6 @@ export function pathToPattern(path: string): string {
       for (let i = 0; i < part.length; i++) {
         const char = part[i];
         if (char === "[") {
-          // Disallow neighbouring params like `/[id][bar].tsx` because
-          // it's ambigious where the `id` param ends and `bar` begins.
-          if (i > 0 && part[i - 1] === "]") {
-            throw new SyntaxError(
-              `Invalid route pattern: "${path}". A parameter cannot be followed by another parameter without any charactes in between.`,
-            );
-          }
           pattern += ":";
           groupOpen++;
         } else if (char === "]") {

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1001,20 +1001,47 @@ function getPriority(part: string) {
 }
 
 /** Transform a filesystem URL path to a `path-to-regex` style matcher. */
-function pathToPattern(path: string): string {
+export function pathToPattern(path: string): string {
   const parts = path.split("/");
   if (parts[parts.length - 1] === "index") {
     parts.pop();
   }
   const route = "/" + parts
     .map((part) => {
+      // Case: /[...foo].tsx
       if (part.startsWith("[...") && part.endsWith("]")) {
         return `:${part.slice(4, part.length - 1)}*`;
       }
-      if (part.startsWith("[") && part.endsWith("]")) {
-        return `:${part.slice(1, part.length - 1)}`;
+
+      // Case: /[id].tsx
+      // Case: /[id]@[bar].tsx
+      // Case: /[id]-asdf.tsx
+      // Case: /[id]-asdf[bar].tsx
+      // Case: /asdf[bar].tsx
+      let pattern = "";
+      let groupOpen = 0;
+      for (let i = 0; i < part.length; i++) {
+        const char = part[i];
+        if (char === "[") {
+          // Disallow neighbouring params like `/[id][bar].tsx` because
+          // it's ambigious where the `id` param ends and `bar` begins.
+          if (i > 0 && part[i - 1] === "]") {
+            throw new SyntaxError(
+              `Invalid route pattern: "${path}". A parameter cannot be followed by another parameter without any charactes in between.`,
+            );
+          }
+          pattern += ":";
+          groupOpen++;
+        } else if (char === "]") {
+          if (--groupOpen < 0) {
+            throw new SyntaxError(`Invalid route pattern: "${path}"`);
+          }
+        } else {
+          pattern += char;
+        }
       }
-      return part;
+
+      return pattern;
     })
     .join("/");
   return route;

--- a/src/server/context_test.ts
+++ b/src/server/context_test.ts
@@ -1,5 +1,10 @@
+import { assertEquals, assertThrows } from "$std/testing/asserts.ts";
 import { assert } from "../../tests/deps.ts";
-import { middlewarePathToPattern, selectMiddlewares } from "./context.ts";
+import {
+  middlewarePathToPattern,
+  pathToPattern,
+  selectMiddlewares,
+} from "./context.ts";
 import { MiddlewareRoute } from "./types.ts";
 
 Deno.test("selectMiddlewares", () => {
@@ -21,4 +26,36 @@ Deno.test("selectMiddlewares", () => {
   ) as MiddlewareRoute[];
   const mws = selectMiddlewares(url, mwRoutes);
   assert(mws.length === 4);
+});
+
+Deno.test("pathToPattern", async (t) => {
+  await t.step("creates pattern", () => {
+    assertEquals(pathToPattern("foo/bar"), "/foo/bar");
+  });
+
+  await t.step("parses index routes", () => {
+    assertEquals(pathToPattern("foo/index"), "/foo");
+  });
+
+  await t.step("parses parameters", () => {
+    assertEquals(pathToPattern("foo/[name]"), "/foo/:name");
+    assertEquals(pathToPattern("foo/[name]/bar/[bob]"), "/foo/:name/bar/:bob");
+  });
+
+  await t.step("parses catchall", () => {
+    assertEquals(pathToPattern("foo/[...name]"), "/foo/:name*");
+  });
+
+  await t.step("parses multiple params in same part", () => {
+    assertEquals(pathToPattern("foo/[mod]@[version]"), "/foo/:mod@:version");
+
+    assertEquals(pathToPattern("foo/[bar].json"), "/foo/:bar.json");
+    assertEquals(pathToPattern("foo/foo[bar]"), "/foo/foo:bar");
+  });
+
+  await t.step("throws on invalid patterns", () => {
+    assertThrows(() => pathToPattern("foo/[foo][bar]"));
+    assertThrows(() => pathToPattern("foo/foo]"));
+    assertThrows(() => pathToPattern("foo/[foo]]"));
+  });
 });

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -40,19 +40,21 @@ import * as $34 from "./routes/layeredMdw/nesting/_middleware.ts";
 import * as $35 from "./routes/middleware-error-handler/_middleware.ts";
 import * as $36 from "./routes/middleware-error-handler/index.tsx";
 import * as $37 from "./routes/middleware_root.ts";
-import * as $38 from "./routes/not_found.ts";
-import * as $39 from "./routes/params.tsx";
-import * as $40 from "./routes/props/[id].tsx";
-import * as $41 from "./routes/signal_shared.tsx";
-import * as $42 from "./routes/state-in-props/_middleware.ts";
-import * as $43 from "./routes/state-in-props/index.tsx";
-import * as $44 from "./routes/state-middleware/_middleware.ts";
-import * as $45 from "./routes/state-middleware/foo/_middleware.ts";
-import * as $46 from "./routes/state-middleware/foo/index.tsx";
-import * as $47 from "./routes/static.tsx";
-import * as $48 from "./routes/status_overwrite.tsx";
-import * as $49 from "./routes/umlaut-äöüß.tsx";
-import * as $50 from "./routes/wildcard.tsx";
+import * as $38 from "./routes/movies/[foo].json.ts";
+import * as $39 from "./routes/movies/[foo]@[bar].ts";
+import * as $40 from "./routes/not_found.ts";
+import * as $41 from "./routes/params.tsx";
+import * as $42 from "./routes/props/[id].tsx";
+import * as $43 from "./routes/signal_shared.tsx";
+import * as $44 from "./routes/state-in-props/_middleware.ts";
+import * as $45 from "./routes/state-in-props/index.tsx";
+import * as $46 from "./routes/state-middleware/_middleware.ts";
+import * as $47 from "./routes/state-middleware/foo/_middleware.ts";
+import * as $48 from "./routes/state-middleware/foo/index.tsx";
+import * as $49 from "./routes/static.tsx";
+import * as $50 from "./routes/status_overwrite.tsx";
+import * as $51 from "./routes/umlaut-äöüß.tsx";
+import * as $52 from "./routes/wildcard.tsx";
 import * as $$0 from "./islands/Counter.tsx";
 import * as $$1 from "./islands/MultipleCounters.tsx";
 import * as $$2 from "./islands/ReturningNull.tsx";
@@ -103,19 +105,21 @@ const manifest = {
     "./routes/middleware-error-handler/_middleware.ts": $35,
     "./routes/middleware-error-handler/index.tsx": $36,
     "./routes/middleware_root.ts": $37,
-    "./routes/not_found.ts": $38,
-    "./routes/params.tsx": $39,
-    "./routes/props/[id].tsx": $40,
-    "./routes/signal_shared.tsx": $41,
-    "./routes/state-in-props/_middleware.ts": $42,
-    "./routes/state-in-props/index.tsx": $43,
-    "./routes/state-middleware/_middleware.ts": $44,
-    "./routes/state-middleware/foo/_middleware.ts": $45,
-    "./routes/state-middleware/foo/index.tsx": $46,
-    "./routes/static.tsx": $47,
-    "./routes/status_overwrite.tsx": $48,
-    "./routes/umlaut-äöüß.tsx": $49,
-    "./routes/wildcard.tsx": $50,
+    "./routes/movies/[foo].json.ts": $38,
+    "./routes/movies/[foo]@[bar].ts": $39,
+    "./routes/not_found.ts": $40,
+    "./routes/params.tsx": $41,
+    "./routes/props/[id].tsx": $42,
+    "./routes/signal_shared.tsx": $43,
+    "./routes/state-in-props/_middleware.ts": $44,
+    "./routes/state-in-props/index.tsx": $45,
+    "./routes/state-middleware/_middleware.ts": $46,
+    "./routes/state-middleware/foo/_middleware.ts": $47,
+    "./routes/state-middleware/foo/index.tsx": $48,
+    "./routes/static.tsx": $49,
+    "./routes/status_overwrite.tsx": $50,
+    "./routes/umlaut-äöüß.tsx": $51,
+    "./routes/wildcard.tsx": $52,
   },
   islands: {
     "./islands/Counter.tsx": $$0,

--- a/tests/fixture/routes/movies/[foo].json.ts
+++ b/tests/fixture/routes/movies/[foo].json.ts
@@ -1,0 +1,3 @@
+import { Handler } from "$fresh/server.ts";
+
+export const handler: Handler = () => new Response("it works");

--- a/tests/fixture/routes/movies/[foo]@[bar].ts
+++ b/tests/fixture/routes/movies/[foo]@[bar].ts
@@ -1,0 +1,3 @@
+import { Handler } from "$fresh/server.ts";
+
+export const handler: Handler = () => new Response("it works");

--- a/tests/route_analysis_test.ts
+++ b/tests/route_analysis_test.ts
@@ -1,6 +1,9 @@
 import { startFreshServerExpectErrors } from "./test_utils.ts";
 import { dirname, join } from "$std/path/mod.ts";
 import { assertStringIncludes } from "./deps.ts";
+import { ServerContext } from "$fresh/server.ts";
+import manifest from "./fixture/fresh.gen.ts";
+import { assertEquals } from "$std/testing/asserts.ts";
 
 const dir = dirname(import.meta.url);
 
@@ -15,4 +18,26 @@ Deno.test({
       "Error: Route conflict detected. Multiple files have the same name",
     );
   },
+});
+
+Deno.test("match route parameter and static", async () => {
+  const handler = (await ServerContext.fromManifest(manifest, {})).handler();
+
+  const res = await handler(
+    new Request("https://fresh.deno.dev/movies/foo.json"),
+  );
+
+  assertEquals(await res.text(), "it works");
+  assertEquals(res.status, 200);
+});
+
+Deno.test("match multiple route parameters", async () => {
+  const handler = (await ServerContext.fromManifest(manifest, {})).handler();
+
+  const res = await handler(
+    new Request("https://fresh.deno.dev/movies/foo@bar"),
+  );
+
+  assertEquals(await res.text(), "it works");
+  assertEquals(res.status, 200);
 });


### PR DESCRIPTION
Our existing way to parse file paths to patterns for routes was a bit rudimentary. It only allowed parameters to be the full path segments:

Before:

- `foo/[bar]@foo` -> `foo/[bar]@foo`

After:

- `foo/[bar]@foo` -> `foo/:bar@foo`

Fixes #1516