### PR TITLE
chore(init): remove blank line from _404 template

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -229,8 +229,7 @@ await Deno.writeTextFile(
 );
 
 // 404 page
-const ROUTES_404_PAGE = `
-import { Head } from "$fresh/runtime.ts";
+const ROUTES_404_PAGE = `import { Head } from "$fresh/runtime.ts";
 
 export default function Error404() {
   return (


### PR DESCRIPTION
Found in https://github.com/denoland/fresh/pull/1454#issuecomment-1655170384. The project produced by `init` doesn't pass the formatting check. Perhaps we should expand the scope of this PR to have a test run the `safe` command (from 1454) on the newly initialized project? I can happily do this in this PR or a separate one. Or if we decide against the `safe` command, we could manually run type checks, linting, and formatting on the initialized project in a test.