### PR TITLE
fix: exclude `_fresh` dir from lint + fmt

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -562,6 +562,10 @@ const config = {
     rules: {
       tags: ["fresh", "recommended"],
     },
+    exclude: ["_fresh"],
+  },
+  fmt: {
+    exclude: ["_fresh"],
   },
   imports: {} as Record<string, string>,
   compilerOptions: {

--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -84,6 +84,13 @@ export interface DenoConfig {
   imports?: Record<string, string>;
   importMap?: string;
   tasks?: Record<string, string>;
+  lint?: {
+    rules: { tags?: string[] };
+    exclude?: string[];
+  };
+  fmt?: {
+    exclude?: string[];
+  };
   compilerOptions?: {
     jsx?: string;
     jsxImportSource?: string;

--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -86,9 +86,17 @@ Deno.test({
       const configPath = path.join(tmpDirName, "deno.json");
       const json = JSON.parse(await Deno.readTextFile(configPath));
 
+      // Check tasks
       assert(json.tasks.start, "Missing 'start' task");
       assert(json.tasks.build, "Missing 'build' task");
       assert(json.tasks.preview, "Missing 'preview' task");
+
+      // Check lint settings
+      assertEquals(json.lint.exclude, ["_fresh"]);
+      assertEquals(json.lint.rules.tags, ["fresh", "recommended"]);
+
+      // Check fmt settings
+      assertEquals(json.fmt.exclude, ["_fresh"]);
     });
 
     await t.step("start up the server and access the root page", async () => {
@@ -390,6 +398,10 @@ Deno.test("fresh-update", async function fn(t) {
     assert(json.tasks?.start, "Missing 'start' task");
     assert(json.tasks?.build, "Missing 'build' task");
     assert(json.tasks?.preview, "Missing 'preview' task");
+
+    assertEquals(json.lint?.rules?.tags, ["fresh", "recommended"]);
+    assertEquals(json.lint?.exclude, ["_fresh"]);
+    assertEquals(json.fmt?.exclude, ["_fresh"]);
   });
 
   const comment = "// This is a test comment";

--- a/update.ts
+++ b/update.ts
@@ -87,6 +87,23 @@ if (!denoJson.lint.rules.tags.includes("fresh")) {
 if (!denoJson.lint.rules.tags.includes("recommended")) {
   denoJson.lint.rules.tags.push("recommended");
 }
+if (!denoJson.lint.exclude) {
+  denoJson.lint.exclude = [];
+}
+if (!denoJson.lint.exclude.includes("_fresh")) {
+  denoJson.lint.exclude.push("_fresh");
+}
+
+// Exclude _fresh dir from linting
+if (!denoJson.fmt) {
+  denoJson.fmt = {};
+}
+if (!denoJson.fmt.exclude) {
+  denoJson.fmt.exclude = [];
+}
+if (!denoJson.fmt.exclude.includes("_fresh")) {
+  denoJson.fmt.exclude.push("_fresh");
+}
 
 if (!denoJson.tasks) {
   denoJson.tasks = {};


### PR DESCRIPTION
Fixes #1652 