### PR TITLE
feat(server): support https

### DIFF
--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -12,7 +12,6 @@ export {
   type Handler as ServeHandler,
   serve,
 } from "https://deno.land/std@0.193.0/http/server.ts";
-export type { ServeInit } from "https://deno.land/std@0.193.0/http/server.ts";
 export { Status } from "https://deno.land/std@0.193.0/http/http_status.ts";
 export {
   typeByExtension,

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,11 +1,10 @@
 import { ComponentChildren, ComponentType, VNode } from "preact";
-import { ServeInit } from "./deps.ts";
 import * as router from "./router.ts";
 import { InnerRenderFunction, RenderContext } from "./render.ts";
 
 // --- APPLICATION CONFIGURATION ---
 
-export type StartOptions = ServeInit & FreshOptions;
+export type StartOptions = Partial<Deno.ServeTlsOptions> & FreshOptions;
 
 export interface FreshOptions {
   render?: RenderFunction;

--- a/tests/fixture/main_tls.ts
+++ b/tests/fixture/main_tls.ts
@@ -1,0 +1,12 @@
+/// <reference no-default-lib="true" />
+/// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
+/// <reference lib="dom.asynciterable" />
+/// <reference lib="deno.ns" />
+
+import { start } from "$fresh/server.ts";
+import routes from "./fresh.gen.ts";
+import options from "./options.ts";
+
+// this just exists to function as a type check to assert that we can actually pass a key and cert in
+await start(routes, { ...options, key: "test", cert: "test" });


### PR DESCRIPTION
closes https://github.com/denoland/fresh/issues/901, closes https://github.com/denoland/fresh/issues/809

We currently have (all referenced and relevant types included for clarity):
```tsx
export type StartOptions = ServeInit & FreshOptions;

export interface ServeInit extends Partial<Deno.ListenOptions> {
  signal?: AbortSignal;
  onError?: (error: unknown) => Response | Promise<Response>;
  onListen?: (params: { hostname: string; port: number }) => void;
}

export interface ListenOptions {
  port: number;
  hostname?: string;
}

```

And after this change we have (all referenced and relevant types included for clarity):
```tsx
export type StartOptions = Partial<Deno.ServeTlsOptions> & FreshOptions;

export interface ServeTlsOptions extends ServeOptions {
  cert: string;
  key: string;
}

export interface ServeOptions {
  port?: number;
  hostname?: string;
  signal?: AbortSignal;
  reusePort?: boolean;
  onError?: (error: unknown) => Response | Promise<Response>;
  onListen?: (params: { hostname: string; port: number }) => void;
}
```

So this change adds the necessary `cert` and `key` to the options bag, and the unnecessary (at least for this change, but overall possibly beneficial) `reusePort`.

Now that we're type checking the project, I created a "test" for this by introducing a `main_tls.ts` file which tries to start a fresh server with `cert` and `key` specified. We'll rely on the deno runtime tests themselves to confirm this works, but this at least asserts that the properties are passable. Note that we get a type error if the actual change here is reverted, proving that https isn't currently supported.