### PR TITLE
chore: remove console.log

### DIFF
--- a/src/dev/mod.ts
+++ b/src/dev/mod.ts
@@ -77,7 +77,6 @@ export async function collect(directory: string): Promise<Manifest> {
       const match = normalized.match(GROUP_REG);
       if (match && match[1].startsWith("_")) {
         if (match[1] === "_islands") {
-          console.log(rel);
           islands.push(rel);
         }
         return;


### PR DESCRIPTION
Accidentally merged a `console.log` in #1600 .