### PR TITLE
chore(server): simplify plugin route creation

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1289,10 +1289,14 @@ function getMiddlewareRoutesFromPlugins(
   return Object.values(mws);
 }
 
+function formatRoutePath(path: string) {
+  return path.startsWith("/") ? path : "/" + path;
+}
+
 function getRoutesFromPlugins(plugins: Plugin[]): [string, RouteModule][] {
   return plugins.flatMap((plugin) => plugin.routes ?? [])
     .map((route) => {
-      return [`./routes${route.path}.ts`, {
+      return [`./routes${formatRoutePath(route.path)}.ts`, {
         // deno-lint-ignore no-explicit-any
         default: route.component as any,
         handler: route.handler,

--- a/tests/fixture_plugin/utils/route-plugin.ts
+++ b/tests/fixture_plugin/utils/route-plugin.ts
@@ -1,6 +1,7 @@
 import { MiddlewareHandlerContext, Plugin } from "$fresh/server.ts";
 import { handler as testMiddleware } from "./sample_routes/_middleware.ts";
 import { AppBuilder } from "./sample_routes/AppBuilder.tsx";
+import { SimpleRoute } from "./sample_routes/simple-route.tsx";
 export type { Options };
 
 interface Options {
@@ -45,6 +46,6 @@ export default function routePlugin(
     routes: [{
       path: "/_app",
       component: AppBuilder(options),
-    }],
+    }, { path: "no-leading-slash-here", component: SimpleRoute }],
   };
 }

--- a/tests/fixture_plugin/utils/sample_routes/simple-route.tsx
+++ b/tests/fixture_plugin/utils/sample_routes/simple-route.tsx
@@ -1,0 +1,3 @@
+export function SimpleRoute() {
+  return <div>Hello</div>;
+}

--- a/tests/plugin_test.ts
+++ b/tests/plugin_test.ts
@@ -81,6 +81,19 @@ Deno.test("plugin middleware multiple handlers", async () => {
   );
 });
 
+Deno.test("plugin route no leading slash", async () => {
+  const resp = await router(
+    new Request("https://fresh.deno.dev/no-leading-slash-here"),
+  );
+  assert(resp);
+  assertEquals(resp.status, Status.OK);
+  const body = await resp.text();
+  assertStringIncludes(
+    body,
+    `<div>Hello</div>`,
+  );
+});
+
 Deno.test({
   name: "/with-island hydration",
   async fn(t) {


### PR DESCRIPTION
closes #1560

As specified in the issue, we should have a simpler way of specifying routes. Forcing the leading slash is confusing and pointless.