### PR TITLE
www: fix tests not run on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,10 @@ jobs:
         run: deno check main.ts dev.ts
         working-directory: www/
 
+      - name: Test website
+        run: deno test -A
+        working-directory: www/
+
       - name: Type check demo
         run: deno check --remote main.ts dev.ts
         working-directory: demo

--- a/www/main_test.ts
+++ b/www/main_test.ts
@@ -2,6 +2,7 @@ import { assertArrayIncludes, assertEquals } from "$std/testing/asserts.ts";
 import { delay } from "$std/async/delay.ts";
 import { startFreshServer, withPageName } from "../tests/test_utils.ts";
 import { dirname, join } from "$std/path/mod.ts";
+import VERSIONS from "../versions.json" assert { type: "json" };
 
 const dir = dirname(import.meta.url);
 
@@ -50,8 +51,8 @@ Deno.test("shows version selector", {
         label: "canary",
       },
       {
-        value: "1.2",
-        label: "1.2.x",
+        value: "latest",
+        label: VERSIONS[0],
       },
     ]);
 
@@ -59,7 +60,7 @@ Deno.test("shows version selector", {
       "#version",
       (el: HTMLSelectElement) => el.value,
     );
-    assertEquals(selectValue, "1.2");
+    assertEquals(selectValue, "latest");
 
     // Go to canary page
     await Promise.all([


### PR DESCRIPTION
Noticed that the tests for `www` were not run as part of the CI and were failing.