### PR TITLE
www: fix docs returning 500

### DIFF
--- a/www/data/docs.ts
+++ b/www/data/docs.ts
@@ -72,7 +72,7 @@ for (const version in toc) {
           ? linkedVersion.slice("link:".length)
           : version;
         const versionFilePath = !pageVersion || pageVersion === LATEST_VERSION
-          ? ""
+          ? "/latest"
           : `/${pageVersion}`;
 
         const href = `/docs${versionSlug}/${slug}`;


### PR DESCRIPTION
Missed a case where we look for the folder version :/

Fixes an accidental regression introduced in #1522 .