### PR TITLE
fix: typo `boder-box` to `border-box`

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -307,7 +307,7 @@ const NO_TWIND_STYLES = `
 *,
 *::before,
 *::after {
-  box-sizing: boder-box;
+  box-sizing: border-box;
 }
 * {
   margin: 0;


### PR DESCRIPTION
minor typographical error in init.ts setup, affects one line in style.css resulting in an invalid property