### PR TITLE
fix: rename layout config options

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -253,8 +253,8 @@ export class ServerContext {
           component,
           handler,
           csp: Boolean(config?.csp ?? false),
-          appTemplate: Boolean(config?.skipAppTemplate),
-          inheritLayouts: Boolean(config?.skipInheritedLayouts),
+          appTemplate: !config?.skipAppTemplate,
+          inheritLayouts: !config?.skipInheritedLayouts,
         };
         routes.push(route);
       } else if (isMiddleware) {
@@ -274,8 +274,8 @@ export class ServerContext {
           baseRoute: toBaseRoute(baseRoute),
           handler: mod.handler,
           component: mod.default,
-          appTemplate: Boolean(config?.skipAppTemplate),
-          inheritLayouts: Boolean(config?.skipInheritedLayouts),
+          appTemplate: !config?.skipAppTemplate,
+          inheritLayouts: !config?.skipInheritedLayouts,
         });
       } else if (
         path === "/_404.tsx" || path === "/_404.ts" ||
@@ -295,8 +295,8 @@ export class ServerContext {
           component,
           handler: handler ?? ((req) => router.defaultOtherHandler(req)),
           csp: Boolean(config?.csp ?? false),
-          appTemplate: Boolean(config?.skipAppTemplate),
-          inheritLayouts: Boolean(config?.skipInheritedLayouts),
+          appTemplate: !config?.skipAppTemplate,
+          inheritLayouts: !config?.skipInheritedLayouts,
         };
       } else if (
         path === "/_500.tsx" || path === "/_500.ts" ||
@@ -317,8 +317,8 @@ export class ServerContext {
           handler: handler ??
             ((req, ctx) => router.defaultErrorHandler(req, ctx, ctx.error)),
           csp: Boolean(config?.csp ?? false),
-          appTemplate: Boolean(config?.skipAppTemplate ?? true),
-          inheritLayouts: Boolean(config?.skipInheritedLayouts ?? false),
+          appTemplate: !config?.skipAppTemplate,
+          inheritLayouts: !config?.skipInheritedLayouts,
         };
       }
     }

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -253,8 +253,8 @@ export class ServerContext {
           component,
           handler,
           csp: Boolean(config?.csp ?? false),
-          appTemplate: Boolean(config?.appTemplate ?? true),
-          inheritLayouts: Boolean(config?.inheritLayouts ?? true),
+          appTemplate: Boolean(config?.skipAppTemplate),
+          inheritLayouts: Boolean(config?.skipInheritedLayouts),
         };
         routes.push(route);
       } else if (isMiddleware) {
@@ -274,8 +274,8 @@ export class ServerContext {
           baseRoute: toBaseRoute(baseRoute),
           handler: mod.handler,
           component: mod.default,
-          appTemplate: Boolean(config?.appTemplate ?? true),
-          inheritLayouts: Boolean(config?.inheritLayouts ?? true),
+          appTemplate: Boolean(config?.skipAppTemplate),
+          inheritLayouts: Boolean(config?.skipInheritedLayouts),
         });
       } else if (
         path === "/_404.tsx" || path === "/_404.ts" ||
@@ -295,8 +295,8 @@ export class ServerContext {
           component,
           handler: handler ?? ((req) => router.defaultOtherHandler(req)),
           csp: Boolean(config?.csp ?? false),
-          appTemplate: Boolean(config?.appTemplate ?? true),
-          inheritLayouts: Boolean(config?.inheritLayouts ?? false),
+          appTemplate: Boolean(config?.skipAppTemplate),
+          inheritLayouts: Boolean(config?.skipInheritedLayouts),
         };
       } else if (
         path === "/_500.tsx" || path === "/_500.ts" ||
@@ -317,8 +317,8 @@ export class ServerContext {
           handler: handler ??
             ((req, ctx) => router.defaultErrorHandler(req, ctx, ctx.error)),
           csp: Boolean(config?.csp ?? false),
-          appTemplate: Boolean(config?.appTemplate ?? true),
-          inheritLayouts: Boolean(config?.inheritLayouts ?? false),
+          appTemplate: Boolean(config?.skipAppTemplate ?? true),
+          inheritLayouts: Boolean(config?.skipInheritedLayouts ?? false),
         };
       }
     }
