### PR TITLE
docs: add section for "Rendering islands on client only"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
   },
   "[javascript]": {
     "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
   }
 }

--- a/docs/latest/concepts/islands.md
+++ b/docs/latest/concepts/islands.md
@@ -171,7 +171,7 @@ export default function Home() {
 
 ## Rendering islands on client only
 
-When using client-only apis, like `EventSource` or `navigator.getUserMedia`,
+When using client-only APIs, like `EventSource` or `navigator.getUserMedia`,
 this component will not run on the server as it will produce an error like:
 
 ```

--- a/docs/latest/concepts/islands.md
+++ b/docs/latest/concepts/islands.md
@@ -184,7 +184,7 @@ An error occurred during route handling or page rendering. ReferenceError: Event
 
 Use the `IS_BROWSER` flag as a guard to fix the issue:
 
-```ts islands/my-island.tsx
+```tsx islands/my-island.tsx
 import { IS_BROWSER } from "$fresh/runtime.ts";
 
 export function MyIsland() {
@@ -193,7 +193,6 @@ export function MyIsland() {
 
   // All the code which must run in the browser comes here!
   // Like: EventSource, navigator.getUserMedia, etc.
-
   return <div></div>;
 }
 ```

--- a/docs/latest/concepts/islands.md
+++ b/docs/latest/concepts/islands.md
@@ -4,8 +4,8 @@ description: |
 ---
 
 Islands enable client side interactivity in Fresh. Islands are isolated Preact
-components that are rendered on the client. This is different from all other
-components in Fresh, as they are usually just rendered on the server.
+components that are rendered on the server and then hydrated on the client. This is different from all other
+components in Fresh, as they are usually rendered on the server only.
 
 Islands are defined by creating a file in the `islands/` folder in a Fresh
 project. The name of this file must be a PascalCase or kebab-case name of the
@@ -140,8 +140,7 @@ export default function MyIsland({ children, foo }: Props) {
     <div>
       <p>String from props: {foo}</p>
       <p>
-        <button onClick={() => (number.value = randomNumber())}>Random</button>
-        {" "}
+        <button onClick={() => (number.value = randomNumber())}>Random</button>{" "}
         number is: {number}.
       </p>
     </div>
@@ -166,5 +165,34 @@ export default function Home() {
       <p>Some more server rendered text</p>
     </div>
   );
+}
+```
+
+## Rendering islands on client only
+
+When using client-only apis, like `EventSource` or `navigator.getUserMedia`, this component will not run on the server
+as it will produce an error like:
+
+```
+An error occurred during route handling or page rendering. ReferenceError: EventSource is not defined
+    at Object.MyIsland (file:///Users/someuser/fresh-project/islandsmy-island.tsx:6:18)
+    at m (https://esm.sh/v129/preact-render-to-string@6.2.0/X-ZS8q/denonext/preact-render-to-string.mjs:2:2602)
+    at m (https://esm.sh/v129/preact-render-to-string@6.2.0/X-ZS8q/denonext/preact-render-to-string.mjs:2:2113)
+    ....
+```
+
+Use the `IS_BROWSER` flag as a guard to fix the issue:
+
+```ts islands/my-island.tsx
+import { IS_BROWSER } from "$fresh/runtime.ts";
+
+export function MyIsland() {
+  // Return any prerenderable JSX here which makes sense for your island
+  if (!IS_BROWSER) return <div></div>;
+
+  // All the code which must run in the browser comes here!
+  // Like: EventSource, navigator.getUserMedia, etc.
+
+  return <div></div>;
 }
 ```

--- a/docs/latest/concepts/islands.md
+++ b/docs/latest/concepts/islands.md
@@ -141,7 +141,8 @@ export default function MyIsland({ children, foo }: Props) {
     <div>
       <p>String from props: {foo}</p>
       <p>
-        <button onClick={() => (number.value = randomNumber())}>Random</button>{" "}
+        <button onClick={() => (number.value = randomNumber())}>Random</button>
+        {" "}
         number is: {number}.
       </p>
     </div>

--- a/docs/latest/concepts/islands.md
+++ b/docs/latest/concepts/islands.md
@@ -4,8 +4,9 @@ description: |
 ---
 
 Islands enable client side interactivity in Fresh. Islands are isolated Preact
-components that are rendered on the server and then hydrated on the client. This is different from all other
-components in Fresh, as they are usually rendered on the server only.
+components that are rendered on the server and then hydrated on the client. This
+is different from all other components in Fresh, as they are usually rendered on
+the server only.
 
 Islands are defined by creating a file in the `islands/` folder in a Fresh
 project. The name of this file must be a PascalCase or kebab-case name of the
@@ -170,8 +171,8 @@ export default function Home() {
 
 ## Rendering islands on client only
 
-When using client-only apis, like `EventSource` or `navigator.getUserMedia`, this component will not run on the server
-as it will produce an error like:
+When using client-only apis, like `EventSource` or `navigator.getUserMedia`,
+this component will not run on the server as it will produce an error like:
 
 ```
 An error occurred during route handling or page rendering. ReferenceError: EventSource is not defined


### PR DESCRIPTION
Changes: 
- new section on "Islands" page about "Rendering islands on client only" 
- in description about islands: state more clearly now that they will be rendered on the Server AND (hydrated) on the client. 

Fixes: #1686 

@marvinhagemeister I have a feeling i might do some more of these small docs changes. 
I don't want to batch them to not delay unrelated improvements too much. 
Should I simply tag you for new PRs (like this), or do you get notified of new PRs anyway?