### PR TITLE
feat: allow layout and _app overrides

### DIFF
--- a/docs/canary/concepts/route-layout.md
+++ b/docs/canary/concepts/route-layout.md
@@ -15,8 +15,8 @@ routes/
     index.tsx
     page.tsx
   /other
-    _layout.tsx
-    page.tsx # will be applied on top of `routes/_layout.tsx`
+    _layout.tsx # will be applied on top of `routes/_layout.tsx`
+    page.tsx
 ```
 
 The component to be wrapped is received via props, in addition to a few other

--- a/docs/canary/concepts/route-layout.md
+++ b/docs/canary/concepts/route-layout.md
@@ -7,6 +7,18 @@ An route layout is defined in a `_layout.tsx` file in any sub directory (at any
 level) under the `routes/` folder. It must contain a default export that is a
 regular Preact component. Only one such layout is allowed per sub directory.
 
+```sh
+routes/
+  _app.tsx
+  _layout.tsx # will be applied to all routes
+  /sub
+    index.tsx
+    page.tsx
+  /other
+    _layout.tsx
+    page.tsx # will be applied on top of `routes/_layout.tsx`
+```
+
 The component to be wrapped is received via props, in addition to a few other
 things. This allows for the introduction of a global container functioning as a
 template which can be conditioned based on state and params. Note that any state
@@ -24,5 +36,55 @@ export default function Layout({ Component, state }: LayoutProps) {
       <Component />
     </div>
   );
+}
+```
+
+## Opting out of layout inheritance
+
+Sometimes you want to opt out of the layout inheritance mechanism for a
+particular route. This can be done via route configuration. Picture a directory
+structure like this:
+
+```sh
+routes/
+  _layout.tsx
+  /sub
+    _layout.tsx
+    index.tsx
+    special.tsx # should not inherit layouts
+```
+
+To make `routes/sub/special.tsx` opt out of rendering layouts we can set
+`rootLayout: true`.
+
+```tsx
+// routes/sub/special.tsx
+import { RouteConfig } from "$fresh/server.ts";
+
+export const config: RouteConfig = {
+  rootLayout: true, // Mark this route as the root layout
+};
+
+export default function MyPage() {
+  return <p>Hello world</p>;
+}
+```
+
+Note that you can also mark layouts as root layouts.
+
+## Disabling the root `_app` template
+
+In very rare cases you might want to disable the root `_app` template for a
+particular route. This can be done by setting `appTemplate: false`.
+
+```tsx
+import { RouteConfig } from "$fresh/server.ts";
+
+export const config: RouteConfig = {
+  appTemplate: false, // Disable the `_app` template
+};
+
+export default function MyPage() {
+  return <p>Hello world</p>;
 }
 ```

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -253,6 +253,8 @@ export class ServerContext {
           component,
           handler,
           csp: Boolean(config?.csp ?? false),
+          appLayout: Boolean(config?.appTemplate ?? true),
+          rootLayout: Boolean(config?.rootLayout ?? false),
         };
         routes.push(route);
       } else if (isMiddleware) {
@@ -288,6 +290,8 @@ export class ServerContext {
           component,
           handler: handler ?? ((req) => router.defaultOtherHandler(req)),
           csp: Boolean(config?.csp ?? false),
+          appLayout: Boolean(config?.appTemplate ?? true),
+          rootLayout: Boolean(config?.rootLayout ?? false),
         };
       } else if (
         path === "/_500.tsx" || path === "/_500.ts" ||
@@ -308,6 +312,8 @@ export class ServerContext {
           handler: handler ??
             ((req, ctx) => router.defaultErrorHandler(req, ctx, ctx.error)),
           csp: Boolean(config?.csp ?? false),
+          appLayout: Boolean(config?.appTemplate ?? true),
+          rootLayout: Boolean(config?.rootLayout ?? false),
         };
       }
     }
