### PR TITLE
refactor: pre-sort all routes

### DIFF
--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -216,8 +216,10 @@ export async function render<Data>(
 
     const layouts = selectLayouts(opts.url.toString(), opts.layouts);
 
-    layouts.forEach((layout) => {
-      const curComp = { ...finalAppComp };
+    let i = layouts.length;
+    while (i--) {
+      const layout = layouts[i];
+      const curComp = finalAppComp;
 
       finalAppComp = h(layout.default, {
         params: opts.params as Record<string, string>,
@@ -229,7 +231,7 @@ export async function render<Data>(
           return curComp;
         },
       });
-    });
+    }
 
     const root = h(CSP_CONTEXT.Provider, {
       value: csp,

--- a/src/server/route_sorting_test.ts
+++ b/src/server/route_sorting_test.ts
@@ -1,94 +1,33 @@
 import { assertEquals } from "../../tests/deps.ts";
-import { sortMiddleware, sortRoutes } from "./context.ts";
+import { sortRoutePaths } from "./context.ts";
 
-Deno.test("sort middleware", () => {
+Deno.test("sortRoutePaths", () => {
   const routes = [
-    { pattern: "{/*}?" },
-    { pattern: "/layeredMdw{/*}?" },
-    { pattern: "/layeredMdw/layer2{/*}?" },
-    { pattern: "/layeredMdw/layer2/layer3{/*}?" },
-    { pattern: "/layeredMdw/nesting/:tenant/:environment{/*}?" },
-    { pattern: "/layeredMdw/nesting/:tenant{/*}?" },
-    { pattern: "/layeredMdw/nesting{/*}?" },
-    { pattern: "/state-in-props{/*}?" },
+    "/foo/[id]",
+    "/foo/[...slug]",
+    "/foo/bar",
+    "/foo/_layout",
+    "/foo/index",
+    "/foo/_middleware",
+    "/foo/bar/_middleware",
+    "/foo/bar/index",
+    "/foo/bar/[...foo]",
+    "/foo/bar/baz",
+    "/foo/bar/_layout",
   ];
-  const sortedRoutes = [
-    { pattern: "{/*}?" },
-    { pattern: "/layeredMdw{/*}?" },
-    { pattern: "/state-in-props{/*}?" },
-    { pattern: "/layeredMdw/layer2{/*}?" },
-    { pattern: "/layeredMdw/nesting{/*}?" },
-    { pattern: "/layeredMdw/layer2/layer3{/*}?" },
-    { pattern: "/layeredMdw/nesting/:tenant{/*}?" },
-    { pattern: "/layeredMdw/nesting/:tenant/:environment{/*}?" },
+  const sorted = [
+    "/foo/_middleware",
+    "/foo/_layout",
+    "/foo/bar",
+    "/foo/index",
+    "/foo/bar/_middleware",
+    "/foo/bar/_layout",
+    "/foo/bar/index",
+    "/foo/bar/baz",
+    "/foo/bar/[...foo]",
+    "/foo/[id]",
+    "/foo/[...slug]",
   ];
-  sortMiddleware(routes);
-  assertEquals(routes, sortedRoutes);
-});
-
-Deno.test("sort routes", () => {
-  const routes = [
-    { pattern: "/:name" },
-    { pattern: "/api/get_only" },
-    { pattern: "/api/head_override" },
-    { pattern: "/assetsCaching" },
-    { pattern: "/books/:id(\\d+)" },
-    { pattern: "/connInfo" },
-    { pattern: "/evil" },
-    { pattern: "/failure" },
-    { pattern: "/" },
-    { pattern: "/intercept" },
-    { pattern: "/intercept_args" },
-    { pattern: "/islands" },
-    { pattern: "/islands/returning_null" },
-    { pattern: "/islands/root_fragment" },
-    { pattern: "/islands/root_fragment_conditional_first" },
-    { pattern: "/layeredMdw/layer2-no-mw/without_mw" },
-    { pattern: "/layeredMdw/layer2/abc" },
-    { pattern: "/layeredMdw/layer2" },
-    { pattern: "/layeredMdw/layer2/layer3/:id" },
-    { pattern: "/layeredMdw/nesting/:tenant/:environment/:id" },
-    { pattern: "/layeredMdw/nesting/:tenant" },
-    { pattern: "/layeredMdw/nesting" },
-    { pattern: "/middleware_root" },
-    { pattern: "/not_found" },
-    { pattern: "/params/:path*" },
-    { pattern: "/props/:id" },
-    { pattern: "/static" },
-    { pattern: "/status_overwrite" },
-    { pattern: "/foo/:path*" },
-  ];
-  const sortedRoutes = [
-    { pattern: "/api/get_only" },
-    { pattern: "/api/head_override" },
-    { pattern: "/assetsCaching" },
-    { pattern: "/books/:id(\\d+)" },
-    { pattern: "/connInfo" },
-    { pattern: "/evil" },
-    { pattern: "/failure" },
-    { pattern: "/" },
-    { pattern: "/intercept" },
-    { pattern: "/intercept_args" },
-    { pattern: "/islands" },
-    { pattern: "/islands/returning_null" },
-    { pattern: "/islands/root_fragment" },
-    { pattern: "/islands/root_fragment_conditional_first" },
-    { pattern: "/layeredMdw/layer2-no-mw/without_mw" },
-    { pattern: "/layeredMdw/layer2" },
-    { pattern: "/layeredMdw/layer2/abc" },
-    { pattern: "/layeredMdw/layer2/layer3/:id" },
-    { pattern: "/layeredMdw/nesting" },
-    { pattern: "/layeredMdw/nesting/:tenant" },
-    { pattern: "/layeredMdw/nesting/:tenant/:environment/:id" },
-    { pattern: "/middleware_root" },
-    { pattern: "/not_found" },
-    { pattern: "/params/:path*" },
-    { pattern: "/props/:id" },
-    { pattern: "/static" },
-    { pattern: "/status_overwrite" },
-    { pattern: "/foo/:path*" },
-    { pattern: "/:name" },
-  ];
-  sortRoutes(routes);
-  assertEquals(routes, sortedRoutes);
+  routes.sort(sortRoutePaths);
+  assertEquals(routes, sorted);
 });


### PR DESCRIPTION
Instead of sorting `routes`, `layouts` and `middlewares` individually we can sort them all at once. Didn't notice any perf differences but to me it makes the code a bit easier to read. As a plus we only have one sort function to deal with instead of 3 separate ones.