### PR TITLE
fix: refresh not working

### DIFF
--- a/src/server/rendering/template.tsx
+++ b/src/server/rendering/template.tsx
@@ -90,6 +90,9 @@ export function renderOuterDocument(
       opts.preloads.map((src) =>
         h("link", { rel: "modulepreload", href: src })
       ),
+      opts.moduleScripts.map(([src, nonce]) =>
+        h("script", { src: src, nonce, type: "module" })
+      ),
       headVNodes,
       h("body", {
         ...docBody,

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -971,3 +971,10 @@ Deno.test({
   sanitizeOps: false,
   sanitizeResources: false,
 });
+
+Deno.test("adds refresh script to html", async () => {
+  await withFresh("./tests/fixture/main.ts", async (address) => {
+    const doc = await fetchHtml(address);
+    assertSelector(doc, `script[src="/_frsh/refresh.js"]`);
+  });
+});


### PR DESCRIPTION
Regression was introduced in #1638 accidentally by not rendering module scripts into the HTML.

Fixes #1647