### PR TITLE
chore(ci): type check entire project in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Type check project
         if: startsWith(matrix.os, 'ubuntu') && matrix.deno == 'canary'
-        run: deno check **/*.ts
+        run: deno task check:types
 
       - name: Cache dependencies
         if: startsWith(matrix.os, 'ubuntu') && matrix.deno == 'v1.x'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
         uses: crate-ci/typos@master
 
       - name: Type check project
-        if: startsWith(matrix.os, 'ubuntu') && matrix.deno == 'canary'
         run: deno task check:types
 
       - name: Cache dependencies
@@ -84,10 +83,6 @@ jobs:
       - name: Type check init script
         run: deno check --remote init.ts
 
-      - name: Type check website
-        run: deno check main.ts dev.ts
-        working-directory: www/
-
       - name: Test website
         run: deno test -A
         working-directory: www/
@@ -95,11 +90,3 @@ jobs:
       - name: Type check demo
         run: deno check --remote main.ts dev.ts
         working-directory: demo
-
-      - name: Type check tests/fixture
-        run: deno check main.ts dev.ts
-        working-directory: tests/fixture/
-
-      - name: Type check tests/fixture_error
-        run: deno check main.ts dev.ts
-        working-directory: tests/fixture_error/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu') && matrix.deno == 'canary'
         uses: crate-ci/typos@master
 
+      - name: Type check project
+        if: startsWith(matrix.os, 'ubuntu') && matrix.deno == 'canary'
+        run: deno check **/*.ts
+
       - name: Cache dependencies
         if: startsWith(matrix.os, 'ubuntu') && matrix.deno == 'v1.x'
         run: deno cache --config=www/deno.json src/dev/deps.ts src/server/deps.ts www/main.ts

--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,8 @@
     "test": "deno test -A --parallel && deno check --config=www/deno.json www/main.ts www/dev.ts && deno check init.ts",
     "fixture": "deno run -A --watch=static/,routes/ tests/fixture/dev.ts",
     "www": "deno task --cwd=www start",
-    "screenshot": "deno run -A www/utils/screenshot.ts"
+    "screenshot": "deno run -A www/utils/screenshot.ts",
+    "check:types": "deno check **/*.ts && deno check **/*.tsx"
   },
   "importMap": "./.vscode/import_map.json",
   "compilerOptions": {


### PR DESCRIPTION
The logical continuation of https://github.com/denoland/fresh/pull/1536 and https://github.com/denoland/fresh/pull/1537. Now that the project is clean (after those are merged), we should prevent any such errors from sneaking in again in the future.

A question here: why are individual things type checked in the CI? Specifically:
```yaml
      - name: Type check init script
        run: deno check --remote init.ts

      - name: Type check website
        run: deno check main.ts dev.ts
        working-directory: www/

      - name: Type check demo
        run: deno check --remote main.ts dev.ts
        working-directory: demo

      - name: Type check tests/fixture
        run: deno check main.ts dev.ts
        working-directory: tests/fixture/

      - name: Type check tests/fixture_error
        run: deno check main.ts dev.ts
        working-directory: tests/fixture_error/
```

Opening as a draft because:
1) this will fail due to the other PRs not being merged yet
2) open question regarding duplicate type checking
3) should I pull the check into the matrix like the other type checks?

I do agree that `deno check --remote init.ts` should remain separate, but the other four seem superfluous if we decide to check the whole project.