### PR TITLE
feat: support async layout functions

### DIFF
--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -329,9 +329,8 @@ export async function render<Data>(
           component,
         ];
 
-        const componentStack: Array<VNode | null> = new Array(
-          renderStack.length,
-        ).map(() => null);
+        const componentStack: (VNode | null)[] = new Array(renderStack.length)
+          .fill(null);
 
         // deno-lint-ignore no-explicit-any
         const preparedLayouts: ComponentType<any>[] = [];

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -139,12 +139,6 @@ function defaultCsp() {
   };
 }
 
-function getSyncPluginsMessage(plugins: Plugin[]) {
-  return `Async server components cannot be rendered synchronously. The following plugins use a synchronous render method: "${
-    plugins.map((plugin) => plugin.name).join('", "')
-  }"`;
-}
-
 function checkAsyncComponent(
   component: unknown,
 ): component is AsyncRoute | AsyncLayout {
@@ -230,10 +224,6 @@ export async function render<Data>(
     // deno-lint-ignore no-explicit-any
     let finalAppComp: VNode<any> = vnode as any;
 
-    if (layouts.some((layout) => checkAsyncComponent(layout.default))) {
-      throw new Error(getSyncPluginsMessage(syncPlugins));
-    }
-
     let i = opts.layouts.length;
     while (i--) {
       const layout = layouts[i];
@@ -258,7 +248,11 @@ export async function render<Data>(
 
   const renderResults: [Plugin, PluginRenderResult][] = [];
   if (isAsyncComponent && syncPlugins.length > 0) {
-    throw new Error(getSyncPluginsMessage(syncPlugins));
+    throw new Error(
+      `Async server components cannot be rendered synchronously. The following plugins use a synchronous render method: "${
+        syncPlugins.map((plugin) => plugin.name).join('", "')
+      }"`,
+    );
   }
 
   function renderSync(): PluginRenderFunctionResult {

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -409,7 +409,6 @@ export async function render<Data>(
   }
 
   await renderAsync();
-  console.log({ asyncRenderResponse });
   if (asyncRenderResponse !== undefined) {
     return asyncRenderResponse;
   }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -177,9 +177,15 @@ export interface LayoutProps<T = any, S = Record<string, unknown>>
   extends PageProps<T, S> {
   Component: ComponentType<Record<never, never>>;
 }
+// deno-lint-ignore no-explicit-any
+export type AsyncLayout<T = any, S = Record<string, unknown>> = (
+  req: Request,
+  ctx: RouteContext<T, S>,
+  props: LayoutProps,
+) => Promise<ComponentChildren | Response>;
 
 export interface LayoutModule {
-  default: ComponentType<LayoutProps>;
+  default: ComponentType<LayoutProps> | AsyncLayout;
 }
 
 export interface LayoutRoute {

--- a/tests/fixture_layouts/fresh.gen.ts
+++ b/tests/fixture_layouts/fresh.gen.ts
@@ -5,42 +5,54 @@
 import * as $0 from "./routes/_app.tsx";
 import * as $1 from "./routes/_layout.tsx";
 import * as $2 from "./routes/_middleware.ts";
-import * as $3 from "./routes/files/js/_layout.js";
-import * as $4 from "./routes/files/js/index.js";
-import * as $5 from "./routes/files/jsx/_layout.jsx";
-import * as $6 from "./routes/files/jsx/index.jsx";
-import * as $7 from "./routes/files/ts/_layout.ts";
-import * as $8 from "./routes/files/ts/index.ts";
-import * as $9 from "./routes/files/tsx/_layout.tsx";
-import * as $10 from "./routes/files/tsx/index.tsx";
-import * as $11 from "./routes/foo/_layout.tsx";
-import * as $12 from "./routes/foo/bar.tsx";
-import * as $13 from "./routes/foo/index.tsx";
-import * as $14 from "./routes/index.tsx";
-import * as $15 from "./routes/other.tsx";
-import * as $16 from "./routes/skip/sub/_layout.tsx";
-import * as $17 from "./routes/skip/sub/index.tsx";
+import * as $3 from "./routes/async/_layout.tsx";
+import * as $4 from "./routes/async/index.tsx";
+import * as $5 from "./routes/async/redirect/_layout.tsx";
+import * as $6 from "./routes/async/redirect/index.tsx";
+import * as $7 from "./routes/async/sub/_layout.tsx";
+import * as $8 from "./routes/async/sub/index.tsx";
+import * as $9 from "./routes/files/js/_layout.js";
+import * as $10 from "./routes/files/js/index.js";
+import * as $11 from "./routes/files/jsx/_layout.jsx";
+import * as $12 from "./routes/files/jsx/index.jsx";
+import * as $13 from "./routes/files/ts/_layout.ts";
+import * as $14 from "./routes/files/ts/index.ts";
+import * as $15 from "./routes/files/tsx/_layout.tsx";
+import * as $16 from "./routes/files/tsx/index.tsx";
+import * as $17 from "./routes/foo/_layout.tsx";
+import * as $18 from "./routes/foo/bar.tsx";
+import * as $19 from "./routes/foo/index.tsx";
+import * as $20 from "./routes/index.tsx";
+import * as $21 from "./routes/other.tsx";
+import * as $22 from "./routes/skip/sub/_layout.tsx";
+import * as $23 from "./routes/skip/sub/index.tsx";
 
 const manifest = {
   routes: {
     "./routes/_app.tsx": $0,
     "./routes/_layout.tsx": $1,
     "./routes/_middleware.ts": $2,
-    "./routes/files/js/_layout.js": $3,
-    "./routes/files/js/index.js": $4,
-    "./routes/files/jsx/_layout.jsx": $5,
-    "./routes/files/jsx/index.jsx": $6,
-    "./routes/files/ts/_layout.ts": $7,
-    "./routes/files/ts/index.ts": $8,
-    "./routes/files/tsx/_layout.tsx": $9,
-    "./routes/files/tsx/index.tsx": $10,
-    "./routes/foo/_layout.tsx": $11,
-    "./routes/foo/bar.tsx": $12,
-    "./routes/foo/index.tsx": $13,
-    "./routes/index.tsx": $14,
-    "./routes/other.tsx": $15,
-    "./routes/skip/sub/_layout.tsx": $16,
-    "./routes/skip/sub/index.tsx": $17,
+    "./routes/async/_layout.tsx": $3,
+    "./routes/async/index.tsx": $4,
+    "./routes/async/redirect/_layout.tsx": $5,
+    "./routes/async/redirect/index.tsx": $6,
+    "./routes/async/sub/_layout.tsx": $7,
+    "./routes/async/sub/index.tsx": $8,
+    "./routes/files/js/_layout.js": $9,
+    "./routes/files/js/index.js": $10,
+    "./routes/files/jsx/_layout.jsx": $11,
+    "./routes/files/jsx/index.jsx": $12,
+    "./routes/files/ts/_layout.ts": $13,
+    "./routes/files/ts/index.ts": $14,
+    "./routes/files/tsx/_layout.tsx": $15,
+    "./routes/files/tsx/index.tsx": $16,
+    "./routes/foo/_layout.tsx": $17,
+    "./routes/foo/bar.tsx": $18,
+    "./routes/foo/index.tsx": $19,
+    "./routes/index.tsx": $20,
+    "./routes/other.tsx": $21,
+    "./routes/skip/sub/_layout.tsx": $22,
+    "./routes/skip/sub/index.tsx": $23,
   },
   islands: {},
   baseUrl: import.meta.url,

--- a/tests/fixture_layouts/routes/_app.tsx
+++ b/tests/fixture_layouts/routes/_app.tsx
@@ -1,6 +1,6 @@
 import { AppProps } from "$fresh/server.ts";
 
-export default function App({ Component }: AppProps) {
+export default function App({ Component, state }: AppProps) {
   return (
     <div class="app">
       <Component />

--- a/tests/fixture_layouts/routes/async/_layout.tsx
+++ b/tests/fixture_layouts/routes/async/_layout.tsx
@@ -1,0 +1,15 @@
+import { LayoutProps, RouteContext } from "$fresh/server.ts";
+
+export default async function AsyncLayout(
+  req: Request,
+  ctx: RouteContext,
+  { Component }: LayoutProps,
+) {
+  await new Promise((r) => setTimeout(r, 10));
+  return (
+    <div class="async-layout">
+      <p>Async layout</p>
+      <Component />
+    </div>
+  );
+}

--- a/tests/fixture_layouts/routes/async/index.tsx
+++ b/tests/fixture_layouts/routes/async/index.tsx
@@ -1,0 +1,10 @@
+import { RouteContext } from "$fresh/server.ts";
+
+export default async function AsyncPage(req: Request, ctx: RouteContext) {
+  await new Promise((r) => setTimeout(r, 10));
+  return (
+    <div class="async-page">
+      <p>Async page</p>
+    </div>
+  );
+}

--- a/tests/fixture_layouts/routes/async/redirect/_layout.tsx
+++ b/tests/fixture_layouts/routes/async/redirect/_layout.tsx
@@ -1,0 +1,13 @@
+import { LayoutProps, RouteContext } from "$fresh/server.ts";
+
+export default async function AsyncSubLayout(
+  req: Request,
+  ctx: RouteContext,
+  { Component }: LayoutProps,
+) {
+  await new Promise((r) => setTimeout(r, 10));
+  return new Response("", {
+    status: 307,
+    headers: { Location: "/async/sub" },
+  });
+}

--- a/tests/fixture_layouts/routes/async/redirect/_layout.tsx
+++ b/tests/fixture_layouts/routes/async/redirect/_layout.tsx
@@ -5,8 +5,8 @@ export default async function AsyncSubLayout(
   ctx: RouteContext,
   { Component }: LayoutProps,
 ) {
-  await new Promise((r) => setTimeout(r, 10));
-  return new Response("", {
+  await delay(10);
+  return new Response(null, {
     status: 307,
     headers: { Location: "/async/sub" },
   });

--- a/tests/fixture_layouts/routes/async/redirect/_layout.tsx
+++ b/tests/fixture_layouts/routes/async/redirect/_layout.tsx
@@ -1,4 +1,5 @@
 import { LayoutProps, RouteContext } from "$fresh/server.ts";
+import { delay } from "$std/async/mod.ts";
 
 export default async function AsyncSubLayout(
   req: Request,

--- a/tests/fixture_layouts/routes/async/redirect/index.tsx
+++ b/tests/fixture_layouts/routes/async/redirect/index.tsx
@@ -1,0 +1,13 @@
+import { RouteContext } from "$fresh/server.ts";
+
+export default async function AsyncRedirectPage(
+  req: Request,
+  ctx: RouteContext,
+) {
+  await new Promise((r) => setTimeout(r, 10));
+  return (
+    <div class="async-sub-page">
+      <p>Async Redirect page</p>
+    </div>
+  );
+}

--- a/tests/fixture_layouts/routes/async/sub/_layout.tsx
+++ b/tests/fixture_layouts/routes/async/sub/_layout.tsx
@@ -1,0 +1,15 @@
+import { LayoutProps, RouteContext } from "$fresh/server.ts";
+
+export default async function AsyncSubLayout(
+  req: Request,
+  ctx: RouteContext,
+  { Component }: LayoutProps,
+) {
+  await new Promise((r) => setTimeout(r, 10));
+  return (
+    <div class="async-sub-layout">
+      <p>Async Sub layout</p>
+      <Component />
+    </div>
+  );
+}

--- a/tests/fixture_layouts/routes/async/sub/index.tsx
+++ b/tests/fixture_layouts/routes/async/sub/index.tsx
@@ -1,0 +1,10 @@
+import { RouteContext } from "$fresh/server.ts";
+
+export default async function AsyncSubPage(req: Request, ctx: RouteContext) {
+  await new Promise((r) => setTimeout(r, 10));
+  return (
+    <div class="async-sub-page">
+      <p>Async Sub page</p>
+    </div>
+  );
+}

--- a/tests/layouts_test.ts
+++ b/tests/layouts_test.ts
@@ -64,3 +64,44 @@ Deno.test("check file types", async (t) => {
     },
   );
 });
+
+Deno.test("render async layout", async () => {
+  await withFresh(
+    "./tests/fixture_layouts/main.ts",
+    async (address) => {
+      const doc = await fetchHtml(`${address}/async`);
+      assertSelector(doc, ".app .root-layout .async-layout .async-page");
+    },
+  );
+});
+
+Deno.test("render nested async layout", async () => {
+  await withFresh(
+    "./tests/fixture_layouts/main.ts",
+    async (address) => {
+      const doc = await fetchHtml(`${address}/async/sub`);
+      assertSelector(
+        doc,
+        ".app .root-layout .async-layout .async-sub-layout .async-sub-page",
+      );
+    },
+  );
+});
+
+Deno.test({
+  name: "can return Response from async layout",
+  fn: async () => {
+    await withFresh(
+      "./tests/fixture_layouts/main.ts",
+      async (address) => {
+        const doc = await fetchHtml(`${address}/async/redirect`);
+        assertSelector(
+          doc,
+          ".app .root-layout .async-layout .async-sub-layout .async-sub-page",
+        );
+      },
+    );
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});

--- a/tests/layouts_test.ts
+++ b/tests/layouts_test.ts
@@ -102,6 +102,4 @@ Deno.test({
       },
     );
   },
-  sanitizeOps: false,
-  sanitizeResources: false,
 });


### PR DESCRIPTION
This PR adds support for making Layouts behave similar to async route components. At some point I'll probably need to add proper async components in Preact, but for now this works and aligns well with the existing capabilities we have for routes.

```tsx
export default async function AsyncLayout(
  req: Request,
  ctx: RouteContext,
  { Component }: LayoutProps,
) {
  return (
    <div class="async-layout">
      <p>Async layout</p>
      <Component />
    </div>
  );
}
```