### PR TITLE
chore: simplify route creation logic

### DIFF
--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -25,4 +25,3 @@ export {
   assertSpyCalls,
   spy,
 } from "https://deno.land/std@0.193.0/testing/mock.ts";
-export { groupBy } from "https://deno.land/std@0.193.0/collections/group_by.ts";


### PR DESCRIPTION
No behaviour changes, just noticed that it could be written with less loops. Saves about `1ms` (not much really) but is a little shorter to read.