### PR TITLE
www: remove counters in sidebar

### DIFF
--- a/www/components/DocsSidebar.tsx
+++ b/www/components/DocsSidebar.tsx
@@ -61,11 +61,11 @@ export default function DocsSidebar(
         />
       </div>
 
-      <ol class="list-decimal list-inside font-semibold nested ml-2.5">
+      <ul class="list-inside font-semibold nested ml-2.5">
         {CATEGORIES[props.selectedVersion].map((category) => (
           <SidebarCategory path={props.path} category={category} />
         ))}
-      </ol>
+      </ul>
     </>
   );
 }
@@ -87,11 +87,11 @@ export function SidebarCategory(props: {
         {title}
       </a>
       {entries.length > 0 && (
-        <ol class="pb-2 pl-4 list-decimal nested list-outside">
+        <ul class="py-2 pl-4 nested list-outside">
           {entries.map((entry) => (
             <SidebarEntry path={props.path} entry={entry} />
           ))}
-        </ol>
+        </ul>
       )}
     </li>
   );


### PR DESCRIPTION
Small design change that removes the decimal numbered list in the sidebar. Always found they include visual noise and don't really have a purpose.

Before:

| Before | After |
|---|---|
| <img width="446" alt="Screenshot 2023-08-12 at 16 00 32" src="https://github.com/denoland/fresh/assets/1062408/7493ac36-ae4f-4b8e-b364-0f862b262c2c"> | <img width="490" alt="Screenshot 2023-08-12 at 16 00 36" src="https://github.com/denoland/fresh/assets/1062408/4bed97ce-c799-4a10-abcc-ec989540330b"> |
