### PR TITLE
chore(test): cleanup `test` task

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": false,
   "tasks": {
-    "test": "deno test -A --parallel && deno check --config=www/deno.json www/main.ts www/dev.ts && deno check init.ts",
+    "test": "deno test -A --parallel",
     "fixture": "deno run -A --watch=static/,routes/ tests/fixture/dev.ts",
     "www": "deno task --cwd=www start",
     "screenshot": "deno run -A www/utils/screenshot.ts",


### PR DESCRIPTION
No need for `check:types` and `test` tasks to overlap. I'll soon be submitting a PR that ensures everything, including linting, formatting, type checks, and testing is ok.