### PR TITLE
chore: clean up remaining type errors in project

### DIFF
--- a/.vscode/import_map.json
+++ b/.vscode/import_map.json
@@ -14,6 +14,8 @@
     "@preact/signals-core@1.2.3": "https://esm.sh/@preact/signals-core@1.2.3",
     "@preact/signals-core@1.3.0": "https://esm.sh/@preact/signals-core@1.3.0",
     "$std/": "https://deno.land/std@0.193.0/",
-    "$ga4": "https://raw.githubusercontent.com/denoland/ga4/main/mod.ts"
+    "$ga4": "https://raw.githubusercontent.com/denoland/ga4/main/mod.ts",
+    "$marked-mangle": "https://esm.sh/marked-mangle@1.0.1",
+    "$marked-smartypants": "https://esm.sh/marked-smartypants@1.0.1"
   }
 }

--- a/tests/fixture_invalid_handlers/main.ts
+++ b/tests/fixture_invalid_handlers/main.ts
@@ -7,4 +7,5 @@
 import { start } from "$fresh/server.ts";
 import manifest from "./fresh.gen.ts";
 
+// @ts-expect-error: the index.tsx file declares a "handlers" but no "handler", to simulate a typo or confusion on the user's part
 await start(manifest);

--- a/tests/fixture_twind_hydrate/twind.config.ts
+++ b/tests/fixture_twind_hydrate/twind.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from "https://esm.sh/@twind/core@1.1.3";
+import { defineConfig, Preset } from "https://esm.sh/@twind/core@1.1.3";
 import presetTailwind from "https://esm.sh/@twind/preset-tailwind@1.1.4";
 
 export default {
   ...defineConfig({
-    presets: [presetTailwind()],
+    presets: [presetTailwind() as Preset],
   }),
   selfURL: import.meta.url,
 };


### PR DESCRIPTION
Resulting from the investigation in https://github.com/denoland/fresh/pull/1536, this resolves three type errors in the project. The import_map one is for `www/routes/docs/[...slug].tsx`.