@@ -971,6 +977,8 @@ const DEFAULT_NOT_FOUND: UnknownPage = {
   name: "_404",
   handler: (req) => router.defaultOtherHandler(req),
   csp: false,
+  appLayout: true,
+  rootLayout: false,
 };
 
 const DEFAULT_ERROR: ErrorPage = {
@@ -981,6 +989,8 @@ const DEFAULT_ERROR: ErrorPage = {
   component: DefaultErrorHandler,
   handler: (_req, ctx) => ctx.render(),
   csp: false,
+  appLayout: true,
+  rootLayout: false,
 };
 
 export function selectSharedRoutes<T>(

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -159,13 +159,15 @@ export async function render<Data>(
   // Note that the route itself can act as the root layout.
   let layouts = opts.layouts;
   if (!opts.route.rootLayout) {
+    let rootIdx = 0;
     let layoutIdx = opts.layouts.length;
     while (layoutIdx--) {
       if (opts.layouts[layoutIdx].config?.rootLayout) {
+        rootIdx = layoutIdx;
         break;
       }
     }
-    layouts = opts.layouts.slice(layoutIdx);
+    layouts = opts.layouts.slice(rootIdx);
   } else {
     layouts = [];
   }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -79,6 +79,18 @@ export interface RouteConfig {
    * using the `useCSP` hook.
    */
   csp?: boolean;
+
+  /**
+   * Mark this route as the root layout and ignore previously
+   * inherited layouts. Default: `false`
+   */
+  rootLayout?: boolean;
+
+  /**
+   * Whether to use the `routes/_app` template if available or not.
+   * Default: `true`
+   */
+  appTemplate?: boolean;
 }
 
 // deno-lint-ignore no-empty-interface
@@ -153,6 +165,8 @@ export interface Route<Data = any> {
   component?: PageComponent<Data>;
   handler: Handler<Data> | Handlers<Data>;
   csp: boolean;
+  appLayout: boolean;
+  rootLayout: boolean;
 }
 
 export interface RouterState {
@@ -185,6 +199,7 @@ export type AsyncLayout<T = any, S = Record<string, unknown>> = (
 
 export interface LayoutModule {
   default: ComponentType<LayoutProps> | AsyncLayout;
+  config?: Pick<RouteConfig, "appLayout" | "rootLayout">;
 }
 
 export interface LayoutRoute {
@@ -236,6 +251,8 @@ export interface UnknownPage {
   component?: PageComponent<UnknownPageProps>;
   handler: UnknownHandler;
   csp: boolean;
+  appLayout: boolean;
+  rootLayout: boolean;
 }
 
 // --- ERROR PAGE ---
@@ -281,6 +298,8 @@ export interface ErrorPage {
   component?: PageComponent<ErrorPageProps>;
   handler: ErrorHandler;
   csp: boolean;
+  appLayout: boolean;
+  rootLayout: boolean;
 }
 
 // --- MIDDLEWARES ---

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -199,7 +199,7 @@ export type AsyncLayout<T = any, S = Record<string, unknown>> = (
 
 export interface LayoutModule {
   default: ComponentType<LayoutProps> | AsyncLayout;
-  config?: Pick<RouteConfig, "appLayout" | "rootLayout">;
+  config?: Pick<RouteConfig, "appTemplate" | "rootLayout">;
 }
 
 export interface LayoutRoute {

--- a/tests/fixture_layouts/fresh.gen.ts
+++ b/tests/fixture_layouts/fresh.gen.ts
@@ -23,9 +23,15 @@ import * as $17 from "./routes/foo/_layout.tsx";
 import * as $18 from "./routes/foo/bar.tsx";
 import * as $19 from "./routes/foo/index.tsx";
 import * as $20 from "./routes/index.tsx";
-import * as $21 from "./routes/other.tsx";
-import * as $22 from "./routes/skip/sub/_layout.tsx";
-import * as $23 from "./routes/skip/sub/index.tsx";
+import * as $21 from "./routes/no_app.tsx";
+import * as $22 from "./routes/other.tsx";
+import * as $23 from "./routes/override/_layout.tsx";
+import * as $24 from "./routes/override/index.tsx";
+import * as $25 from "./routes/override/no_app.tsx";
+import * as $26 from "./routes/override/no_layout.tsx";
+import * as $27 from "./routes/override/no_layout_no_app.tsx";
+import * as $28 from "./routes/skip/sub/_layout.tsx";
+import * as $29 from "./routes/skip/sub/index.tsx";
 
 const manifest = {
   routes: {
@@ -50,9 +56,15 @@ const manifest = {
     "./routes/foo/bar.tsx": $18,
     "./routes/foo/index.tsx": $19,
     "./routes/index.tsx": $20,
-    "./routes/other.tsx": $21,
-    "./routes/skip/sub/_layout.tsx": $22,
-    "./routes/skip/sub/index.tsx": $23,
+    "./routes/no_app.tsx": $21,
+    "./routes/other.tsx": $22,
+    "./routes/override/_layout.tsx": $23,
+    "./routes/override/index.tsx": $24,
+    "./routes/override/no_app.tsx": $25,
+    "./routes/override/no_layout.tsx": $26,
+    "./routes/override/no_layout_no_app.tsx": $27,
+    "./routes/skip/sub/_layout.tsx": $28,
+    "./routes/skip/sub/index.tsx": $29,
   },
   islands: {},
   baseUrl: import.meta.url,

--- a/tests/fixture_layouts/routes/no_app.tsx
+++ b/tests/fixture_layouts/routes/no_app.tsx
@@ -1,0 +1,17 @@
+import { RouteConfig } from "$fresh/server.ts";
+
+export const config: RouteConfig = {
+  appTemplate: false,
+};
+
+export default function OverridePage() {
+  return (
+    <html>
+      <body>
+        <p class="no-app">
+          no <pre>_app.tsx</pre> template
+        </p>
+      </body>
+    </html>
+  );
+}

--- a/tests/fixture_layouts/routes/override/_layout.tsx
+++ b/tests/fixture_layouts/routes/override/_layout.tsx
@@ -1,0 +1,13 @@
+import { LayoutProps, RouteConfig } from "$fresh/server.ts";
+
+export const config: RouteConfig = {
+  rootLayout: true,
+};
+
+export default function OverrideLayout({ Component }: LayoutProps) {
+  return (
+    <div class="override-layout">
+      <Component />
+    </div>
+  );
+}

--- a/tests/fixture_layouts/routes/override/index.tsx
+++ b/tests/fixture_layouts/routes/override/index.tsx
@@ -1,0 +1,7 @@
+export default function OverridePage() {
+  return (
+    <div class="override-page">
+      /override index page
+    </div>
+  );
+}

--- a/tests/fixture_layouts/routes/override/no_app.tsx
+++ b/tests/fixture_layouts/routes/override/no_app.tsx
@@ -1,0 +1,13 @@
+import { RouteConfig } from "$fresh/server.ts";
+
+export const config: RouteConfig = {
+  appTemplate: false,
+};
+
+export default function OverridePage() {
+  return (
+    <p class="no-app">
+      no <code>_app.tsx</code> template
+    </p>
+  );
+}

--- a/tests/fixture_layouts/routes/override/no_layout.tsx
+++ b/tests/fixture_layouts/routes/override/no_layout.tsx
@@ -1,0 +1,13 @@
+import { RouteConfig } from "$fresh/server.ts";
+
+export const config: RouteConfig = {
+  rootLayout: true,
+};
+
+export default function OverridePage() {
+  return (
+    <p class="no-layouts">
+      no layouts
+    </p>
+  );
+}

--- a/tests/fixture_layouts/routes/override/no_layout_no_app.tsx
+++ b/tests/fixture_layouts/routes/override/no_layout_no_app.tsx
@@ -1,0 +1,14 @@
+import { RouteConfig } from "$fresh/server.ts";
+
+export const config: RouteConfig = {
+  appTemplate: false,
+  rootLayout: true,
+};
+
+export default function OverridePage() {
+  return (
+    <p class="no-app-no-layouts">
+      no <code>_app.tsx</code> template and no layouts
+    </p>
+  );
+}

--- a/tests/layouts_test.ts
+++ b/tests/layouts_test.ts
@@ -1,5 +1,10 @@
 import { assert } from "./deps.ts";
-import { assertSelector, fetchHtml, withFresh } from "./test_utils.ts";
+import {
+  assertNotSelector,
+  assertSelector,
+  fetchHtml,
+  withFresh,
+} from "./test_utils.ts";
 
 Deno.test("apply root _layout and _app", async () => {
   await withFresh(
@@ -102,4 +107,45 @@ Deno.test({
       },
     );
   },
+});
+
+Deno.test("disable _app layout", async () => {
+  await withFresh(
+    "./tests/fixture_layouts/main.ts",
+    async (address) => {
+      const doc = await fetchHtml(`${address}/override/no_app`);
+      assertNotSelector(doc, "body body");
+      assertSelector(doc, "body > .override-layout >.no-app");
+    },
+  );
+});
+
+Deno.test("override layouts", async () => {
+  await withFresh(
+    "./tests/fixture_layouts/main.ts",
+    async (address) => {
+      const doc = await fetchHtml(`${address}/override`);
+      assertSelector(doc, "body > .app > .override-layout > .override-page");
+    },
+  );
+});
+
+Deno.test("route overrides layout", async () => {
+  await withFresh(
+    "./tests/fixture_layouts/main.ts",
+    async (address) => {
+      const doc = await fetchHtml(`${address}/override/no_layout`);
+      assertSelector(doc, "body > .app > .no-layouts");
+    },
+  );
+});
+
+Deno.test("route overrides layout", async () => {
+  await withFresh(
+    "./tests/fixture_layouts/main.ts",
+    async (address) => {
+      const doc = await fetchHtml(`${address}/override/no_layout_no_app`);
+      assertSelector(doc, "body > .no-app-no-layouts");
+    },
+  );
 });

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -40,6 +40,15 @@ export function assertSelector(doc: Document, selector: string) {
   }
 }
 
+export function assertNotSelector(doc: Document, selector: string) {
+  if (doc.querySelector(selector) !== null) {
+    const html = prettyDom(doc);
+    throw new Error(
+      `Selector "${selector}" found in document.\n\n${html}`,
+    );
+  }
+}
+
 export function assertTextMany(
   doc: Document,
   selector: string,


### PR DESCRIPTION
This PR adds two new options to route configuration to override previously inherited layouts or skip the `_app` template.

```tsx
export const config: RouteConfig = {
  rootLayout: true, // Mark this route as the root layout
  appTemplate: false // Disable `_app` template
};

export default function MyPage() {
  return <p>Hello world</p>;
}
