### PR TITLE
chore: speed up layout tests

### DIFF
--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -19,4 +19,9 @@ export {
   default as puppeteer,
   Page,
 } from "https://deno.land/x/puppeteer@16.2.0/mod.ts";
-export { DOMParser } from "https://esm.sh/linkedom@0.15.1";
+export {
+  Document,
+  DOMParser,
+  HTMLElement,
+  HTMLMetaElement,
+} from "https://esm.sh/linkedom@0.15.1";

--- a/tests/layouts_test.ts
+++ b/tests/layouts_test.ts
@@ -1,63 +1,63 @@
-import { withPageName } from "./test_utils.ts";
+import { assertSelector, fetchHtml, withFresh } from "./test_utils.ts";
 
 Deno.test("apply root _layout and _app", async () => {
-  await withPageName(
+  await withFresh(
     "./tests/fixture_layouts/main.ts",
-    async (page, address) => {
-      await page.goto(address);
-      await page.waitForSelector(".app .root-layout .home-page");
+    async (address) => {
+      const doc = await fetchHtml(address);
+      assertSelector(doc, ".app .root-layout .home-page");
 
-      await page.goto(`${address}/other`);
-      await page.waitForSelector(".app .root-layout .other-page");
+      const doc2 = await fetchHtml(`${address}/other`);
+      assertSelector(doc2, ".app .root-layout .other-page");
     },
   );
 });
 
 Deno.test("apply sub layouts", async () => {
-  await withPageName(
+  await withFresh(
     "./tests/fixture_layouts/main.ts",
-    async (page, address) => {
-      await page.goto(`${address}/foo`);
-      await page.waitForSelector(".app .root-layout .foo-layout .foo-page");
+    async (address) => {
+      const doc = await fetchHtml(`${address}/foo`);
+      assertSelector(doc, ".app .root-layout .foo-layout .foo-page");
 
-      await page.goto(`${address}/foo/bar`);
-      await page.waitForSelector(".app .root-layout .foo-layout .bar-page");
+      const doc2 = await fetchHtml(`${address}/foo/bar`);
+      assertSelector(doc2, ".app .root-layout .foo-layout .bar-page");
     },
   );
 });
 
 Deno.test("skip layouts if not present", async () => {
-  await withPageName(
+  await withFresh(
     "./tests/fixture_layouts/main.ts",
-    async (page, address) => {
-      await page.goto(`${address}/skip/sub`);
-      await page.waitForSelector(".app .root-layout .sub-layout .sub-page");
+    async (address) => {
+      const doc = await fetchHtml(`${address}/skip/sub`);
+      assertSelector(doc, ".app .root-layout .sub-layout .sub-page");
     },
   );
 });
 
 Deno.test("check file types", async (t) => {
-  await withPageName(
+  await withFresh(
     "./tests/fixture_layouts/main.ts",
-    async (page, address) => {
+    async (address) => {
       await t.step(".js", async () => {
-        await page.goto(`${address}/files/js`);
-        await page.waitForSelector(".app .root-layout .js-layout .js-page");
+        const doc = await fetchHtml(`${address}/files/js`);
+        assertSelector(doc, ".app .root-layout .js-layout .js-page");
       });
 
       await t.step(".jsx", async () => {
-        await page.goto(`${address}/files/jsx`);
-        await page.waitForSelector(".app .root-layout .jsx-layout .jsx-page");
+        const doc = await fetchHtml(`${address}/files/jsx`);
+        assertSelector(doc, ".app .root-layout .jsx-layout .jsx-page");
       });
 
       await t.step(".ts", async () => {
-        await page.goto(`${address}/files/ts`);
-        await page.waitForSelector(".app .root-layout .ts-layout .ts-page");
+        const doc = await fetchHtml(`${address}/files/ts`);
+        assertSelector(doc, ".app .root-layout .ts-layout .ts-page");
       });
 
       await t.step(".tsx", async () => {
-        await page.goto(`${address}/files/tsx`);
-        await page.waitForSelector(".app .root-layout .tsx-layout .tsx-page");
+        const doc = await fetchHtml(`${address}/files/tsx`);
+        assertSelector(doc, ".app .root-layout .tsx-layout .tsx-page");
       });
     },
   );


### PR DESCRIPTION
The layout tests were a bit slow. Noticed that they only check if the server sent HTML is correct and don't need any JS to be executed client side. This means we can skip launching a full `puppeteer` process and simply assert against the fetched HTML. This brings down the layout test time from a couple of seconds down to `<100ms`.

Wrote a tiny pretty printer that parsers the linkedom document into something for humans to debug when for example a selector isn't found:

<img width="747" alt="Screenshot 2023-08-01 at 15 33 18" src="https://github.com/denoland/fresh/assets/1062408/6d0afc5f-6fce-4f0f-b268-8cc9cc8594ec">

_Note the charset casing issue is resolved in `preact-render-to-string`, just need to cut a new version_

