### PR TITLE
www: add language switcher to code blocks

### DIFF
--- a/docs/canary/concepts/middleware.md
+++ b/docs/canary/concepts/middleware.md
@@ -17,9 +17,8 @@ special [\_app](/docs/concepts/app-wrapper.md) wrapper and normal
 properties, e.g. `ctx.state.loggedIn = true`, but you can also replace the
 entire object like `ctx.state = { loggedIn = true }`.
 
-```ts
-// routes/_middleware.ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+```ts { "title": "routes/_middleware.ts" }
+import type { MiddlewareHandlerContext } from "$fresh/server.ts";
 
 interface State {
   data: string;
@@ -27,7 +26,7 @@ interface State {
 
 export async function handler(
   req: Request,
-  ctx: MiddlewareHandlerContext<State>,
+  ctx: MiddlewareHandlerContext<State>
 ) {
   ctx.state.data = "myData";
   const resp = await ctx.next();
@@ -36,8 +35,7 @@ export async function handler(
 }
 ```
 
-```ts
-// routes/myHandler.ts
+```ts { "title": "routes/myHandler.ts" }
 export const handler: Handlers<any, { data: string }> = {
   GET(_req, ctx) {
     return new Response(`middleware data is ${ctx.state.data}`);
@@ -52,7 +50,7 @@ specific first).
 
 For example, take a project with the following routes:
 
-```
+```txt { "title": "Project structure" }
 └── routes
     ├── _middleware.ts
     ├── index.ts
@@ -85,9 +83,7 @@ A single middleware file can also define multiple middlewares (all for the same
 route) by exporting an array of handlers instead of a single handler. For
 example:
 
-```ts
-// routes/_middleware.ts
-
+```ts { "title": "routes/_middleware.ts"}
 export const handler = [
   async function middleware1(req, ctx) {
     // do something
@@ -103,8 +99,8 @@ export const handler = [
 It should be noted that `middleware` has access to route parameters. If you're
 running a fictitious `routes/[tenant]/admin/_middleware.ts` like this:
 
-```ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+```ts { "title": "routes/[tenant]/admin/_middleware.ts" }
+import type { MiddlewareHandlerContext } from "$fresh/server.ts";
 
 export async function handler(_req: Request, ctx: MiddlewareHandlerContext) {
   const currentTenant = ctx.params.tenant;
@@ -121,7 +117,7 @@ the value of `acme` in your middleware.
 
 To set the stage for this section, `MiddlewareHandlerContext` looks like this:
 
-```ts
+```ts { "title": "Type definition", "lang_switcher": false}
 export interface MiddlewareHandlerContext<State = Record<string, unknown>> {
   next: () => Promise<Response>;
   state: State;
@@ -136,7 +132,7 @@ export interface MiddlewareHandlerContext<State = Record<string, unknown>> {
 
 and `router.DestinationKind` is defined like this:
 
-```ts
+```ts { "title": "Type definition", "lang_switcher": false}
 export type DestinationKind = "internal" | "static" | "route" | "notFound";
 ```
 
@@ -148,8 +144,8 @@ for a `route`, as opposed to something like `http://localhost:8001/favicon.ico`.
 Initiate a new Fresh project (`deno run -A -r https://fresh.deno.dev/`) and then
 create a `_middleware.ts` file in the `routes` folder like this:
 
-```ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+```ts { "title": "routes/_middleware.ts" }
+import type { MiddlewareHandlerContext } from "$fresh/server.ts";
 
 export async function handler(req: Request, ctx: MiddlewareHandlerContext) {
   console.log(ctx.destination);
@@ -161,7 +157,7 @@ export async function handler(req: Request, ctx: MiddlewareHandlerContext) {
 
 If you start up your server (`deno task start`) you'll see the following:
 
-```
+```sh { "title": "Terminal output"}
 Task start deno run -A --watch=static/,routes/ dev.ts
 Watcher Process started.
 The manifest has been generated for 4 routes and 1 islands.

--- a/docs/canary/concepts/route-groups.md
+++ b/docs/canary/concepts/route-groups.md
@@ -10,7 +10,7 @@ than another route that's in the same URL segment.
 
 Let's illustrate that with an example:
 
-```txt
+```txt { "title": "Intended URL to layout mapping"}
 /about -> layout A
 /career -> layout A
 /archive -> layout B
@@ -20,13 +20,13 @@ Let's illustrate that with an example:
 Without any way to group routes this is a problem because every route segment
 can only have one `_layout` file.
 
-```txt
-/routes
-  /_layout.tsx   <-- applies to all routes here :(
-  /about.tsx
-  /career.tsx
-  /archive.tsx
-  /contact.tsx
+```txt { "title": "Project struture "}
+routes/
+  _layout.tsx   <-- applies to all routes here :(
+  about.tsx
+  career.tsx
+  archive.tsx
+  contact.tsx
 ```
 
 We can solve this problem with route groups. A route group is a folder which has
@@ -34,25 +34,27 @@ a name that is wrapped in braces. For example `(pages)` would be considered a
 route and so would be `(marketing)`. This enables us to group related routes in
 a folder and use a different `_layout` file for each group.
 
-```txt
-/routes
-  /(marketing)
-    /_layout.tsx   <-- only applies to about.tsx and career.tsx
-    /about.tsx
-    /career.tsx
-  /(info)
-    /_layout.tsx   <-- only applies to archive.tsx and contact.tsx
-    /archive.tsx
-    /contact.tsx
+```txt { "title": "Project structure"}
+routes/
+  (marketing)/
+    _layout.tsx   <-- only applies to about.tsx and career.tsx
+    about.tsx
+    career.tsx
+
+  (info)/
+    _layout.tsx   <-- only applies to archive.tsx and contact.tsx
+    archive.tsx
+    contact.tsx
 ```
 
 > ℹ️ Be careful about routes in different groups which match to the same URL.
 > Such scenarios will lead to ambiguity as to which route file should be picked.
 >
-> ```txt
-> /routes
->   /(group-1)
->     /about.tsx  <-- Bad: Both routes map to the same `/about` url
->   /(group-2)
->     /about.tsx  <-- Bad: Both routes map to the same `/about` url
+> ```txt { "title": "Project structure"}
+> routes/
+>   (group-1)/
+>     about.tsx  <-- Bad: Both routes map to the same `/about` url
+>
+>   (group-2)/
+>     about.tsx  <-- Bad: Both routes map to the same `/about` url
 > ```

--- a/docs/canary/concepts/route-groups.md
+++ b/docs/canary/concepts/route-groups.md
@@ -20,7 +20,7 @@ Let's illustrate that with an example:
 Without any way to group routes this is a problem because every route segment
 can only have one `_layout` file.
 
-```txt { "title": "Project struture "}
+```txt { "title": "Project structure "}
 routes/
   _layout.tsx   <-- applies to all routes here :(
   about.tsx

--- a/docs/canary/concepts/route-layout.md
+++ b/docs/canary/concepts/route-layout.md
@@ -7,14 +7,14 @@ An route layout is defined in a `_layout.tsx` file in any sub directory (at any
 level) under the `routes/` folder. It must contain a default export that is a
 regular Preact component. Only one such layout is allowed per sub directory.
 
-```sh
+```txt { "title": "Project structure" }
 routes/
   _app.tsx
   _layout.tsx # will be applied to all routes
-  /sub
+  sub/
     index.tsx
     page.tsx
-  /other
+  other/
     _layout.tsx # will be applied on top of `routes/_layout.tsx`
     page.tsx
 ```
@@ -24,10 +24,8 @@ things. This allows for the introduction of a global container functioning as a
 template which can be conditioned based on state and params. Note that any state
 set by middleware is available via `props.state`.
 
-```tsx
-// routes/sub/_layout.tsx
-
-import { LayoutProps } from "$fresh/server.ts";
+```tsx { "title": "routes/sub/_layout.tsx" }
+import type { LayoutProps } from "$fresh/server.ts";
 
 export default function Layout({ Component, state }: LayoutProps) {
   //do something with state here
@@ -45,10 +43,10 @@ Sometimes you want to opt out of the layout inheritance mechanism for a
 particular route. This can be done via route configuration. Picture a directory
 structure like this:
 
-```sh
+```txt { "title": "Project structure" }
 routes/
   _layout.tsx
-  /sub
+  sub/
     _layout.tsx
     index.tsx
     special.tsx # should not inherit layouts
@@ -57,9 +55,8 @@ routes/
 To make `routes/sub/special.tsx` opt out of rendering layouts we can set
 `rootLayout: true`.
 
-```tsx
-// routes/sub/special.tsx
-import { RouteConfig } from "$fresh/server.ts";
+```tsx { "title": "routes/sub/special.tsx"}
+import type { RouteConfig } from "$fresh/server.ts";
 
 export const config: RouteConfig = {
   rootLayout: true, // Mark this route as the root layout
@@ -77,8 +74,8 @@ Note that you can also mark layouts as root layouts.
 In very rare cases you might want to disable the root `_app` template for a
 particular route. This can be done by setting `appTemplate: false`.
 
-```tsx
-import { RouteConfig } from "$fresh/server.ts";
+```tsx { "title": "routes/my-page.tsx"}
+import type { RouteConfig } from "$fresh/server.ts";
 
 export const config: RouteConfig = {
   appTemplate: false, // Disable the `_app` template

--- a/docs/latest/concepts/app-wrapper.md
+++ b/docs/latest/concepts/app-wrapper.md
@@ -12,10 +12,8 @@ things. This allows for the introduction of a global container functioning as a
 template which can be conditioned based on state and params. Note that any state
 set by middleware is available via `props.state`.
 
-```tsx
-// routes/_app.tsx
-
-import { AppProps } from "$fresh/server.ts";
+```tsx { "title": "routes/_app.tsx" }
+import type { AppProps } from "$fresh/server.ts";
 
 export default function App({ Component, state }: AppProps) {
   //do something with state here

--- a/docs/latest/concepts/data-fetching.md
+++ b/docs/latest/concepts/data-fetching.md
@@ -10,7 +10,7 @@ component through the `data` property on the `props`.
 
 Here is an example:
 
-```tsx
+```tsx { "title": "routes/projects/[id].tsx" }
 interface Project {
   name: string;
   stars: number;

--- a/docs/latest/concepts/deployment.md
+++ b/docs/latest/concepts/deployment.md
@@ -35,7 +35,7 @@ caching **will** cause your project to not function correctly.
 
 Here is an example `Dockerfile` for a Fresh project:
 
-```dockerfile
+```dockerfile { "title": "Dockerfile" }
 FROM denoland/deno:1.35.0
 
 ARG GIT_REVISION
@@ -53,13 +53,13 @@ CMD ["run", "-A", "main.ts"]
 
 To build your Docker image inside of a Git repository:
 
-```sh
+```sh { "title": "Terminal output" }
 $ docker build --build-arg GIT_REVISION=$(git rev-parse HEAD) -t my-fresh-app .
 ```
 
 Then run your Docker container:
 
-```sh
+```sh { "title": "Terminal output" }
 $ docker run -t -i -p 80:8000 my-fresh-app
 ```
 

--- a/docs/latest/concepts/error-pages.md
+++ b/docs/latest/concepts/error-pages.md
@@ -14,8 +14,8 @@ The 404 page can be customized by creating a `_404.tsx` file in the `routes/`
 folder. The file must have a default export that is a regular Preact component.
 A props object of type `UnknownPageProps` is passed in as an argument.
 
-```tsx
-import { UnknownPageProps } from "$fresh/server.ts";
+```tsx { "title": "routes/_404.tsx" }
+import type { UnknownPageProps } from "$fresh/server.ts";
 
 export default function NotFoundPage({ url }: UnknownPageProps) {
   return <p>404 not found: {url.pathname}</p>;
@@ -29,8 +29,8 @@ In some cases, one needs to manually trigger the rendering of the 404 page, for
 example when the route did match, but the requested resource does not exist.
 This can be achieved with `ctx.renderNotFound`.
 
-```tsx
-import { Handlers, PageProps } from "$fresh/server.ts";
+```tsx { "title": "routes/blog/[slug].tsx" }
+import type { Handlers, PageProps } from "$fresh/server.ts";
 
 export const handler: Handlers = {
   async GET(req, ctx) {
@@ -60,8 +60,8 @@ The 500 page can be customized by creating a `_500.tsx` file in the `routes/`
 folder. The file must have a default export that is a regular Preact component.
 A props object of type `ErrorPageProps` is passed in as an argument.
 
-```tsx
-import { ErrorPageProps } from "$fresh/server.ts";
+```tsx { "title": "routes/_500.tsx" }
+import type { ErrorPageProps } from "$fresh/server.ts";
 
 export default function Error500Page({ error }: ErrorPageProps) {
   return <p>500 internal error: {(error as Error).message}</p>;

--- a/docs/latest/concepts/forms.md
+++ b/docs/latest/concepts/forms.md
@@ -18,9 +18,8 @@ or as a `POST` request with `multipart/form-data`.
 This example demonstrates how to handle `multipart/form-data` `<form>`
 submissions:
 
-```tsx
-// routes/subscribe.tsx
-import { Handlers } from "$fresh/server.ts";
+```tsx { "title": "routes/subscribe.tsx" }
+import { type Handlers } from "$fresh/server.ts";
 
 export const handler: Handlers = {
   async GET(req, ctx) {

--- a/docs/latest/concepts/islands.md
+++ b/docs/latest/concepts/islands.md
@@ -11,9 +11,7 @@ Islands are defined by creating a file in the `islands/` folder in a Fresh
 project. The name of this file must be a PascalCase or kebab-case name of the
 island.
 
-```tsx
-// islands/MyIsland.tsx
-
+```tsx { "title": "islands/MyIsland.tsx" }
 import { useSignal } from "@preact/signals";
 
 export default function MyIsland() {
@@ -53,8 +51,7 @@ functions is not supported.
 Islands support passing JSX elements via the `children` property. This allows
 you to pass static content rendered by the server to an island in the browser.
 
-```jsx
-// route/index.tsx
+```tsx { "title": "route/index.tsx" }
 import MyIsland from "../islands/my-island.tsx";
 
 export default function Home() {
@@ -77,8 +74,7 @@ Islands can be nested within other islands as well. In that scenario they act
 like a normal Preact component, but still receive the serialized props if any
 were present.
 
-```jsx
-// route/index.tsx
+```tsx { "title": "route/index.tsx" }
 import MyIsland from "../islands/my-island.tsx";
 import OtherIsland from "../islands/other-island.tsx";
 
@@ -97,8 +93,7 @@ In essence, Fresh allows you to mix static and interactive parts in your app in
 a way that's most optimal for your use app. We'll keep sending only the
 JavaScript that is needed for the islands to the browser.
 
-```jsx
-// route/index.tsx
+```tsx { "title": "route/index.tsx"}
 import MyIsland from "../islands/my-island.tsx";
 import OtherIsland from "../islands/other-island.tsx";
 

--- a/docs/latest/concepts/middleware.md
+++ b/docs/latest/concepts/middleware.md
@@ -15,8 +15,7 @@ be used to pass arbitrary data to downstream (or upstream) handlers. This
 special [\_app](/docs/concepts/app-wrapper.md) wrapper and normal
 [routes](/docs/concepts/routes.md).
 
-```ts
-// routes/_middleware.ts
+```ts { "title": "routes/_middleware.ts" }
 import { MiddlewareHandlerContext } from "$fresh/server.ts";
 
 interface State {
@@ -25,7 +24,7 @@ interface State {
 
 export async function handler(
   req: Request,
-  ctx: MiddlewareHandlerContext<State>,
+  ctx: MiddlewareHandlerContext<State>
 ) {
   ctx.state.data = "myData";
   const resp = await ctx.next();
@@ -34,8 +33,7 @@ export async function handler(
 }
 ```
 
-```ts
-// routes/myHandler.ts
+```ts { "title": "routes/myHandler.ts"}
 export const handler: Handlers<any, { data: string }> = {
   GET(_req, ctx) {
     return new Response(`middleware data is ${ctx.state.data}`);
@@ -50,7 +48,7 @@ specific first).
 
 For example, take a project with the following routes:
 
-```
+```txt { "title": "Project structure" }
 └── routes
     ├── _middleware.ts
     ├── index.ts
@@ -83,9 +81,7 @@ A single middleware file can also define multiple middlewares (all for the same
 route) by exporting an array of handlers instead of a single handler. For
 example:
 
-```ts
-// routes/_middleware.ts
-
+```ts { "title": "routes/_middleware.ts" }
 export const handler = [
   async function middleware1(req, ctx) {
     // do something
@@ -101,8 +97,8 @@ export const handler = [
 It should be noted that `middleware` has access to route parameters. If you're
 running a fictitious `routes/[tenant]/admin/_middleware.ts` like this:
 
-```ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+```ts { "title": "routes/_middleware.ts" }
+import { type MiddlewareHandlerContext } from "$fresh/server.ts";
 
 export async function handler(_req: Request, ctx: MiddlewareHandlerContext) {
   const currentTenant = ctx.params.tenant;
@@ -119,7 +115,7 @@ the value of `acme` in your middleware.
 
 To set the stage for this section, `MiddlewareHandlerContext` looks like this:
 
-```ts
+```ts { "title": "TypeScript", "lang_switcher": false }
 export interface MiddlewareHandlerContext<State = Record<string, unknown>> {
   next: () => Promise<Response>;
   state: State;
@@ -134,7 +130,7 @@ export interface MiddlewareHandlerContext<State = Record<string, unknown>> {
 
 and `router.DestinationKind` is defined like this:
 
-```ts
+```ts { "title": "TypeScript", "lang_switcher": false }
 export type DestinationKind = "internal" | "static" | "route" | "notFound";
 ```
 
@@ -146,8 +142,8 @@ for a `route`, as opposed to something like `http://localhost:8001/favicon.ico`.
 Initiate a new Fresh project (`deno run -A -r https://fresh.deno.dev/`) and then
 create a `_middleware.ts` file in the `routes` folder like this:
 
-```ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+```ts { "title": "routes/_middleware.ts" }
+import { type MiddlewareHandlerContext } from "$fresh/server.ts";
 
 export async function handler(req: Request, ctx: MiddlewareHandlerContext) {
   console.log(ctx.destination);
@@ -159,7 +155,7 @@ export async function handler(req: Request, ctx: MiddlewareHandlerContext) {
 
 If you start up your server (`deno task start`) you'll see the following:
 
-```
+```sh { "title": "Terminal output" }
 Task start deno run -A --watch=static/,routes/ dev.ts
 Watcher Process started.
 The manifest has been generated for 4 routes and 1 islands.
@@ -202,7 +198,7 @@ is only supposed to deal with routes.
 
 If you want to redirect a request from a middleware, you can do so by returning:
 
-```ts
+```ts { "title": "Redirect middleware" }
 export function handler(req: Request): Response {
   return Response.redirect("https://example.com", 307);
 }
@@ -211,7 +207,7 @@ export function handler(req: Request): Response {
 `307` stands for temporary redirect. You can also use `301` for permanent
 redirect. You can also redirect to a relative path by doing:
 
-```ts
+```ts { "title": "Redirect middleware" }
 export function handler(req: Request): Response {
   return new Response("", {
     status: 307,

--- a/docs/latest/concepts/middleware.md
+++ b/docs/latest/concepts/middleware.md
@@ -16,7 +16,7 @@ special [\_app](/docs/concepts/app-wrapper.md) wrapper and normal
 [routes](/docs/concepts/routes.md).
 
 ```ts { "title": "routes/_middleware.ts" }
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import type { MiddlewareHandlerContext } from "$fresh/server.ts";
 
 interface State {
   data: string;

--- a/docs/latest/concepts/plugins.md
+++ b/docs/latest/concepts/plugins.md
@@ -6,9 +6,7 @@ Plugins can dynamically add new functionality to Fresh without exposing
 significant complexity to the user. Users can add plugins by importing and
 initializing them in their `main.ts` file:
 
-```ts
-// main.ts
-
+```ts { "title": "main.ts" }
 import { start } from "$fresh/server.ts";
 import manifest from "./fresh.gen.ts";
 
@@ -43,8 +41,8 @@ A Fresh plugin is just a JavaScript object that conforms to the
 required property of a plugin is its name. Names must only contain the
 characters `a`-`z`, and `_`.
 
-```ts
-import { Plugin } from "$fresh/server.ts";
+```ts { "title": "my-plugin.ts" }
+import type { Plugin } from "$fresh/server.ts";
 
 const plugin: Plugin = {
   name: "my_plugin",

--- a/docs/latest/concepts/routes.md
+++ b/docs/latest/concepts/routes.md
@@ -25,9 +25,7 @@ the handler's `render` function.
 
 Let's look at a basic route that returns a plain text string:
 
-```tsx
-// routes/plain.tsx
-
+```tsx { "title": "routes/plain.tsx" }
 import { HandlerContext, Handlers } from "$fresh/server.ts";
 
 export const handler: Handlers = {
@@ -48,10 +46,8 @@ have a corresponding handler, a 405 HTTP error is returned.
 
 Now, let's render some HTML using the route component:
 
-```tsx
-// routes/html.tsx
-
-import { PageProps } from "$fresh/server.ts";
+```tsx { "title": "routes/html.tsx" }
+import { type PageProps } from "$fresh/server.ts";
 
 export default function Page(props: PageProps) {
   return <div>You are on the page '{props.url.href}'.</div>;
@@ -71,10 +67,8 @@ should work.
 In the below example, a custom handler is used to add a custom header to the
 response after rendering the page component.
 
-```tsx
-// routes/html.tsx
-
-import { HandlerContext, Handlers, PageProps } from "$fresh/server.ts";
+```tsx { "title": "routes/html.tsx" }
+import type { HandlerContext, Handlers, PageProps } from "$fresh/server.ts";
 
 export const handler: Handlers = {
   async GET(_req: Request, ctx: HandlerContext) {
@@ -96,7 +90,7 @@ test these in isolation, but can become a bit cumbersome to maintain. They
 require some additional indirection of declaring an interface for the component
 `Data` when you're passing it around through `ctx.render()`.
 
-```tsx
+```tsx { "title": "routes/my-page.tsx" }
 interface Data {
   foo: number;
 }
@@ -117,7 +111,7 @@ When a route has both a component and a `GET` handler, they are typically very
 closely coupled. With async route components you can merge the two together and
 avoid having to create the `Data` interface boilerplate.
 
-```tsx
+```tsx { "title": "routes/my-page.tsx" }
 // Async route component
 export default async function MyPage(req: Request, ctx: RouteContext) {
   const value = await loadFooValue();
@@ -130,7 +124,7 @@ can think of async route components inlining the `GET` handler into the
 component function. Note, that you can still add additional HTTP handlers in the
 same file like before.
 
-```tsx
+```tsx { "title": "routes/my-page.tsx" }
 export const handler: Handlers = {
   async POST(req) {
     // ... do something here
@@ -148,7 +142,7 @@ export default async function MyPage(req: Request, ctx: RouteContext) {
 Quite often a route handler needs to render a 404 page or bail out of rendering
 in another manner. This can be done by returning a `Response` object.
 
-```tsx
+```tsx { "title": "routes/my-page.tsx" }
 // Async route component
 export default async function MyPage(req: Request, ctx: RouteContext) {
   const value = await loadFooValue();

--- a/docs/latest/concepts/routes.md
+++ b/docs/latest/concepts/routes.md
@@ -26,7 +26,7 @@ the handler's `render` function.
 Let's look at a basic route that returns a plain text string:
 
 ```tsx { "title": "routes/plain.tsx" }
-import { HandlerContext, Handlers } from "$fresh/server.ts";
+import type { HandlerContext, Handlers } from "$fresh/server.ts";
 
 export const handler: Handlers = {
   GET(_req: Request, _ctx: HandlerContext) {

--- a/docs/latest/concepts/routing.md
+++ b/docs/latest/concepts/routing.md
@@ -41,10 +41,8 @@ Advanced use-cases can require that a more complex pattern be used for matching.
 A custom [URL pattern][urlpattern] can be specified in the route configuration.
 This pattern will be used instead of the file path based pattern:
 
-```ts
-// routes/x.ts
-
-import { RouteConfig } from "$fresh/server.ts";
+```ts { "title": "routes/x.ts" }
+import type { RouteConfig } from "$fresh/server.ts";
 
 export const config: RouteConfig = {
   routeOverride: "/x/:module@:version/:path*",

--- a/docs/latest/concepts/server-configuration.md
+++ b/docs/latest/concepts/server-configuration.md
@@ -7,7 +7,7 @@ In this page we discuss how the server can be configured during startup.
 
 The signature of the primary method looks like this:
 
-```ts
+```ts { "title": "Type Signature", "lang_switcher": false }
 export async function start(routes: Manifest, opts: StartOptions = {});
 ```
 
@@ -16,13 +16,13 @@ export async function start(routes: Manifest, opts: StartOptions = {});
 `Manifest` comes from `fresh.gen.ts`, so nothing to do there. `opts` is where
 things get interesting. `StartOptions` looks like this:
 
-```
+```ts { "title": "Type Definition", "lang_switcher": false }
 export type StartOptions = ServeInit & FreshOptions;
 ```
 
 The good stuff is really in...
 
-```ts
+```ts { "title": "Type Definition", "lang_switcher": false }
 export interface FreshOptions {
   render?: RenderFunction;
   plugins?: Plugin[];
@@ -33,10 +33,10 @@ export interface FreshOptions {
 
 And for brevity here are the remaining two types:
 
-```ts
+```ts { "title": "Type Definitions", "lang_switcher": false }
 export type RenderFunction = (
   ctx: RenderContext,
-  render: InnerRenderFunction,
+  render: InnerRenderFunction
 ) => void | Promise<void>;
 
 export interface RouterOptions {
@@ -52,7 +52,7 @@ export interface RouterOptions {
 See the [docs](/docs/concepts/plugins) on this topic for more detail. But for
 completion, you can do something like this to load plugins:
 
-```ts
+```ts { "title": "main.ts" }
 await start(manifest, { plugins: [twindPlugin(twindConfig)] });
 ```
 
@@ -61,7 +61,7 @@ await start(manifest, { plugins: [twindPlugin(twindConfig)] });
 This allows you to specify the location where your site's static assets are
 stored. Here's an example:
 
-```ts
+```ts { "title": "main.ts" }
 await start(manifest, { staticDir: "./custom_static" });
 ```
 
@@ -81,6 +81,6 @@ By default Fresh uses URLs like `https://www.example.com/about`. If you'd like,
 you can configure this to `https://www.example.com/about/` by using the
 `trailingSlash` setting.
 
-```ts
+```ts { "title": "main.ts" }
 await start(manifest, { router: { trailingSlash: true } });
 ```

--- a/docs/latest/concepts/static-files.md
+++ b/docs/latest/concepts/static-files.md
@@ -47,5 +47,5 @@ deems it safe to do so. You can always opt out of this behaviour per tag, by
 adding the `data-fresh-disable-lock` attribute.
 
 ```jsx
-<img src="/user.png" />
+<img src="/user.png" />;
 ```

--- a/docs/latest/concepts/static-files.md
+++ b/docs/latest/concepts/static-files.md
@@ -47,5 +47,5 @@ deems it safe to do so. You can always opt out of this behaviour per tag, by
 adding the `data-fresh-disable-lock` attribute.
 
 ```jsx
-<img src="/user.png" />;
+<img src="/user.png" />
 ```

--- a/docs/latest/concepts/static-files.md
+++ b/docs/latest/concepts/static-files.md
@@ -29,7 +29,7 @@ version of this path that contains a build ID for cache busting. When the asset
 is requested at this "locked" path, it will be served with a cache lifetime of
 one year.
 
-```jsx
+```tsx { "title": "routes/my-page.tsx"}
 import { asset } from "$fresh/runtime.ts";
 
 export default function Page() {

--- a/docs/latest/concepts/updating.md
+++ b/docs/latest/concepts/updating.md
@@ -54,7 +54,7 @@ file in the root of your projects directory. Dependency versions are encoded
 into the URLs in this file. For example, here is how to update a project from
 Fresh 1.0.2 to 1.1.3, and update Preact to the latest version:
 
-```diff
+```diff { "title": "deno.json" }
   {
     "imports": {
 -     "$fresh/": "https://deno.land/x/fresh@1.0.2/",
@@ -97,7 +97,7 @@ the recommended way to use JSX in Fresh projects. Instead, starting with version
 1.1.0, Fresh projects should use the automatic JSX transform that requires no
 JSX pragma or preact import.
 
-```diff
+```diff { "title": "routes/index.jsx" }
 - /** @jsx h */
 - import { h } from "preact";
 

--- a/docs/latest/examples/changing-the-src-dir.md
+++ b/docs/latest/examples/changing-the-src-dir.md
@@ -6,7 +6,7 @@ description: |
 When you initialize a project with `deno run -A -r https://fresh.deno.dev`,
 you'll end up with a project like the following:
 
-```
+```txt { "title": "Project structure" }
 .
 ├── README.md
 ├── components
@@ -40,7 +40,7 @@ your choosing), then you'll need to do the following things:
 
 Here's what the diff of `deno.json` looks like:
 
-```diff
+```diff { "title": "deno.json" }
  {
    "lock": false,
    "tasks": {
@@ -53,7 +53,7 @@ Here's what the diff of `deno.json` looks like:
 
 The resulting file structure looks like this:
 
-```
+```txt { "title": "Project structure" }
 .
 ├── README.md
 ├── deno.json

--- a/docs/latest/examples/creating-a-crud-api.md
+++ b/docs/latest/examples/creating-a-crud-api.md
@@ -19,7 +19,7 @@ In this example we'll be creating a small API that uses
 Our project structure will look like this (in addition to the rest of the Fresh
 code from a new project):
 
-```
+```txt { "title": "Project structure" }
 ├── routes
 │   └── api
 │       └── users
@@ -34,15 +34,12 @@ full files are available at the bottom for reference.
 
 `POST` (create) is used to create a resource.
 
-```tsx
-// routes/api/users/index.ts
+```tsx { "title": "routes/api/users/index.ts" }
 export const handler: Handlers<User | null> = {
   async POST(req, _ctx) {
-    const user = await req.json() as User;
+    const user = (await req.json()) as User;
     const userKey = ["user", user.id];
-    const ok = await kv.atomic()
-      .set(userKey, user)
-      .commit();
+    const ok = await kv.atomic().set(userKey, user).commit();
     if (!ok) throw new Error("Something went wrong.");
     return new Response(JSON.stringify(user));
   },
@@ -53,7 +50,7 @@ Test this with Postman (or your favorite client) with a URL like
 `http://localhost:8000/api/users` and a method of `POST`. Make sure to have a
 payload like:
 
-```json
+```json { "title": "Server Response" }
 {
   "id": "2",
   "name": "TestUserName"
@@ -62,7 +59,7 @@ payload like:
 
 You should receive the same thing back:
 
-```json
+```json { "title": "Server Response" }
 { "id": "2", "name": "TestUserName" }
 ```
 
@@ -71,8 +68,7 @@ You should receive the same thing back:
 `GET` (read) is used to retrieve a resource and is by far the most common HTTP
 method. You can use `GET` to fetch database content, markdown, or static files.
 
-```tsx
-// routes/api/users/[id].ts
+```tsx { "title": "routes/api/users/[id].ts" }
 export const handler: Handlers<User | null> = {
   async GET(_req, ctx) {
     const id = ctx.params.id;
@@ -86,7 +82,7 @@ export const handler: Handlers<User | null> = {
 Let's practice retrieving our user! A `GET` request to
 `http://localhost:8000/api/users/2` should return:
 
-```json
+```json { "title": "Server Response" }
 { "id": "2", "name": "TestUserName" }
 ```
 
@@ -102,19 +98,15 @@ The short version of it: `PUT` requires the entire object to be submitted, while
 
 An example of an update endpoint using `PUT`:
 
-```tsx
-// routes/api/users/[id].ts
+```tsx { "title": "routes/api/users/[id].ts" }
 export const handler: Handlers<User | null> = {
   async PUT(req, ctx) {
     const id = ctx.params.id;
-    const user = await req.json() as User;
+    const user = (await req.json()) as User;
     const userKey = ["user", id];
     const userRes = await kv.get(userKey);
     if (!userRes.value) return new Response(`no user with id ${id} found`);
-    const ok = await kv.atomic()
-      .check(userRes)
-      .set(userKey, user)
-      .commit();
+    const ok = await kv.atomic().check(userRes).set(userKey, user).commit();
     if (!ok) throw new Error("Something went wrong.");
     return new Response(JSON.stringify(user));
   },
@@ -124,7 +116,7 @@ export const handler: Handlers<User | null> = {
 Time to change their name. We'll now `PUT` a request to
 `http://localhost:8000/api/users/2` like:
 
-```json
+```json { "title": "Server Request" }
 {
   "id": "2",
   "name": "New Name"
@@ -133,14 +125,14 @@ Time to change their name. We'll now `PUT` a request to
 
 We should receive:
 
-```json
+```json { "title": "Server Response" }
 { "id": "2", "name": "New Name" }
 ```
 
 If, on the other hand, we chose to implement this as a `PATCH` operation, the
 request would just involve the changed property like this:
 
-```json
+```json { "title": "Server Request" }
 {
   "name": "New Name"
 }
@@ -152,18 +144,14 @@ No need to send in the id in this case.
 
 `DELETE` (delete) is used to delete a resource.
 
-```tsx
-// routes/api/users/[id].ts
+```tsx { "title": "routes/api/users/[id].ts" }
 export const handler: Handlers<User | null> = {
   async DELETE(_req, ctx) {
     const id = ctx.params.id;
     const userKey = ["user", id];
     const userRes = await kv.get(userKey);
     if (!userRes.value) return new Response(`no user with id ${id} found`);
-    const ok = await kv.atomic()
-      .check(userRes)
-      .delete(userKey)
-      .commit();
+    const ok = await kv.atomic().check(userRes).delete(userKey).commit();
     if (!ok) throw new Error("Something went wrong.");
     return new Response(`user ${id} deleted`);
   },
@@ -173,7 +161,7 @@ export const handler: Handlers<User | null> = {
 Try sending `DELETE` to `http://localhost:8000/api/users/2` without a body.
 We'll get back:
 
-```
+```txt { "title": "Server response" }
 user 2 deleted
 ```
 
@@ -188,8 +176,8 @@ request checks for complex CORS use cases. See more on the
 <details>
 <summary>[id].ts</summary>
 
-```ts
-import { Handlers } from "$fresh/server.ts";
+```ts { "title": "routes/api/users/[id].ts" }
+import type { Handlers } from "$fresh/server.ts";
 
 type User = {
   id: string;
@@ -210,23 +198,17 @@ export const handler: Handlers<User | null> = {
     const userKey = ["user", id];
     const userRes = await kv.get(userKey);
     if (!userRes.value) return new Response(`no user with id ${id} found`);
-    const ok = await kv.atomic()
-      .check(userRes)
-      .delete(userKey)
-      .commit();
+    const ok = await kv.atomic().check(userRes).delete(userKey).commit();
     if (!ok) throw new Error("Something went wrong.");
     return new Response(`user ${id} deleted`);
   },
   async PUT(req, ctx) {
     const id = ctx.params.id;
-    const user = await req.json() as User;
+    const user = (await req.json()) as User;
     const userKey = ["user", id];
     const userRes = await kv.get(userKey);
     if (!userRes.value) return new Response(`no user with id ${id} found`);
-    const ok = await kv.atomic()
-      .check(userRes)
-      .set(userKey, user)
-      .commit();
+    const ok = await kv.atomic().check(userRes).set(userKey, user).commit();
     if (!ok) throw new Error("Something went wrong.");
     return new Response(JSON.stringify(user));
   },
@@ -238,8 +220,8 @@ export const handler: Handlers<User | null> = {
 <details>
 <summary>index.ts</summary>
 
-```ts
-import { Handlers } from "$fresh/server.ts";
+```ts { "title": "routes/api/users/index.ts" }
+import type { Handlers } from "$fresh/server.ts";
 
 type User = {
   id: string;
@@ -257,11 +239,9 @@ export const handler: Handlers<User | null> = {
     return new Response(JSON.stringify(users));
   },
   async POST(req, _ctx) {
-    const user = await req.json() as User;
+    const user = (await req.json()) as User;
     const userKey = ["user", user.id];
-    const ok = await kv.atomic()
-      .set(userKey, user)
-      .commit();
+    const ok = await kv.atomic().set(userKey, user).commit();
     if (!ok) throw new Error("Something went wrong.");
     return new Response(JSON.stringify(user));
   },

--- a/docs/latest/examples/dealing-with-cors.md
+++ b/docs/latest/examples/dealing-with-cors.md
@@ -15,13 +15,10 @@ As per the above link, "simple" requests involve `GET`, `HEAD`, or `POST`
 requests. You can CORS enable all the routes affected by some `middleware` by
 doing the following:
 
-```ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+```ts { "title": "routes/_middleware.ts" }
+import type { MiddlewareHandlerContext } from "$fresh/server.ts";
 
-export async function handler(
-  req: Request,
-  ctx: MiddlewareHandlerContext,
-) {
+export async function handler(req: Request, ctx: MiddlewareHandlerContext) {
   const origin = req.headers.get("Origin") || "*";
   const resp = await ctx.next();
   const headers = resp.headers;
@@ -30,11 +27,11 @@ export async function handler(
   headers.set("Access-Control-Allow-Credentials", "true");
   headers.set(
     "Access-Control-Allow-Headers",
-    "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With",
+    "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With"
   );
   headers.set(
     "Access-Control-Allow-Methods",
-    "POST, OPTIONS, GET, PUT, DELETE",
+    "POST, OPTIONS, GET, PUT, DELETE"
   );
 
   return resp;
@@ -47,13 +44,10 @@ What about for one of the other HTTP methods? Then you'll need to be able to
 deal with "preflight requests". Let's imagine you're trying to support a
 `DELETE` route. Then you'd need to do something like this:
 
-```ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+```ts { "title": "routes/_middleware.ts" }
+import type { MiddlewareHandlerContext } from "$fresh/server.ts";
 
-export async function handler(
-  _req: Request,
-  ctx: MiddlewareHandlerContext,
-) {
+export async function handler(_req: Request, ctx: MiddlewareHandlerContext) {
   if (_req.method == "OPTIONS") {
     const resp = new Response(null, {
       status: 204,
@@ -61,10 +55,7 @@ export async function handler(
     const origin = _req.headers.get("Origin") || "*";
     const headers = resp.headers;
     headers.set("Access-Control-Allow-Origin", origin);
-    headers.set(
-      "Access-Control-Allow-Methods",
-      "DELETE",
-    );
+    headers.set("Access-Control-Allow-Methods", "DELETE");
     return resp;
   }
   const origin = _req.headers.get("Origin") || "*";
@@ -75,11 +66,11 @@ export async function handler(
   headers.set("Access-Control-Allow-Credentials", "true");
   headers.set(
     "Access-Control-Allow-Headers",
-    "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With",
+    "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With"
   );
   headers.set(
     "Access-Control-Allow-Methods",
-    "POST, OPTIONS, GET, PUT, DELETE",
+    "POST, OPTIONS, GET, PUT, DELETE"
   );
 
   return resp;

--- a/docs/latest/examples/handling-complex-routes.md
+++ b/docs/latest/examples/handling-complex-routes.md
@@ -16,8 +16,8 @@ Here you can define named groups, wildcards, regex groups, and other bits.
 Let's look at the example from the routing page more closely. We'll flesh out
 the handler so that we end up with something like the following:
 
-```ts
-import { HandlerContext, RouteConfig } from "$fresh/server.ts";
+```ts { "title": "routes/my-page.tsx" }
+import type { HandlerContext, RouteConfig } from "$fresh/server.ts";
 
 export const handler = {
   GET(_req: Request, { params }: HandlerContext) {
@@ -35,7 +35,7 @@ Now if we hit the server with a request like
 `http://localhost:8000/x/bestModule@1.33.7/asdf`, then logging the params will
 show the following:
 
-```
+```sh { "title": "Terminal output" }
 {
   module: "bestModule",
   version: "1.33.7",
@@ -47,8 +47,8 @@ show the following:
 
 Let's look at something a bit more complex:
 
-```ts
-import { HandlerContext, RouteConfig } from "$fresh/server.ts";
+```ts { "title": "routes/my-page.ts" }
+import type { HandlerContext, RouteConfig } from "$fresh/server.ts";
 
 export const handler = {
   GET(_req: Request, { params }: HandlerContext) {

--- a/docs/latest/examples/init-the-server.md
+++ b/docs/latest/examples/init-the-server.md
@@ -7,7 +7,7 @@ Let's pretend you've just initialized a new Fresh project. You want to do some
 complicated setup that runs once, before the server is started. This is,
 fortunately, quite easy. Here's how:
 
-```diff
+```diff { "title": "main.ts" }
  import { start } from "$fresh/server.ts";
  import manifest from "./fresh.gen.ts";
 +import { Context } from "./routes/_middleware.ts";
@@ -18,7 +18,7 @@ fortunately, quite easy. Here's how:
 
 So your full `main.ts` should look like this:
 
-```ts
+```ts { "title": "main.ts" }
 /// <reference no-default-lib="true" />
 /// <reference lib="dom" />
 /// <reference lib="dom.iterable" />
@@ -37,8 +37,8 @@ await start(manifest);
 
 But what's going on in this new `_middleware.ts` we've created?
 
-```ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+```ts { "title": "main.ts"}
+import type { MiddlewareHandlerContext } from "$fresh/server.ts";
 
 export interface State {
   context: Context;
@@ -66,7 +66,7 @@ export class Context {
 
 export async function handler(
   req: Request,
-  ctx: MiddlewareHandlerContext<State>,
+  ctx: MiddlewareHandlerContext<State>
 ) {
   ctx.state.context = Context.instance();
   const resp = await ctx.next();

--- a/docs/latest/examples/modifying-the-head.md
+++ b/docs/latest/examples/modifying-the-head.md
@@ -13,8 +13,7 @@ the web page. Some uses include:
 - Linking to resources like stylesheets using `<link>`
 - Including third-party JavaScript code using `<script>`
 
-```tsx
-// routes/index.tsx
+```tsx { "title": "routes/index.tsx" }
 import { Head } from "$fresh/runtime.ts";
 import Counter from "../islands/Counter.tsx";
 

--- a/docs/latest/examples/rendering-markdown.md
+++ b/docs/latest/examples/rendering-markdown.md
@@ -14,9 +14,8 @@ The following file uses
 [dynamic routing](https://fresh.deno.dev/docs/getting-started/dynamic-routes) to
 handle the three cases. It's assumed this file is called `[slug].tsx`:
 
-```ts
-// routes/[slug].tsx
-import { Handlers, PageProps } from "$fresh/server.ts";
+```tsx { "title": "routes/[slug].tsx" }
+import type { Handlers, PageProps } from "$fresh/server.ts";
 import { extract } from "$std/front_matter/yaml.ts";
 import { CSS, render } from "$gfm";
 import { Head } from "$fresh/runtime.ts";
@@ -31,7 +30,7 @@ export const handler: Handlers<Page> = {
     let rawMarkdown = "";
     if (ctx.params.slug === "remote") {
       const resp = await fetch(
-        `https://raw.githubusercontent.com/denoland/fresh/main/docs/introduction/index.md`,
+        `https://raw.githubusercontent.com/denoland/fresh/main/docs/introduction/index.md`
       );
       if (resp.status !== 200) {
         return ctx.render(undefined);
@@ -81,7 +80,7 @@ export default function MarkdownPage({ data }: PageProps<Page | null>) {
 
 The contents of the `text.md` file are the following:
 
-```md
+```md { "title": "text.md" }
 ---
 description: testFromText
 ---
@@ -93,8 +92,12 @@ description: testFromText
 
 You'll also need to import the `Github Flavored Markdown` module:
 
-```json
-"$gfm": "https://deno.land/x/gfm@0.2.3/mod.ts",
+```diff { "title": "deno.json" }
+  {
+    "imports": {
++     "$gfm": "https://deno.land/x/gfm@0.2.3/mod.ts"
+    }
+  }
 ```
 
 Andy has a helpful [post](https://deno.com/blog/build-a-blog-with-fresh) on the

--- a/docs/latest/examples/setting-the-language.md
+++ b/docs/latest/examples/setting-the-language.md
@@ -6,7 +6,7 @@ description: |
 When you initialize a project with `deno run -A -r https://fresh.deno.dev`,
 you'll end up with a `main.ts` like the following:
 
-```ts
+```ts { "title": "main.ts" }
 /// <reference no-default-lib="true" />
 /// <reference lib="dom" />
 /// <reference lib="dom.iterable" />
@@ -26,7 +26,7 @@ This is a great start if your site is in English, but let's say you want to
 change the language, as per the `<html lang=asdf>` tag. Then you'll need to do
 something like this:
 
-```ts
+```ts { "title": "main.ts" }
 /// <reference no-default-lib="true" />
 /// <reference lib="dom" />
 /// <reference lib="dom.iterable" />

--- a/docs/latest/examples/sharing-state-between-islands.md
+++ b/docs/latest/examples/sharing-state-between-islands.md
@@ -11,8 +11,7 @@ All of this content is lifted from this great
 
 Imagine we have `Counter.tsx` like this:
 
-```ts
-// islands/Counter.tsx
+```tsx { "title": "islands/Counter.tsx" }
 import { useSignal } from "@preact/signals";
 import { Button } from "../components/Button.tsx";
 
@@ -37,7 +36,7 @@ export default function Counter(props: CounterProps) {
 Note how `useSignal` is within the `Counter` component. Then if we instantiate
 some counters like this...
 
-```ts
+```jsx { "title": "Usage", "transform": false }
 <Counter start={3} />
 <Counter start={4} />
 ```
@@ -49,9 +48,8 @@ here, yet.
 
 But we can switch things up by looking at a `SynchronizedSlider.tsx` like this:
 
-```ts
-// islands/SynchronizedSlider.tsx
-import { Signal } from "@preact/signals";
+```tsx { "title": "islands/SynchronizedSlider.tsx" }
+import type { Signal } from "@preact/signals";
 
 interface SliderProps {
   slider: Signal<number>;
@@ -67,7 +65,7 @@ export default function SynchronizedSlider(props: SliderProps) {
       min={1}
       max={100}
       value={props.slider.value}
-      onInput={(e) => props.slider.value = Number(e.currentTarget.value)}
+      onInput={(e) => (props.slider.value = Number(e.currentTarget.value))}
     />
   );
 }
@@ -75,8 +73,7 @@ export default function SynchronizedSlider(props: SliderProps) {
 
 Now if we were to do the following...
 
-```ts
-// routes/index.tsx
+```tsx { "title": "routes/index.tsx" }
 export default function Home() {
   const sliderSignal = useSignal(50);
   return (
@@ -96,15 +93,13 @@ they would all use the same value.
 We can also create a `signal` in a utility file and export it for consumption
 across multiple places.
 
-```ts
-// utils/cart.ts
+```ts { "title": "utils/cart.ts" }
 import { signal } from "@preact/signals";
 
 export const cart = signal<string[]>([]);
 ```
 
-```ts
-// islands/AddToCart.tsx
+```tsx { "title": "islands/AddToCart.tsx" }
 import { Button } from "../components/Button.tsx";
 import { cart } from "../utils/cart.ts";
 
@@ -116,18 +111,17 @@ interface AddToCartProps {
 export default function AddToCart(props: AddToCartProps) {
   return (
     <Button
-      onClick={() => cart.value = [...cart.value, props.product]}
+      onClick={() => (cart.value = [...cart.value, props.product])}
       class="w-full"
     >
-      Add{cart.value.includes(props.product) ? " another" : ""}{" "}
-      "{props.product}" to cart
+      Add{cart.value.includes(props.product) ? " another" : ""} "{props.product}"
+      to cart
     </Button>
   );
 }
 ```
 
-```ts
-// islands/Cart.tsx
+```tsx { "title": "islands/Cart.tsx" }
 import { Button } from "../components/Button.tsx";
 import { cart } from "../utils/cart.ts";
 import * as icons from "../components/Icons.tsx";
@@ -135,25 +129,23 @@ import * as icons from "../components/Icons.tsx";
 // This island is used to display the cart contents and remove items from it.
 export default function Cart() {
   return (
-    <h1 class="text-xl flex items-center justify-center">
-      Cart
-    </h1>
+    <>
+      <h1 class="text-xl flex items-center justify-center">Cart</h1>
 
-    <ul class="w-full bg-gray-50 mt-2 p-2 rounded min-h-[6.5rem]">
-      {cart.value.length === 0 && (
-        <li class="text-center my-4">
-          <div class="text-gray-400">
-            <icons.Cart class="w-8 h-8 inline-block" />
-            <div>
-              Your cart is empty.
+      <ul class="w-full bg-gray-50 mt-2 p-2 rounded min-h-[6.5rem]">
+        {cart.value.length === 0 && (
+          <li class="text-center my-4">
+            <div class="text-gray-400">
+              <icons.Cart class="w-8 h-8 inline-block" />
+              <div>Your cart is empty.</div>
             </div>
-          </div>
-        </li>
-      )}
-      {cart.value.map((product, index) => (
-        <CartItem product={product} index={index} />
-      ))}
-    </ul>
+          </li>
+        )}
+        {cart.value.map((product, index) => (
+          <CartItem product={product} index={index} />
+        ))}
+      </ul>
+    </>
   );
 }
 
@@ -172,9 +164,7 @@ function CartItem(props: CartItemProps) {
   return (
     <li class="flex items-center justify-between gap-1">
       <icons.Lemon class="text-gray-500" />
-      <div class="flex-1">
-        {props.product}
-      </div>
+      <div class="flex-1">{props.product}</div>
       <Button onClick={remove} aria-label="Remove" class="border-none">
         <icons.X class="inline-block w-4 h-4" />
       </Button>
@@ -185,7 +175,7 @@ function CartItem(props: CartItemProps) {
 
 Now we can add the islands to our site by doing the following:
 
-```ts
+```jsx { "title": "Usage", "transform": false }
 <AddToCart product="Lemon" />
 <AddToCart product="Lime" />
 <Cart />

--- a/docs/latest/examples/using-csp.md
+++ b/docs/latest/examples/using-csp.md
@@ -25,7 +25,7 @@ Fresh's CSP implementation supports the following
 <details>
 <summary>directives</summary>
 
-```ts
+```ts { "title": "CSP configuration reference" }
 export interface ContentSecurityPolicyDirectives {
   // Fetch directives
   /**
@@ -145,8 +145,7 @@ applied to any of the directives.
 
 We'll start off by having an example stylesheet defined like this:
 
-```css
-/* static/example.css */
+```css { "title": "static/example.css" }
 h1 {
   font-size: 25px;
   font-weight: normal;
@@ -161,9 +160,8 @@ To kick things off, we'll create the following control route which doesn't do
 anything with CSP. We include a stylesheet to confirm that our sheet correctly
 styles the response.
 
-```tsx
-// routes/noCSP.tsx
-import { RouteContext } from "$fresh/server.ts";
+```tsx { "title": "routes/noCSP.tsx" }
+import type { RouteContext } from "$fresh/server.ts";
 
 export default function Home(req: Request, ctx: RouteContext) {
   return (
@@ -177,7 +175,7 @@ export default function Home(req: Request, ctx: RouteContext) {
 
 We can hit `http://localhost:8000/noCSP` and we should see the following:
 
-```
+```txt { "title": "Server response" }
 This page doesn't use CSP at all. Styles will be applied.
 ```
 
@@ -188,8 +186,7 @@ closely, we're using the wrong URL! This will cause the browser to reject the
 stylesheet, due to the header that Fresh produces. We get a `(blocked:csp)`
 status when the browser tries to request this resource.
 
-```tsx
-// routes/incorrectCSP.tsx
+```tsx { "title": "routes/incorrectCSP.tsx" }
 import { RouteConfig, RouteContext } from "$fresh/server.ts";
 import { useCSP } from "$fresh/runtime.ts";
 
@@ -198,9 +195,7 @@ export default function Home(req: Request, ctx: RouteContext) {
     if (!csp.directives.styleSrc) {
       csp.directives.styleSrc = [];
     }
-    csp.directives.styleSrc.push(
-      "http://www.example.com",
-    );
+    csp.directives.styleSrc.push("http://www.example.com");
   });
   return (
     <>
@@ -217,7 +212,7 @@ export const config: RouteConfig = {
 
 We can hit `http://localhost:8000/incorrectCSP` and we should see the following:
 
-```
+```txt { "title": "Server response" }
 This page violates our configured CSP. Styles won't be applied.
 ```
 
@@ -226,9 +221,8 @@ This page violates our configured CSP. Styles won't be applied.
 Let's fix our simple mistake and use the correct URL. Everything is working
 correctly here.
 
-```tsx
-// routes/correctCSP.tsx
-import { RouteConfig, RouteContext } from "$fresh/server.ts";
+```tsx { "title": "routes/correctCSP.tsx" }
+import type { RouteConfig, RouteContext } from "$fresh/server.ts";
 import { useCSP } from "$fresh/runtime.ts";
 
 export default function Home(req: Request, ctx: RouteContext) {
@@ -236,9 +230,7 @@ export default function Home(req: Request, ctx: RouteContext) {
     if (!csp.directives.styleSrc) {
       csp.directives.styleSrc = [];
     }
-    csp.directives.styleSrc.push(
-      "http://localhost:8000/example.css",
-    );
+    csp.directives.styleSrc.push("http://localhost:8000/example.css");
   });
   return (
     <>
@@ -255,7 +247,7 @@ export const config: RouteConfig = {
 
 We can hit `http://localhost:8000/correctCSP` and we should see the following:
 
-```
+```txt { "title": "Server response" }
 This page adheres to our configured CSP. Styles will be applied.
 ```
 
@@ -263,8 +255,7 @@ This page adheres to our configured CSP. Styles will be applied.
 
 What happens if we forget to use a `RouteConfig` in our route?
 
-```tsx
-// routes/cspNoRouteConfig.tsx
+```tsx { "title": "routes/cspNoRouteConfig.tsx" }
 import { RouteContext } from "$fresh/server.ts";
 import { useCSP } from "$fresh/runtime.ts";
 
@@ -273,16 +264,14 @@ export default function Home(req: Request, ctx: RouteContext) {
     if (!csp.directives.styleSrc) {
       csp.directives.styleSrc = [];
     }
-    csp.directives.styleSrc.push(
-      "http://www.example.com",
-    );
+    csp.directives.styleSrc.push("http://www.example.com");
   });
   return (
     <>
       <h1>
         This page violates our configured CSP. But we don't have a{" "}
-        <code>RouteConfig</code>{" "}
-        enabled, so Fresh doesn't know to use the CSP. Styles will be applied.
+        <code>RouteConfig</code> enabled, so Fresh doesn't know to use the CSP.
+        Styles will be applied.
       </h1>
       <link rel="stylesheet" type="text/css" href="example.css" />
     </>
@@ -293,7 +282,7 @@ export default function Home(req: Request, ctx: RouteContext) {
 We can hit `http://localhost:8000/cspNoRouteConfig` and we should see the
 following:
 
-```
+```txt { "title": "Server response" }
 This page violates our configured CSP. But we don't have a RouteConfig enabled, so Fresh doesn't know to use the CSP. Styles will be applied.
 ```
 
@@ -305,8 +294,7 @@ should be able to receive `POST` requests. If the `reportOnly` flag is enabled,
 then the browser will ignore the CSP headers and log any issues to the
 `reportUri` destination.
 
-```tsx
-// routes/incorrectCSPwithReport.tsx
+```tsx { "title": "routes/incorrectCSPwithReport.tsx" }
 import { RouteConfig, RouteContext } from "$fresh/server.ts";
 import { useCSP } from "$fresh/runtime.ts";
 
@@ -317,9 +305,7 @@ export default function Home(req: Request, ctx: RouteContext) {
       csp.directives.styleSrc = [];
     }
     csp.directives.reportUri = "http://localhost:8000/reportHandler";
-    csp.directives.styleSrc.push(
-      "http://www.example.com",
-    );
+    csp.directives.styleSrc.push("http://www.example.com");
   });
   return (
     <>
@@ -337,8 +323,7 @@ export const config: RouteConfig = {
 };
 ```
 
-```ts
-// routes/reportHandler.ts
+```ts { "title": "routes/reportHandler.ts" }
 import { HandlerContext } from "$fresh/server.ts";
 
 export const handler = {
@@ -357,14 +342,14 @@ export const handler = {
 We can hit `http://localhost:8000/incorrectCSPwithReport` and we should see the
 following:
 
-```
+```txt { "title": "Server response" }
 This page violates our configured CSP. But we're using "reportOnly". Styles will be applied.
 ```
 
 We can then check our server and we'll see that `csp-reports.txt` has an entry
 like this:
 
-```json
+```json { "title": "csp-reports.txt" }
 {
   "csp-report": {
     "document-uri": "http://localhost:8000/incorrectCSPwithReport",

--- a/docs/latest/examples/using-csp.md
+++ b/docs/latest/examples/using-csp.md
@@ -187,7 +187,7 @@ stylesheet, due to the header that Fresh produces. We get a `(blocked:csp)`
 status when the browser tries to request this resource.
 
 ```tsx { "title": "routes/incorrectCSP.tsx" }
-import { RouteConfig, RouteContext } from "$fresh/server.ts";
+import type { RouteConfig, RouteContext } from "$fresh/server.ts";
 import { useCSP } from "$fresh/runtime.ts";
 
 export default function Home(req: Request, ctx: RouteContext) {
@@ -256,7 +256,7 @@ This page adheres to our configured CSP. Styles will be applied.
 What happens if we forget to use a `RouteConfig` in our route?
 
 ```tsx { "title": "routes/cspNoRouteConfig.tsx" }
-import { RouteContext } from "$fresh/server.ts";
+import type { RouteContext } from "$fresh/server.ts";
 import { useCSP } from "$fresh/runtime.ts";
 
 export default function Home(req: Request, ctx: RouteContext) {
@@ -295,7 +295,7 @@ then the browser will ignore the CSP headers and log any issues to the
 `reportUri` destination.
 
 ```tsx { "title": "routes/incorrectCSPwithReport.tsx" }
-import { RouteConfig, RouteContext } from "$fresh/server.ts";
+import type { RouteConfig, RouteContext } from "$fresh/server.ts";
 import { useCSP } from "$fresh/runtime.ts";
 
 export default function Home(req: Request, ctx: RouteContext) {
@@ -324,7 +324,7 @@ export const config: RouteConfig = {
 ```
 
 ```ts { "title": "routes/reportHandler.ts" }
-import { HandlerContext } from "$fresh/server.ts";
+import type { HandlerContext } from "$fresh/server.ts";
 
 export const handler = {
   async POST(req: Request, _ctx: HandlerContext) {

--- a/docs/latest/examples/using-deno-kv-oauth.md
+++ b/docs/latest/examples/using-deno-kv-oauth.md
@@ -22,8 +22,7 @@ available.
 2. Create your pre-configured OAuth client instance. For reusability the
    instance is stored in `utils/oauth2_client.ts`.
 
-   ```ts
-   // utils/oauth2_client.ts
+   ```ts { "title": "utils/oauth2_client.ts" }
    import { createGitHubOAuth2Client } from "https://deno.land/x/deno_kv_oauth@v0.2.4/mod.ts";
 
    export const oauth2Client = createGitHubOAuth2Client();
@@ -35,8 +34,7 @@ available.
    Please ensure that the `callback` handler matches the authorization callback
    URL in the configured OAuth application.
 
-   ```ts
-   // routes/signin.ts
+   ```ts { "title": "routes/signin.ts" }
    import { Handlers } from "$fresh/server.ts";
    import { signIn } from "https://deno.land/x/deno_kv_oauth@v0.2.4/mod.ts";
    import { oauth2Client } from "../utils/oauth2_client.ts";
@@ -48,7 +46,7 @@ available.
    };
    ```
 
-   ```ts
+   ```ts { "title": "routes/signout.ts" }
    // routes/signout.ts
    import { Handlers } from "$fresh/server.ts";
    import { signOut } from "https://deno.land/x/deno_kv_oauth@v0.2.4/mod.ts";
@@ -60,8 +58,7 @@ available.
    };
    ```
 
-   ```ts
-   // routes/callback.ts
+   ```ts { "title": "routes/callback.ts" }
    import { Handlers } from "$fresh/server.ts";
    import { handleCallback } from "https://deno.land/x/deno_kv_oauth@v0.2.4/mod.ts";
    import { oauth2Client } from "../utils/oauth2_client.ts";
@@ -77,8 +74,7 @@ available.
 
 4. Use Deno KV OAuth's helper functions where needed.
 
-   ```tsx
-   // routes/index.tsx
+   ```tsx { "title": "routes/index.tsx" }
    import { Handlers, PageProps } from "$fresh/server.ts";
    import {
      getSessionAccessToken,
@@ -129,7 +125,7 @@ available.
 
 5. Start your project with the necessary environment variables.
 
-   ```sh
+   ```sh { "title": "Terminal" }
    GITHUB_CLIENT_ID=xxx GITHUB_CLIENT_SECRET=xxx deno task start
    ```
 

--- a/docs/latest/examples/using-deno-kv-oauth.md
+++ b/docs/latest/examples/using-deno-kv-oauth.md
@@ -35,7 +35,7 @@ available.
    URL in the configured OAuth application.
 
    ```ts { "title": "routes/signin.ts" }
-   import { Handlers } from "$fresh/server.ts";
+   import type { Handlers } from "$fresh/server.ts";
    import { signIn } from "https://deno.land/x/deno_kv_oauth@v0.2.4/mod.ts";
    import { oauth2Client } from "../utils/oauth2_client.ts";
 
@@ -48,7 +48,7 @@ available.
 
    ```ts { "title": "routes/signout.ts" }
    // routes/signout.ts
-   import { Handlers } from "$fresh/server.ts";
+   import type { Handlers } from "$fresh/server.ts";
    import { signOut } from "https://deno.land/x/deno_kv_oauth@v0.2.4/mod.ts";
 
    export const handler: Handlers = {
@@ -59,7 +59,7 @@ available.
    ```
 
    ```ts { "title": "routes/callback.ts" }
-   import { Handlers } from "$fresh/server.ts";
+   import type { Handlers } from "$fresh/server.ts";
    import { handleCallback } from "https://deno.land/x/deno_kv_oauth@v0.2.4/mod.ts";
    import { oauth2Client } from "../utils/oauth2_client.ts";
 
@@ -75,7 +75,7 @@ available.
 4. Use Deno KV OAuth's helper functions where needed.
 
    ```tsx { "title": "routes/index.tsx" }
-   import { Handlers, PageProps } from "$fresh/server.ts";
+   import type { Handlers, PageProps } from "$fresh/server.ts";
    import {
      getSessionAccessToken,
      getSessionId,

--- a/docs/latest/examples/using-fresh-canary-version.md
+++ b/docs/latest/examples/using-fresh-canary-version.md
@@ -16,7 +16,7 @@ How can you modify your project to no longer use the current release, but
 instead this one particular commit? Just make the following changes to your
 `deno.json`:
 
-```diff
+```diff { "title": "deno.json" }
      "update": "deno run -A -r https://fresh.deno.dev/update ."
    },
    "imports": {
@@ -34,7 +34,7 @@ worry, you can use the same approach to reference any branch in a fork as well.
 Here's an example of referencing a feature in a forked repository that hasn't
 been merged yet (at the time of writing this):
 
-```diff
+```diff { "title": "deno.json" }
      "update": "deno run -A -r https://fresh.deno.dev/update ."
    },
    "imports": {
@@ -55,13 +55,13 @@ create a test project based on your local changes.
 
 Instead of doing it like this:
 
-```sh
+```sh { "title": "Terminal" }
 deno run -A -r https://fresh.deno.dev/
 ```
 
 do it like this:
 
-```sh
+```sh { "title": "Terminal" }
 deno run -A -r path/to/fresh/init.ts
 ```
 
@@ -73,6 +73,6 @@ Of course there's no reason why you have to check out the Fresh source. You can
 create a project from the latest commit by combining the techniques on this page
 like this:
 
-```sh
+```sh { "title": "Terminal" }
 deno run -A -r https://raw.githubusercontent.com/denoland/fresh/main/init.ts
 ```

--- a/docs/latest/examples/using-twind-v1.md
+++ b/docs/latest/examples/using-twind-v1.md
@@ -6,7 +6,7 @@ description: |
 When you initialize a project with `deno run -A -r https://fresh.deno.dev`,
 you'll end up with a `main.ts` like the following:
 
-```ts
+```ts { "title": "main.ts" }
 /// <reference no-default-lib="true" />
 /// <reference lib="dom" />
 /// <reference lib="dom.iterable" />
@@ -26,7 +26,7 @@ The template generates a Twind v0 project by default. If you want to use Twind
 v1 you can follow this guide. First of all, change the import path to use the
 `twindv1` plugin:
 
-```ts
+```ts { "title": "main.ts" }
 /// <reference no-default-lib="true" />
 /// <reference lib="dom" />
 /// <reference lib="dom.iterable" />
@@ -45,8 +45,8 @@ await start(manifest, { plugins: [twindPlugin(twindConfig)] });
 The twind config object has changed significantly in v1, so we must also go
 change `twind.config.ts`. A good base looks like this:
 
-```ts
-import { defineConfig, Preset } from "https://esm.sh/@twind/core@1.1.3";
+```ts { "title": "twind.config.ts" }
+import { defineConfig, type Preset } from "https://esm.sh/@twind/core@1.1.3";
 import presetTailwind from "https://esm.sh/@twind/preset-tailwind@1.1.4";
 import presetAutoprefix from "https://esm.sh/@twind/preset-autoprefix@1.0.7";
 

--- a/docs/latest/examples/writing-tests.md
+++ b/docs/latest/examples/writing-tests.md
@@ -9,10 +9,8 @@ through
 
 ## 1. Create your routes
 
-```tsx
-// routes/index.tsx
-
-import { Handlers } from "$fresh/server.ts";
+```tsx { "title": "routes/index.tsx" }
+import type { Handlers } from "$fresh/server.ts";
 
 export const handler: Handlers = {
   async POST(req) {
@@ -28,32 +26,20 @@ export const handler: Handlers = {
 };
 
 export default function HomePage() {
-  return (
-    <div>
-      Hello Deno!
-    </div>
-  );
+  return <div>Hello Deno!</div>;
 }
 ```
 
-```tsx
-// routes/foo.tsx
-
+```tsx { "title": "routes/foo.tsx" }
 export default function FooPage() {
-  return (
-    <div>
-      Hello Foo!
-    </div>
-  );
+  return <div>Hello Foo!</div>;
 }
 ```
 
 ## 2. Write your tests
 
-```ts
-// tests/main_test.ts
-
-import { createHandler, ServeHandlerInfo } from "$fresh/server.ts";
+```ts { "title": "tests/main_test.ts" }
+import { createHandler, type ServeHandlerInfo } from "$fresh/server.ts";
 import manifest from "../fresh.gen.ts";
 import { assert, assertEquals } from "$std/testing/asserts.ts";
 
@@ -81,10 +67,7 @@ Deno.test("HTTP assert test.", async (t) => {
   });
 
   await t.step("#3 GET /foo", async () => {
-    const resp = await handler(
-      new Request("http://127.0.0.1/foo"),
-      CONN_INFO,
-    );
+    const resp = await handler(new Request("http://127.0.0.1/foo"), CONN_INFO);
     const text = await resp.text();
     assert(text.includes("<div>Hello Foo!</div>"));
   });
@@ -93,7 +76,7 @@ Deno.test("HTTP assert test.", async (t) => {
 
 ## 3. Run the tests
 
-```sh
+```sh { "title": "Terminal output" }
 $ deno test --allow-read --allow-env --allow-net
 running 1 test from ./tests/main_test.ts
 HTTP assert test. ...

--- a/docs/latest/getting-started/adding-interactivity.md
+++ b/docs/latest/getting-started/adding-interactivity.md
@@ -1,7 +1,7 @@
 ---
 description: |
   Add JavaScript based interactivity to your project without sacrificing user
-  experience, by using Fresh's powerful islands system. 
+  experience, by using Fresh's powerful islands system.
 ---
 
 Up to now none of the pages in the demo project have contained any client side
@@ -28,9 +28,7 @@ component. For example a counter component would be defined in the file
 
 Here is an example of an island component that counts down to a specific time.
 
-```tsx
-// islands/Countdown.tsx
-
+```tsx { "title": "islands/Countdown.tsx" }
 import { useSignal } from "@preact/signals";
 import { useEffect } from "preact/hooks";
 
@@ -55,7 +53,7 @@ export default function Countdown(props: { target: string }) {
   }, [props.target]);
 
   const secondsLeft = Math.floor(
-    (target.getTime() - now.value.getTime()) / 1000,
+    (target.getTime() - now.value.getTime()) / 1000
   );
 
   // If the target date has passed, we stop counting down.
@@ -73,9 +71,7 @@ To include this in a page component, one can just use the component normally.
 Fresh will take care of automatically mounting the island component on the
 client with the correct props:
 
-```tsx
-// routes/countdown.tsx
-
+```tsx { "title": "routes/countdown.tsx" }
 import Countdown from "../islands/Countdown.tsx";
 
 export default function Page() {

--- a/docs/latest/getting-started/create-a-project.md
+++ b/docs/latest/getting-started/create-a-project.md
@@ -9,7 +9,7 @@ will scaffold out a new project with some example files to get you started.
 
 To create a new project, run:
 
-```
+```sh
 deno run -A -r https://fresh.deno.dev
 cd fresh-project
 deno task start

--- a/docs/latest/getting-started/create-a-route.md
+++ b/docs/latest/getting-started/create-a-route.md
@@ -1,7 +1,7 @@
 ---
 description: |
   Create a new route to a Fresh project by creating a new file in the `routes/`
-  folder. 
+  folder.
 ---
 
 After getting the project running locally, the next step is to add a new route
@@ -34,9 +34,7 @@ This is done with JSX.
 > [Preact][preact], a lighter weight virtual dom library that works similar to
 > React.
 
-```tsx
-// routes/about.tsx
-
+```tsx { "title": "routes/about.tsx", "lines": true, "highlight": [2,3], "ts_switch": true }
 export default function AboutPage() {
   return (
     <main>

--- a/docs/latest/getting-started/custom-handlers.md
+++ b/docs/latest/getting-started/custom-handlers.md
@@ -27,9 +27,7 @@ the HTTP method it handles.
 Here is an example of a custom `GET` handler that renders the page component and
 then adds a custom header to the response before returning it:
 
-```tsx
-// routes/about.tsx
-
+```tsx { "title": "routes/about.tsx"}
 import { Handlers } from "$fresh/server.ts";
 
 export const handler: Handlers = {
@@ -54,9 +52,7 @@ Note that handlers do not need to call `ctx.render()`. This feature can be used
 to create API routes. Here is an API route that returns a random UUID as a JSON
 response:
 
-```ts
-// routes/api/random-uuid.ts
-
+```ts { "title": "routes/api/random-uuid.ts" }
 import { Handlers } from "$fresh/server.ts";
 
 export const handler: Handlers = {

--- a/docs/latest/getting-started/custom-handlers.md
+++ b/docs/latest/getting-started/custom-handlers.md
@@ -28,7 +28,7 @@ Here is an example of a custom `GET` handler that renders the page component and
 then adds a custom header to the response before returning it:
 
 ```tsx { "title": "routes/about.tsx"}
-import { Handlers } from "$fresh/server.ts";
+import type { Handlers } from "$fresh/server.ts";
 
 export const handler: Handlers = {
   async GET(_req, ctx) {
@@ -53,7 +53,7 @@ to create API routes. Here is an API route that returns a random UUID as a JSON
 response:
 
 ```ts { "title": "routes/api/random-uuid.ts" }
-import { Handlers } from "$fresh/server.ts";
+import type { Handlers } from "$fresh/server.ts";
 
 export const handler: Handlers = {
   GET(_req) {

--- a/docs/latest/getting-started/dynamic-routes.md
+++ b/docs/latest/getting-started/dynamic-routes.md
@@ -24,10 +24,8 @@ render a page. The module must once again expose a component as a default
 export. This time the component will receive the matched path segment properties
 as arguments in its `props` object though.
 
-```tsx
-// routes/greet/[name].tsx
-
-import { PageProps } from "$fresh/server.ts";
+```tsx { "title": "routes/greet/[name].tsx", "lang_switcher": true }
+import type { PageProps } from "$fresh/server.ts";
 
 export default function GreetPage(props: PageProps) {
   const { name } = props.params;

--- a/docs/latest/getting-started/fetching-data.md
+++ b/docs/latest/getting-started/fetching-data.md
@@ -17,9 +17,7 @@ The second `ctx` parameter is used to get the route parameters.
 Here is an example of a route that fetches user data from the GitHub API and
 renders it in a page component.
 
-```tsx
-// routes/github/[username].tsx
-
+```tsx { "title": "routes/github/[username].tsx" }
 import { RouteContext } from "$fresh/server.ts";
 
 interface GitHubResponse {
@@ -30,14 +28,14 @@ interface GitHubResponse {
 
 export default async function Page(_req: Request, ctx: RouteContext) {
   const resp = await fetch(
-    `https://api.github.com/users/${ctx.params.username}`,
+    `https://api.github.com/users/${ctx.params.username}`
   );
 
   if (!resp.ok) {
     return <h1>An Error occurred</h1>;
   }
 
-  const { login, name, avatar_url } = await resp.json() as GitHubResponse;
+  const { login, name, avatar_url } = (await resp.json()) as GitHubResponse;
 
   return (
     <div>

--- a/docs/latest/getting-started/fetching-data.md
+++ b/docs/latest/getting-started/fetching-data.md
@@ -18,7 +18,7 @@ Here is an example of a route that fetches user data from the GitHub API and
 renders it in a page component.
 
 ```tsx { "title": "routes/github/[username].tsx" }
-import { RouteContext } from "$fresh/server.ts";
+import type { RouteContext } from "$fresh/server.ts";
 
 interface GitHubResponse {
   login: string;

--- a/docs/latest/getting-started/form-submissions.md
+++ b/docs/latest/getting-started/form-submissions.md
@@ -29,9 +29,7 @@ any necessary processing on the form data, and then pass data to the
 Here is an example implementing a search form that filters an array of names
 server side:
 
-```tsx
-// routes/search.tsx
-
+```tsx { "title": "routes/search.tsx" }
 import { Handlers, PageProps } from "$fresh/server.ts";
 
 const NAMES = ["Alice", "Bob", "Charlie", "Dave", "Eve", "Frank"];
@@ -59,7 +57,9 @@ export default function Page({ data }: PageProps<Data>) {
         <button type="submit">Search</button>
       </form>
       <ul>
-        {results.map((name) => <li key={name}>{name}</li>)}
+        {results.map((name) => (
+          <li key={name}>{name}</li>
+        ))}
       </ul>
     </div>
   );

--- a/docs/latest/getting-started/form-submissions.md
+++ b/docs/latest/getting-started/form-submissions.md
@@ -30,7 +30,7 @@ Here is an example implementing a search form that filters an array of names
 server side:
 
 ```tsx { "title": "routes/search.tsx" }
-import { Handlers, PageProps } from "$fresh/server.ts";
+import type { Handlers, PageProps } from "$fresh/server.ts";
 
 const NAMES = ["Alice", "Bob", "Charlie", "Dave", "Eve", "Frank"];
 

--- a/docs/latest/getting-started/running-locally.md
+++ b/docs/latest/getting-started/running-locally.md
@@ -8,7 +8,7 @@ The next step after scaffolding out a new project, is to actually start it. To
 do this you can just `deno task start`. Environment variables will be
 automatically read from `.env`.
 
-```
+```sh { "title": "Terminal" }
 $ deno task start
 Watcher Process started.
  🍋 Fresh ready
@@ -38,19 +38,19 @@ you add a new route.
 If you want to change the port or host, modify the options bag of the `start()`
 call in `main.ts` to include an explicit port number:
 
-```js
+```ts { "title": "main.ts" }
 await start(manifest, { port: 3000 });
 ```
 
 You can also change the port by setting the `PORT` environment variable:
 
-```
+```sh { "title": "Terminal" }
 $ PORT=3000 deno task start
 ```
 
 Combining all of this we get the following `deno run` command:
 
-```
+```sh { "title": "Terminal"}
 $ deno run --allow-net --allow-read --allow-env --allow-run --watch=static/,routes/ main.ts
 Watcher Process started.
  🍋 Fresh ready

--- a/plugins/markdown.ts
+++ b/plugins/markdown.ts
@@ -1,0 +1,1 @@
+export * from "./markdown/mod.ts";

--- a/plugins/markdown/mod.ts
+++ b/plugins/markdown/mod.ts
@@ -1,0 +1,33 @@
+import * as Marked from "https://esm.sh/marked@7.0.2";
+
+class DefaultRenderer extends Marked.Renderer {
+  heading(
+    text: string,
+    level: 1 | 2 | 3 | 4 | 5 | 6,
+    raw: string,
+    slugger: Marked.Slugger,
+  ): string {
+    const slug = slugger.slug(raw);
+    return `<h${level} id="${slug}"><a class="anchor" aria-hidden="true" tabindex="-1" href="#${slug}">#</a>${text}</h${level}>`;
+  }
+}
+
+export interface MarkdownOptions {
+  inline?: boolean;
+  disableHtmlSanitization?: boolean;
+  renderer?: Marked.Renderer;
+}
+export function renderMarkdown(input: string, opts: MarkdownOptions = {}) {
+  const markedOpts: Marked.MarkedOptions = {
+    gfm: true,
+    renderer: opts.renderer ?? new DefaultRenderer(),
+  };
+
+  const html = opts.inline
+    ? Marked.parseInline(input, markedOpts)
+    : Marked.parse(input, markedOpts);
+
+  if (opts.disableHtmlSanitization) {
+    return html;
+  }
+}

--- a/www/deno.json
+++ b/www/deno.json
@@ -14,8 +14,7 @@
     "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.2.3",
     "$std/": "https://deno.land/std@0.193.0/",
     "$ga4": "https://raw.githubusercontent.com/denoland/ga4/main/mod.ts",
-    "$marked-mangle": "https://esm.sh/marked-mangle@1.0.1",
-    "$marked-smartypants": "https://esm.sh/marked-smartypants@1.0.1"
+    "$marked-mangle": "https://esm.sh/marked-mangle@1.0.1"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/www/fresh.gen.ts
+++ b/www/fresh.gen.ts
@@ -4,15 +4,16 @@
 
 import * as $0 from "./routes/_404.tsx";
 import * as $1 from "./routes/_500.tsx";
-import * as $2 from "./routes/_middleware.ts";
-import * as $3 from "./routes/components.tsx";
-import * as $4 from "./routes/docs/[...slug].tsx";
-import * as $5 from "./routes/docs/index.tsx";
-import * as $6 from "./routes/gfm.css.ts";
-import * as $7 from "./routes/index.tsx";
-import * as $8 from "./routes/raw.ts";
-import * as $9 from "./routes/showcase.tsx";
-import * as $10 from "./routes/update.tsx";
+import * as $2 from "./routes/_app.tsx";
+import * as $3 from "./routes/_middleware.ts";
+import * as $4 from "./routes/components.tsx";
+import * as $5 from "./routes/docs/[...slug].tsx";
+import * as $6 from "./routes/docs/index.tsx";
+import * as $7 from "./routes/gfm.css.ts";
+import * as $8 from "./routes/index.tsx";
+import * as $9 from "./routes/raw.ts";
+import * as $10 from "./routes/showcase.tsx";
+import * as $11 from "./routes/update.tsx";
 import * as $$0 from "./islands/ComponentGallery.tsx";
 import * as $$1 from "./islands/CopyArea.tsx";
 import * as $$2 from "./islands/Counter.tsx";
@@ -24,15 +25,16 @@ const manifest = {
   routes: {
     "./routes/_404.tsx": $0,
     "./routes/_500.tsx": $1,
-    "./routes/_middleware.ts": $2,
-    "./routes/components.tsx": $3,
-    "./routes/docs/[...slug].tsx": $4,
-    "./routes/docs/index.tsx": $5,
-    "./routes/gfm.css.ts": $6,
-    "./routes/index.tsx": $7,
-    "./routes/raw.ts": $8,
-    "./routes/showcase.tsx": $9,
-    "./routes/update.tsx": $10,
+    "./routes/_app.tsx": $2,
+    "./routes/_middleware.ts": $3,
+    "./routes/components.tsx": $4,
+    "./routes/docs/[...slug].tsx": $5,
+    "./routes/docs/index.tsx": $6,
+    "./routes/gfm.css.ts": $7,
+    "./routes/index.tsx": $8,
+    "./routes/raw.ts": $9,
+    "./routes/showcase.tsx": $10,
+    "./routes/update.tsx": $11,
   },
   islands: {
     "./islands/ComponentGallery.tsx": $$0,

--- a/www/routes/_app.tsx
+++ b/www/routes/_app.tsx
@@ -1,0 +1,59 @@
+import { AppProps } from "$fresh/server.ts";
+
+export default function App({ Component }: AppProps) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      </head>
+      <body data-code-lang="ts">
+        <Component />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            var savedValue = "ts";
+            try {
+              var lsValue = localStorage.getItem("fresh-code-lang");
+              if (lsValue !== null) {
+                savedValue = lsValue;
+              }
+            } catch (err) {
+              // ignore
+            }
+
+            document.body.setAttribute("data-code-lang", savedValue);
+
+            var dropdowns = document.querySelectorAll(".fenced-code-dropdown");
+
+            dropdowns.forEach(function (element) {
+              element.value = savedValue;
+            
+              element.addEventListener("input", function (event) {
+                var node = event.target;
+                var beforeTop = node.getBoundingClientRect().top;
+
+                document.body.setAttribute("data-code-lang", node.value);
+                dropdowns.forEach(function (element) {
+                  element.value = node.value;
+                });
+
+                // Prevent clicked select element from jumping around
+                var afterTop = node.getBoundingClientRect().top;
+                var delta = afterTop - beforeTop;
+                window.scrollTo(window.scrollX, window.scrollY + delta);
+
+                try {
+                  localStorage.setItem("fresh-code-lang", node.value);
+                } catch (err) {
+                  // ignore
+                }
+              });
+            });
+          `,
+          }}
+        />
+      </body>
+    </html>
+  );
+}

--- a/www/routes/docs/[...slug].tsx
+++ b/www/routes/docs/[...slug].tsx
@@ -10,13 +10,8 @@ import {
   TABLE_OF_CONTENTS,
   TableOfContentsEntry,
 } from "../../data/docs.ts";
-import { frontMatter, gfm } from "../../utils/markdown.ts";
+import { frontMatter, renderMarkdown } from "../../utils/markdown.ts";
 import toc from "../../../docs/toc.ts";
-import { mangle } from "$marked-mangle";
-import { markedSmartypants } from "$marked-smartypants";
-
-gfm.Marked.marked.use(mangle());
-gfm.Marked.marked.use(markedSmartypants());
 
 interface Data {
   page: Page;
@@ -249,7 +244,8 @@ function DesktopSidebar(props: { path: string; page: Page }) {
 }
 
 function Content(props: { page: Page }) {
-  const html = gfm.render(props.page.markdown);
+  const html = renderMarkdown(props.page.markdown);
+
   return (
     <main class="py-6 overflow-hidden md:mr-4 lg:mr-32">
       <h1 class="text(4xl gray-900) tracking-tight font-extrabold mt-6 md:mt-0">

--- a/www/routes/gfm.css.ts
+++ b/www/routes/gfm.css.ts
@@ -3,8 +3,20 @@ import { gfm } from "../utils/markdown.ts";
 
 // TODO(lucacasonato): hash the file and use the hash as the filename, and serve
 // with high-cacheability headers.
+function css(template: TemplateStringsArray, ...params: string[]) {
+  let out = "";
 
-const CSS = `${gfm.CSS}
+  for (let i = 0; i < template.length; i++) {
+    out += template[i];
+    if (i < params.length) {
+      out += String(params[i]);
+    }
+  }
+
+  return out;
+}
+
+const CSS = css`${gfm.CSS}
 
 ol.nested {
 	counter-reset: item;
@@ -38,6 +50,53 @@ ol.nested li:before {
 
 .toggle:checked + .toggled {
 	display: block;
+}
+
+.fenced-code {
+  margin-bottom: 1rem;
+}
+.fenced-code pre {
+  margin-bottom: 0;
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+}
+.fenced-code-header {
+  border-top-left-radius: .5rem;
+  border-top-right-radius: .5rem;
+  padding: 0.5rem;
+  background: #eaeef1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.fenced-code-title {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  font-size: .8125rem;
+  line-height: 1;
+}
+.fenced-code-dropdown {
+  background: none;
+  font-size: .875rem;
+  cursor: pointer;
+}
+.fenced-code.with-switcher pre {
+  display: none;
+}
+.fenced-code.with-switcher .fenced-code-title {
+  display: none;
+}
+[data-code-lang="ts"] .fenced-code pre.lang-ts,
+[data-code-lang="ts"] .fenced-code pre.lang-tsx,
+[data-code-lang="ts"] .fenced-code-title.lang-ts,
+[data-code-lang="ts"] .fenced-code-title.lang-tsx {
+  display: block;
+}
+[data-code-lang="js"] .fenced-code pre.lang-js,
+[data-code-lang="js"] .fenced-code pre.lang-jsx,
+[data-code-lang="js"] .fenced-code-title.lang-js,
+[data-code-lang="js"] .fenced-code-title.lang-jsx {
+  display: block;
 }
 `;
 

--- a/www/utils/markdown.ts
+++ b/www/utils/markdown.ts
@@ -129,8 +129,8 @@ class DefaultRenderer extends Marked.Renderer {
             .replace(/\s+;$/gm, ";")
             .replace(/\s+,/gm, ",")
             // Update import specifiers
-            .replace(/\.tsx";$/gm, '.jsx";')
-            .replace(/\.ts";$/gm, '.js";')
+            .replace(/["']([\w/_.-]+)\.tsx["'];$/gm, '"$1.jsx";')
+            .replace(/["']([\w/_.-]+)\.ts["'];$/gm, '"$1.js";')
             // Trim multiline whitespace
             .replace(/^(\s*\n){2,}/gm, "\n");
         }

--- a/www/utils/markdown.ts
+++ b/www/utils/markdown.ts
@@ -16,16 +16,6 @@ import { markedSmartypants } from "$marked-smartypants";
 Marked.marked.use(mangle());
 Marked.marked.use(markedSmartypants());
 
-const LOGOS: Record<string, string> = {
-  js: "/js-logo.svg",
-  jsx: "/js-logo.svg",
-  ts: "/ts-logo.svg",
-  tsx: "/ts-logo.svg",
-};
-function getLogo(lang: string) {
-  return LOGOS[lang] ?? "";
-}
-
 function replaceExtName(file: string, newExt: string) {
   const idx = file.lastIndexOf(".");
   if (idx > -1) {
@@ -86,13 +76,11 @@ class DefaultRenderer extends Marked.Renderer {
     const snippets: {
       lang: string;
       code: string;
-      logo: string;
       title: string;
     }[] = [{
       title,
       lang,
       code,
-      logo: getLogo(lang),
     }];
 
     if (!("lang_switcher" in meta) && (lang === "ts" || lang === "tsx")) {
@@ -140,7 +128,6 @@ class DefaultRenderer extends Marked.Renderer {
 
         snippets.push({
           title: actualTitle,
-          logo: getLogo(actualLang),
           lang: actualLang,
           code: transformedCode,
         });

--- a/www/utils/markdown.ts
+++ b/www/utils/markdown.ts
@@ -3,5 +3,200 @@ import "https://esm.sh/prismjs@1.29.0/components/prism-jsx.js?no-check";
 import "https://esm.sh/prismjs@1.29.0/components/prism-typescript.js?no-check";
 import "https://esm.sh/prismjs@1.29.0/components/prism-tsx.js?no-check";
 import "https://esm.sh/prismjs@1.29.0/components/prism-diff.js?no-check";
+import Prism from "https://esm.sh/prismjs@1.29.0";
 
 export { extract as frontMatter } from "$std/front_matter/yaml.ts";
+
+import * as Marked from "https://esm.sh/marked@7.0.2";
+import { escape as escapeHtml } from "$std/html/entities.ts";
+import * as sucrase from "https://esm.sh/sucrase@3.34.0";
+import { mangle } from "$marked-mangle";
+import { markedSmartypants } from "$marked-smartypants";
+
+Marked.marked.use(mangle());
+Marked.marked.use(markedSmartypants());
+
+const LOGOS: Record<string, string> = {
+  js: "/js-logo.svg",
+  jsx: "/js-logo.svg",
+  ts: "/ts-logo.svg",
+  tsx: "/ts-logo.svg",
+};
+function getLogo(lang: string) {
+  return LOGOS[lang] ?? "";
+}
+
+function replaceExtName(file: string, newExt: string) {
+  const idx = file.lastIndexOf(".");
+  if (idx > -1) {
+    return file.slice(0, idx) + "." + newExt;
+  }
+  return file;
+}
+
+class DefaultRenderer extends Marked.Renderer {
+  heading(
+    text: string,
+    level: 1 | 2 | 3 | 4 | 5 | 6,
+    raw: string,
+    slugger: Marked.Slugger,
+  ): string {
+    const slug = slugger.slug(raw);
+    return `<h${level} id="${slug}"><a class="anchor" aria-hidden="true" tabindex="-1" href="#${slug}">#</a>${text}</h${level}>`;
+  }
+
+  link(href: string, title: string | null, text: string) {
+    const titleAttr = title ? ` title="${title}"` : "";
+    if (href.startsWith("#")) {
+      return `<a href="${href}"${titleAttr}>${text}</a>`;
+    }
+    if (this.options.baseUrl) {
+      try {
+        href = new URL(href, this.options.baseUrl).href;
+      } catch (_) {
+        //
+      }
+    }
+    return `<a href="${href}"${titleAttr} rel="noopener noreferrer">${text}</a>`;
+  }
+
+  image(src: string, title: string | null, alt: string | null) {
+    return `<img src="${src}" alt="${alt ?? ""}" title="${title ?? ""}" />`;
+  }
+
+  code(code: string, info: string | undefined): string {
+    // format: tsx
+    // format: tsx { "foo": 1 }
+    let meta: Record<string, unknown> = {};
+    let lang = "";
+    const match = info?.match(/^(\w+)(\s+(.*))?$/);
+    if (match) {
+      lang = match[1].toLocaleLowerCase();
+      if (match[3]) {
+        try {
+          meta = JSON.parse(match[3]) as Record<string, unknown>;
+        } catch (err) {
+          console.log(JSON.stringify(match[3]));
+          console.log(err);
+        }
+      }
+    }
+
+    const title = String(meta.title ?? "");
+    const snippets: {
+      lang: string;
+      code: string;
+      logo: string;
+      title: string;
+    }[] = [{
+      title,
+      lang,
+      code,
+      logo: getLogo(lang),
+    }];
+
+    if (!("lang_switcher" in meta) && (lang === "ts" || lang === "tsx")) {
+      meta.lang_switcher = true;
+    }
+    if (!("transform" in meta)) {
+      meta.transform = true;
+    }
+
+    let switcher = "";
+    if (meta.lang_switcher && (lang === "ts" || lang === "tsx")) {
+      switcher = `<select class="fenced-code-dropdown">
+        <option value="ts">TypeScript</option>
+        <option value="js">JavaScript</option>
+      </select>
+      `;
+
+      try {
+        let transformedCode = code;
+        if (meta.transform) {
+          const result = sucrase.transform(code, {
+            disableESTransforms: true,
+            keepUnusedImports: true,
+            preserveDynamicImport: true,
+            production: false,
+            transforms: ["typescript", "jsx"],
+            jsxRuntime: "preserve",
+          });
+
+          transformedCode = result.code
+            // Remove empty imports after TS conversion
+            .replace(/^import\s+{\s*}\s+from\s+["'].*["'];$/gm, "")
+            // Sucrase leaves some spacee after "as" modifier
+            .replace(/\s+;$/gm, ";")
+            .replace(/\s+,/gm, ",")
+            // Update import specifiers
+            .replace(/\.tsx";$/gm, '.jsx";')
+            .replace(/\.ts";$/gm, '.js";')
+            // Trim multiline whitespace
+            .replace(/^(\s*\n){2,}/gm, "\n");
+        }
+
+        const actualLang = `j${lang.slice(1)}`;
+        const actualTitle = replaceExtName(title, actualLang);
+
+        snippets.push({
+          title: actualTitle,
+          logo: getLogo(actualLang),
+          lang: actualLang,
+          code: transformedCode,
+        });
+      } catch (err) {
+        console.log(code.slice(Math.max(0, err.pos), err.pos + 100));
+        console.log(err);
+      }
+    }
+
+    const switcherClass = switcher ? " with-switcher" : "";
+    let out = `<div class="fenced-code${switcherClass}">
+      <div class="fenced-code-header">`;
+
+    for (let i = 0; i < snippets.length; i++) {
+      const { title, lang } = snippets[i];
+      out += `<span class="fenced-code-title lang-${lang}">${
+        title ? escapeHtml(String(title)) : "&nbsp;"
+      }</span>`;
+    }
+
+    out += `${switcher}</div>`;
+
+    for (let i = 0; i < snippets.length; i++) {
+      const { code, lang } = snippets[i];
+      const grammar = lang && Object.hasOwnProperty.call(Prism.languages, lang)
+        ? Prism.languages[lang]
+        : undefined;
+
+      if (grammar === undefined) {
+        out += `<pre><code class="notranslate">${
+          escapeHtml(code)
+        }</code></pre>`;
+      } else {
+        const html = Prism.highlight(code, grammar, lang);
+        out +=
+          `<pre class="highlight highlight-source-${lang} notranslate lang-${lang}">${html}</pre>`;
+      }
+    }
+
+    out += `</div>`;
+    return out;
+  }
+}
+
+export interface MarkdownOptions {
+  inline?: boolean;
+}
+export function renderMarkdown(input: string, opts: MarkdownOptions = {}) {
+  const markedOpts: Marked.MarkedOptions = {
+    gfm: true,
+    renderer: new DefaultRenderer(),
+  };
+
+  const html = opts.inline
+    ? Marked.parseInline(input, markedOpts)
+    : Marked.parse(input, markedOpts);
+
+  return html;
+}

--- a/www/utils/markdown.ts
+++ b/www/utils/markdown.ts
@@ -130,7 +130,10 @@ class DefaultRenderer extends Marked.Renderer {
             .replace(/\s+,/gm, ",")
             // Update import specifiers
             .replace(/["']([\w/_.-]+)\.tsx["'];$/gm, '"$1.jsx";')
-            .replace(/["']([\w/_.-]+)\.ts["'];$/gm, '"$1.js";')
+            .replace(
+              /["'](!<=\$fresh)([\w/_.-]+)(!<=fresh\.gen)\.ts["'];$/gm,
+              '"$1.js";',
+            )
             // Trim multiline whitespace
             .replace(/^(\s*\n){2,}/gm, "\n");
         }

--- a/www/utils/markdown.ts
+++ b/www/utils/markdown.ts
@@ -11,10 +11,8 @@ import * as Marked from "https://esm.sh/marked@7.0.2";
 import { escape as escapeHtml } from "$std/html/entities.ts";
 import * as sucrase from "https://esm.sh/sucrase@3.34.0";
 import { mangle } from "$marked-mangle";
-import { markedSmartypants } from "$marked-smartypants";
 
 Marked.marked.use(mangle());
-Marked.marked.use(markedSmartypants());
 
 function replaceExtName(file: string, newExt: string) {
   const idx = file.lastIndexOf(".");
@@ -25,6 +23,20 @@ function replaceExtName(file: string, newExt: string) {
 }
 
 class DefaultRenderer extends Marked.Renderer {
+  text(text: string): string {
+    // Smartypants typography enhancement
+    return text
+      .replaceAll("...", "&#8230;")
+      .replaceAll("--", "&#8212;")
+      .replaceAll("---", "&#8211;")
+      .replaceAll(/(\w)'(\w)/g, "$1&#8217;$2")
+      .replaceAll(/s'/g, "s&#8217;")
+      .replaceAll("&#39;", "&#8217;")
+      .replaceAll(/["](.*?)["]/g, "&#8220;$1&#8221")
+      .replaceAll(/&quot;(.*?)&quot;/g, "&#8220;$1&#8221")
+      .replaceAll(/['](.*?)[']/g, "&#8216;$1&#8217;");
+  }
+
   heading(
     text: string,
     level: 1 | 2 | 3 | 4 | 5 | 6,

--- a/www/utils/markdown.ts
+++ b/www/utils/markdown.ts
@@ -188,15 +188,18 @@ class DefaultRenderer extends Marked.Renderer {
 export interface MarkdownOptions {
   inline?: boolean;
 }
-export function renderMarkdown(input: string, opts: MarkdownOptions = {}) {
+export function renderMarkdown(
+  input: string,
+  opts: MarkdownOptions = {},
+): string {
   const markedOpts: Marked.MarkedOptions = {
     gfm: true,
     renderer: new DefaultRenderer(),
   };
 
   const html = opts.inline
-    ? Marked.parseInline(input, markedOpts)
-    : Marked.parse(input, markedOpts);
+    ? Marked.parseInline(input, markedOpts) as string
+    : Marked.parse(input, markedOpts) as string;
 
   return html;
 }


### PR DESCRIPTION
This PR spices up the code blocks quite a bit. It adds a language selector so that you can switch between `TypeScript/JavaScript` code. The setting is persisted in local store and is applied globally to all code blocks.

On top of that the PR adds the ability to add a title to a code block so that it tells the user what they're looking at. In most cases that will be the file name.

The marked smartypants plugin doesn't work with the latest marked version. The previous plugin would parse the final generated HTML again anyway instead of just tapping into marked's parser. So I've hand rolled our own smartypants.


https://github.com/denoland/fresh/assets/1062408/518b6d3c-0697-4a63-b397-92395925ca31

