### PR TITLE
chore: add test for checking initialized project

### DIFF
--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -27,7 +27,7 @@ const assertFileExistence = async (files: string[], dirname: string) => {
 };
 
 Deno.test({
-  name: "fresh-init",
+  name: "fresh-init asdf",
   async fn(t) {
     // Preparation
     const tmpDirName = await Deno.makeTempDir();
@@ -62,6 +62,21 @@ Deno.test({
 
     await t.step("check generated files", async () => {
       await assertFileExistence(files, tmpDirName);
+    });
+
+    await t.step("check project", async () => {
+      const cliProcess = new Deno.Command(Deno.execPath(), {
+        args: [
+          "task",
+          "check",
+        ],
+        cwd: tmpDirName,
+        stdin: "null",
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const { code } = await cliProcess.output();
+      assertEquals(code, 0);
     });
 
     await t.step("start up the server and access the root page", async () => {


### PR DESCRIPTION
This is, I think, the natural followup to https://github.com/denoland/fresh/pull/1539 and https://github.com/denoland/fresh/pull/1454. Now that we have an easy way to type check the initialized project, we should assert that there are no type errors in that project.

This adds three seconds on my slow computer, but I think it's worth it; releasing code with red squiggles or linting or formatting errors is a bit silly.