### PR TITLE
www: fix 404 on "Using Deno KV OAuth" example

### DIFF
--- a/docs/toc.ts
+++ b/docs/toc.ts
@@ -159,6 +159,7 @@ const toc: RawTableOfContents = {
           ["handling-complex-routes", "Handling complex routes"],
           ["rendering-markdown", "Rendering markdown"],
           ["sharing-state-between-islands", "Sharing state between islands"],
+          ["using-deno-kv-oauth", "Using Deno KV OAuth"],
           ["using-csp", "Using CSP"],
         ],
       },


### PR DESCRIPTION
visiting [Using Deno KV Oauth](https://fresh.deno.dev/docs/examples/using-deno-kv-oauth) yields a 404.  
this pr fixes it by adding the correct article link to the toc.