### PR TITLE
fix: add missing state property to interface

### DIFF
--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -186,7 +186,7 @@ export interface LayoutRoute {
 // --- UNKNOWN PAGE ---
 
 // deno-lint-ignore no-explicit-any
-export interface UnknownPageProps<T = any> {
+export interface UnknownPageProps<T = any, S = Record<string, unknown>> {
   /** The URL of the request that resulted in this page being rendered. */
   url: URL;
 
@@ -199,6 +199,7 @@ export interface UnknownPageProps<T = any> {
    * `undefined`.
    */
   data: T;
+  state: S;
 }
 
 export interface UnknownHandlerContext<State = Record<string, unknown>>

--- a/tests/fixture/routes/_404.tsx
+++ b/tests/fixture/routes/_404.tsx
@@ -1,10 +1,19 @@
 import { UnknownPageProps } from "$fresh/server.ts";
 
-export default function NotFoundPage({ data, url }: UnknownPageProps) {
+type Data = { hello: string };
+type State = { root: string };
+
+export default function NotFoundPage(
+  { data, state, url }: UnknownPageProps<Data | undefined, State>,
+) {
+  // Checks that we have the correct type for state
+  state.root satisfies string;
+
   return (
     <>
       <p>404 not found: {url.pathname}</p>
       {data?.hello && <p>Hello {data.hello}</p>}
+      <p>State root: {state.root}</p>
     </>
   );
 }

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -637,6 +637,7 @@ Deno.test({
     const body = await resp.text();
     assertStringIncludes(body, "404 not found: /not_found");
     assertStringIncludes(body, "Hello Dino");
+    assertStringIncludes(body, "State root: root_mw");
   },
 });
 


### PR DESCRIPTION
Corrects the props interface used in 404 pages to reflect that `state` is available as well.

Closes #1578