@@ -983,7 +983,7 @@ const DEFAULT_NOT_FOUND: UnknownPage = {
   handler: (req) => router.defaultOtherHandler(req),
   csp: false,
   appTemplate: true,
-  inheritLayouts: false,
+  inheritLayouts: true,
 };
 
 const DEFAULT_ERROR: ErrorPage = {
@@ -995,7 +995,7 @@ const DEFAULT_ERROR: ErrorPage = {
   handler: (_req, ctx) => ctx.render(),
   csp: false,
   appTemplate: true,
-  inheritLayouts: false,
+  inheritLayouts: true,
 };
 
 export function selectSharedRoutes<T extends { baseRoute: BaseRoute }>(

--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -23,6 +23,7 @@ export type {
   Handler,
   HandlerContext,
   Handlers,
+  LayoutConfig,
   LayoutContext,
   LayoutProps,
   MiddlewareHandler,

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -15,7 +15,7 @@ import {
   AsyncRoute,
   ErrorPage,
   Island,
-  LayoutModule,
+  LayoutRoute,
   Plugin,
   PluginRenderFunctionResult,
   PluginRenderResult,
@@ -83,7 +83,7 @@ export interface RenderOptions<Data> {
   islands: Island[];
   plugins: Plugin[];
   app: AppModule;
-  layouts: LayoutModule[];
+  layouts: LayoutRoute[];
   imports: string[];
   dependenciesFn: (path: string) => string[];
   url: URL;
@@ -182,11 +182,11 @@ export async function render<Data>(
   // Only inherit layouts up to the nearest root layout.
   // Note that the route itself can act as the root layout.
   let layouts = opts.layouts;
-  if (!opts.route.rootLayout) {
+  if (opts.route.inheritLayouts) {
     let rootIdx = 0;
     let layoutIdx = opts.layouts.length;
     while (layoutIdx--) {
-      if (opts.layouts[layoutIdx].config?.rootLayout) {
+      if (!opts.layouts[layoutIdx].inheritLayouts) {
         rootIdx = layoutIdx;
         break;
       }

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -265,13 +265,13 @@ export async function render<Data>(
   const renderStack: any[] = [];
   // Check if appLayout is enabled
   if (
-    opts.route.appLayout &&
-    layouts.every((layout) => layout.config?.appTemplate)
+    opts.route.appTemplate &&
+    layouts.every((layout) => layout.appTemplate)
   ) {
     renderStack.push(opts.app.default);
   }
   for (let i = 0; i < layouts.length; i++) {
-    renderStack.push(layouts[i].default);
+    renderStack.push(layouts[i].component);
   }
   renderStack.push(component);
 

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -266,7 +266,7 @@ export async function render<Data>(
   // Check if appLayout is enabled
   if (
     opts.route.appLayout &&
-    layouts.every((layout) => layout.config?.appTemplate !== false)
+    layouts.every((layout) => layout.config?.appTemplate)
   ) {
     renderStack.push(opts.app.default);
   }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -89,14 +89,14 @@ export interface RouteConfig {
   csp?: boolean;
 
   /**
-   * Apply inherited layouts.
-   * Default: `true`
+   * Skip already inherited layouts
+   * Default: `false`
    */
   skipInheritedLayouts?: boolean;
 
   /**
-   * Whether to use the `routes/_app` template if available or not.
-   * Default: `true`
+   * Skip rendering the `routes/_app` template
+   * Default: `false`
    */
   skipAppTemplate?: boolean;
 }
@@ -215,13 +215,13 @@ export type AsyncLayout<T = any, S = Record<string, unknown>> = (
 
 export interface LayoutConfig {
   /**
-   * Apply inherited layouts.
-   * Default: `true`
+   * Skip already inherited layouts
+   * Default: `false`
    */
   skipAppTemplate?: boolean;
   /**
-   * Whether to use the `routes/_app` template if available or not.
-   * Default: `true`
+   * Skip rendering the `routes/_app`.
+   * Default: `false`
    */
   skipInheritedLayouts?: boolean;
 }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -238,7 +238,7 @@ export interface LayoutRoute {
   // deno-lint-ignore no-explicit-any
   handler?: Handler<any, any> | Handlers<any, any>;
   component: LayoutModule["default"];
-  appTemplate: boolean; // TODO: Test this
+  appTemplate: boolean;
   inheritLayouts: boolean;
 }
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -92,13 +92,13 @@ export interface RouteConfig {
    * Apply inherited layouts.
    * Default: `true`
    */
-  inheritLayouts?: boolean;
+  skipInheritedLayouts?: boolean;
 
   /**
    * Whether to use the `routes/_app` template if available or not.
    * Default: `true`
    */
-  appTemplate?: boolean;
+  skipAppTemplate?: boolean;
 }
 
 // deno-lint-ignore no-empty-interface
@@ -218,12 +218,12 @@ export interface LayoutConfig {
    * Apply inherited layouts.
    * Default: `true`
    */
-  appTemplate?: boolean;
+  skipAppTemplate?: boolean;
   /**
    * Whether to use the `routes/_app` template if available or not.
    * Default: `true`
    */
-  inheritLayouts?: boolean;
+  skipInheritedLayouts?: boolean;
 }
 
 export interface LayoutModule {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -89,10 +89,10 @@ export interface RouteConfig {
   csp?: boolean;
 
   /**
-   * Mark this route as the root layout and ignore previously
-   * inherited layouts. Default: `false`
+   * Apply inherited layouts.
+   * Default: `true`
    */
-  rootLayout?: boolean;
+  inheritLayouts?: boolean;
 
   /**
    * Whether to use the `routes/_app` template if available or not.
@@ -173,8 +173,8 @@ export interface Route<Data = any> {
   component?: PageComponent<Data> | AsyncLayout<Data> | AsyncRoute<Data>;
   handler: Handler<Data> | Handlers<Data>;
   csp: boolean;
-  appLayout: boolean;
-  rootLayout: boolean;
+  appTemplate: boolean;
+  inheritLayouts: boolean;
 }
 
 export interface RouterState {
@@ -213,14 +213,33 @@ export type AsyncLayout<T = any, S = Record<string, unknown>> = (
   ctx: LayoutContext<T, S>,
 ) => Promise<ComponentChildren | Response>;
 
+export interface LayoutConfig {
+  /**
+   * Apply inherited layouts.
+   * Default: `true`
+   */
+  appTemplate?: boolean;
+  /**
+   * Whether to use the `routes/_app` template if available or not.
+   * Default: `true`
+   */
+  inheritLayouts?: boolean;
+}
+
 export interface LayoutModule {
+  // deno-lint-ignore no-explicit-any
+  handler?: Handler<any, any> | Handlers<any, any>;
   default: ComponentType<LayoutProps> | AsyncLayout;
-  config?: Pick<RouteConfig, "appTemplate" | "rootLayout">;
+  config?: LayoutConfig;
 }
 
 export interface LayoutRoute {
   baseRoute: BaseRoute;
-  module: LayoutModule;
+  // deno-lint-ignore no-explicit-any
+  handler?: Handler<any, any> | Handlers<any, any>;
+  component: LayoutModule["default"];
+  appTemplate: boolean; // TODO: Test this
+  inheritLayouts: boolean;
 }
 
 // --- UNKNOWN PAGE ---
@@ -267,8 +286,8 @@ export interface UnknownPage {
   component?: PageComponent<UnknownPageProps>;
   handler: UnknownHandler;
   csp: boolean;
-  appLayout: boolean;
-  rootLayout: boolean;
+  appTemplate: boolean;
+  inheritLayouts: boolean;
 }
 
 // --- ERROR PAGE ---
@@ -314,8 +333,8 @@ export interface ErrorPage {
   component?: PageComponent<ErrorPageProps>;
   handler: ErrorHandler;
   csp: boolean;
-  appLayout: boolean;
-  rootLayout: boolean;
+  appTemplate: boolean;
+  inheritLayouts: boolean;
 }
 
 // --- MIDDLEWARES ---

--- a/tests/fixture_layouts/fresh.gen.ts
+++ b/tests/fixture_layouts/fresh.gen.ts
@@ -27,11 +27,13 @@ import * as $21 from "./routes/no_app.tsx";
 import * as $22 from "./routes/other.tsx";
 import * as $23 from "./routes/override/_layout.tsx";
 import * as $24 from "./routes/override/index.tsx";
-import * as $25 from "./routes/override/no_app.tsx";
-import * as $26 from "./routes/override/no_layout.tsx";
-import * as $27 from "./routes/override/no_layout_no_app.tsx";
-import * as $28 from "./routes/skip/sub/_layout.tsx";
-import * as $29 from "./routes/skip/sub/index.tsx";
+import * as $25 from "./routes/override/layout_no_app/_layout.tsx";
+import * as $26 from "./routes/override/layout_no_app/index.tsx";
+import * as $27 from "./routes/override/no_app.tsx";
+import * as $28 from "./routes/override/no_layout.tsx";
+import * as $29 from "./routes/override/no_layout_no_app.tsx";
+import * as $30 from "./routes/skip/sub/_layout.tsx";
+import * as $31 from "./routes/skip/sub/index.tsx";
 
 const manifest = {
   routes: {
@@ -60,11 +62,13 @@ const manifest = {
     "./routes/other.tsx": $22,
     "./routes/override/_layout.tsx": $23,
     "./routes/override/index.tsx": $24,
-    "./routes/override/no_app.tsx": $25,
-    "./routes/override/no_layout.tsx": $26,
-    "./routes/override/no_layout_no_app.tsx": $27,
-    "./routes/skip/sub/_layout.tsx": $28,
-    "./routes/skip/sub/index.tsx": $29,
+    "./routes/override/layout_no_app/_layout.tsx": $25,
+    "./routes/override/layout_no_app/index.tsx": $26,
+    "./routes/override/no_app.tsx": $27,
+    "./routes/override/no_layout.tsx": $28,
+    "./routes/override/no_layout_no_app.tsx": $29,
+    "./routes/skip/sub/_layout.tsx": $30,
+    "./routes/skip/sub/index.tsx": $31,
   },
   islands: {},
   baseUrl: import.meta.url,

--- a/tests/fixture_layouts/routes/no_app.tsx
+++ b/tests/fixture_layouts/routes/no_app.tsx
@@ -1,7 +1,7 @@
 import { RouteConfig } from "$fresh/server.ts";
 
 export const config: RouteConfig = {
-  appTemplate: false,
+  skipAppTemplate: false,
 };
 
 export default function OverridePage() {

--- a/tests/fixture_layouts/routes/override/_layout.tsx
+++ b/tests/fixture_layouts/routes/override/_layout.tsx
@@ -1,7 +1,7 @@
 import { LayoutConfig, LayoutProps } from "$fresh/server.ts";
 
 export const config: LayoutConfig = {
-  inheritLayouts: false,
+  skipInheritedLayouts: false,
 };
 
 export default function OverrideLayout({ Component }: LayoutProps) {

--- a/tests/fixture_layouts/routes/override/_layout.tsx
+++ b/tests/fixture_layouts/routes/override/_layout.tsx
@@ -1,7 +1,7 @@
-import { LayoutProps, RouteConfig } from "$fresh/server.ts";
+import { LayoutConfig, LayoutProps } from "$fresh/server.ts";
 
-export const config: RouteConfig = {
-  rootLayout: true,
+export const config: LayoutConfig = {
+  inheritLayouts: false,
 };
 
 export default function OverrideLayout({ Component }: LayoutProps) {

--- a/tests/fixture_layouts/routes/override/_layout.tsx
+++ b/tests/fixture_layouts/routes/override/_layout.tsx
@@ -1,7 +1,7 @@
 import { LayoutConfig, LayoutProps } from "$fresh/server.ts";
 
 export const config: LayoutConfig = {
-  skipInheritedLayouts: false,
+  skipInheritedLayouts: true,
 };
 
 export default function OverrideLayout({ Component }: LayoutProps) {

--- a/tests/fixture_layouts/routes/override/layout_no_app/_layout.tsx
+++ b/tests/fixture_layouts/routes/override/layout_no_app/_layout.tsx
@@ -1,7 +1,7 @@
 import { LayoutConfig, LayoutProps } from "$fresh/server.ts";
 
 export const config: LayoutConfig = {
-  skipAppTemplate: false,
+  skipAppTemplate: true,
 };
 
 export default function OverrideLayout({ Component }: LayoutProps) {

--- a/tests/fixture_layouts/routes/override/layout_no_app/_layout.tsx
+++ b/tests/fixture_layouts/routes/override/layout_no_app/_layout.tsx
@@ -1,0 +1,13 @@
+import { LayoutConfig, LayoutProps } from "$fresh/server.ts";
+
+export const config: LayoutConfig = {
+  appTemplate: false,
+};
+
+export default function OverrideLayout({ Component }: LayoutProps) {
+  return (
+    <div class="no-app-layout">
+      <Component />
+    </div>
+  );
+}

--- a/tests/fixture_layouts/routes/override/layout_no_app/_layout.tsx
+++ b/tests/fixture_layouts/routes/override/layout_no_app/_layout.tsx
@@ -1,7 +1,7 @@
 import { LayoutConfig, LayoutProps } from "$fresh/server.ts";
 
 export const config: LayoutConfig = {
-  appTemplate: false,
+  skipAppTemplate: false,
 };
 
 export default function OverrideLayout({ Component }: LayoutProps) {

--- a/tests/fixture_layouts/routes/override/layout_no_app/index.tsx
+++ b/tests/fixture_layouts/routes/override/layout_no_app/index.tsx
@@ -1,0 +1,7 @@
+export default function OverridePage() {
+  return (
+    <div class="page">
+      /override/layout_no_app page
+    </div>
+  );
+}

--- a/tests/fixture_layouts/routes/override/no_app.tsx
+++ b/tests/fixture_layouts/routes/override/no_app.tsx
@@ -1,7 +1,7 @@
 import { RouteConfig } from "$fresh/server.ts";
 
 export const config: RouteConfig = {
-  skipAppTemplate: false,
+  skipAppTemplate: true,
 };
 
 export default function OverridePage() {

--- a/tests/fixture_layouts/routes/override/no_app.tsx
+++ b/tests/fixture_layouts/routes/override/no_app.tsx
@@ -1,7 +1,7 @@
 import { RouteConfig } from "$fresh/server.ts";
 
 export const config: RouteConfig = {
-  appTemplate: false,
+  skipAppTemplate: false,
 };
 
 export default function OverridePage() {

--- a/tests/fixture_layouts/routes/override/no_layout.tsx
+++ b/tests/fixture_layouts/routes/override/no_layout.tsx
@@ -1,7 +1,7 @@
-import { RouteConfig } from "$fresh/server.ts";
+import { LayoutConfig } from "$fresh/server.ts";
 
-export const config: RouteConfig = {
-  rootLayout: true,
+export const config: LayoutConfig = {
+  inheritLayouts: false,
 };
 
 export default function OverridePage() {

--- a/tests/fixture_layouts/routes/override/no_layout.tsx
+++ b/tests/fixture_layouts/routes/override/no_layout.tsx
@@ -1,7 +1,7 @@
 import { LayoutConfig } from "$fresh/server.ts";
 
 export const config: LayoutConfig = {
-  skipInheritedLayouts: false,
+  skipInheritedLayouts: true,
 };
 
 export default function OverridePage() {

--- a/tests/fixture_layouts/routes/override/no_layout.tsx
+++ b/tests/fixture_layouts/routes/override/no_layout.tsx
@@ -1,7 +1,7 @@
 import { LayoutConfig } from "$fresh/server.ts";
 
 export const config: LayoutConfig = {
-  inheritLayouts: false,
+  skipInheritedLayouts: false,
 };
 
 export default function OverridePage() {

--- a/tests/fixture_layouts/routes/override/no_layout_no_app.tsx
+++ b/tests/fixture_layouts/routes/override/no_layout_no_app.tsx
@@ -1,8 +1,8 @@
 import { LayoutConfig } from "$fresh/server.ts";
 
 export const config: LayoutConfig = {
-  skipAppTemplate: false,
-  skipInheritedLayouts: false,
+  skipAppTemplate: true,
+  skipInheritedLayouts: true,
 };
 
 export default function OverridePage() {

--- a/tests/fixture_layouts/routes/override/no_layout_no_app.tsx
+++ b/tests/fixture_layouts/routes/override/no_layout_no_app.tsx
@@ -1,8 +1,8 @@
-import { RouteConfig } from "$fresh/server.ts";
+import { LayoutConfig } from "$fresh/server.ts";
 
-export const config: RouteConfig = {
+export const config: LayoutConfig = {
   appTemplate: false,
-  rootLayout: true,
+  inheritLayouts: false,
 };
 
 export default function OverridePage() {

--- a/tests/fixture_layouts/routes/override/no_layout_no_app.tsx
+++ b/tests/fixture_layouts/routes/override/no_layout_no_app.tsx
@@ -1,8 +1,8 @@
 import { LayoutConfig } from "$fresh/server.ts";
 
 export const config: LayoutConfig = {
-  appTemplate: false,
-  inheritLayouts: false,
+  skipAppTemplate: false,
+  skipInheritedLayouts: false,
 };
 
 export default function OverridePage() {

--- a/tests/layouts_test.ts
+++ b/tests/layouts_test.ts
@@ -120,6 +120,17 @@ Deno.test("disable _app layout", async () => {
   );
 });
 
+Deno.test("disable _app in _layout", async () => {
+  await withFresh(
+    "./tests/fixture_layouts/main.ts",
+    async (address) => {
+      const doc = await fetchHtml(`${address}/override/layout_no_app`);
+      assertNotSelector(doc, "body body");
+      assertSelector(doc, "body > .override-layout > .no-app-layout > .page");
+    },
+  );
+});
+
 Deno.test("override layouts", async () => {
   await withFresh(
     "./tests/fixture_layouts/main.ts",
@@ -140,7 +151,7 @@ Deno.test("route overrides layout", async () => {
   );
 });
 
-Deno.test("route overrides layout", async () => {
+Deno.test("route overrides layout and app", async () => {
   await withFresh(
     "./tests/fixture_layouts/main.ts",
     async (address) => {


### PR DESCRIPTION
This addresses some feedback on the naming of the layout config options. Whilst changing that I noticed that we don't have a test for when a layout disables the `_app` template.