### PR TITLE
When specifying the path when importing, it is now easier to specify …

### DIFF
--- a/demo/deno.json
+++ b/demo/deno.json
@@ -9,7 +9,8 @@
     "preact/": "https://esm.sh/preact@10.15.1/",
     "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.0",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
-    "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.2.3"
+    "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.2.3",
+    "~/": "./"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/demo/deno.json
+++ b/demo/deno.json
@@ -10,7 +10,7 @@
     "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.0",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
     "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.2.3",
-    "~/": "./"
+    "@/": "./"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/demo/deno.json
+++ b/demo/deno.json
@@ -4,13 +4,13 @@
     "start": "deno run -A --watch=static/,routes/ dev.ts"
   },
   "imports": {
+    "@/": "./",
     "$fresh/": "../",
     "preact": "https://esm.sh/preact@10.15.1",
     "preact/": "https://esm.sh/preact@10.15.1/",
     "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.0",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
-    "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.2.3",
-    "@/": "./"
+    "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.2.3"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/demo/routes/index.tsx
+++ b/demo/routes/index.tsx
@@ -1,5 +1,5 @@
 import { useSignal } from "@preact/signals";
-import Counter from "../islands/Counter.tsx";
+import Counter from "@/islands/Counter.tsx";
 
 export default function Home() {
   const count = useSignal(3);

--- a/demo/routes/passthrough.tsx
+++ b/demo/routes/passthrough.tsx
@@ -1,5 +1,5 @@
 import { ComponentChildren } from "preact";
-import Passthrough from "../islands/Passthrough.tsx";
+import Passthrough from "@/islands/Passthrough.tsx";
 
 export interface FooProps {
   children?: ComponentChildren;


### PR DESCRIPTION

The method of specifying from `"~/"` is very straightforward. For example, using `import Counter from "./islands/Counter.tsx"` instead of `import Counter from "~/islands/Counter.tsx"`. We believe that the former is less likely to lose the directory structure.

Oops, I feel like I already know this.

Anyway, this should be accepted as a memorable first directory notation...