### PR TITLE
chore: `deno task ok`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,18 +1,16 @@
 {
   "lock": false,
   "tasks": {
-    "test": "deno test -A --parallel && deno check --config=www/deno.json www/main.ts www/dev.ts && deno check init.ts",
+    "test": "deno test -A --parallel",
     "fixture": "deno run -A --watch=static/,routes/ tests/fixture/dev.ts",
     "www": "deno task --cwd=www start",
     "screenshot": "deno run -A www/utils/screenshot.ts",
-    "check:types": "deno check **/*.ts && deno check **/*.tsx"
+    "check:types": "deno check **/*.ts && deno check **/*.tsx",
+    "ok": "deno fmt --check && deno lint && deno task check:types && deno task test"
   },
   "importMap": "./.vscode/import_map.json",
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "preact"
-  },
-  "test": {
-    "exclude": ["www/"]
   }
 }


### PR DESCRIPTION
This task checks formatting, linting, types and performs tests in one. Now, before committing, a contributor only needs to run `deno task ok` without worrying about each aspect of the repo is ok. This has worked great in Deno SaaSKit's repo.

If reasonable, this task should be used in CI to (almost) guarantee parity in checks between the local machine and CI.

Note to self: once this is merged, update the manual.