### PR TITLE
fix(server): change RouteContext data type parameter default to any

### DIFF
--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -59,11 +59,9 @@ export interface PageProps<T = any, S = Record<string, unknown>> {
 /**
  * Context passed to async route components.
  */
-export type RouteContext<T = unknown, S = Record<string, unknown>> =
-  & Omit<
-    HandlerContext<T, S>,
-    "render"
-  >
+// deno-lint-ignore no-explicit-any
+export type RouteContext<T = any, S = Record<string, unknown>> =
+  & Omit<HandlerContext<T, S>, "render">
   & Omit<PageProps<unknown, S>, "data">;
 
 export interface RouteConfig {


### PR DESCRIPTION
closes https://github.com/denoland/fresh/issues/1528

I have a large comment in 1528 explaining what's going on here.

During the course of researching this, I found `deno check **/*.ts` to type check all the files in the project. It turns out we have this issue in our code base as well! `tests/fixture_server_components/main.ts` shows this exact error, because `routes/context/[id].tsx` and `routes/fail.tsx` don't qualify `RouteContext` with any type parameters.

In a soon-to-be-opened PR, I will suggest that we type check our entire project as part of CI. If we had always been doing this, then we would have caught this problem before users had to report an issue.