### PR TITLE
chore: disable canary deno tests temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deno: ["v1.x", "canary"]
+        deno: ["v1.x"]
         os: [macOS-latest, windows-latest, ubuntu-latest]
         include:
         - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: deno lint
 
       - name: Spell-check
-        if: startsWith(matrix.os, 'ubuntu') && matrix.deno == 'canary'
+        if: startsWith(matrix.os, 'ubuntu') && matrix.deno == 'v1.x'
         uses: crate-ci/typos@master
 
       - name: Cache dependencies and Chrome


### PR DESCRIPTION
All CIs are currently failing to due formatting differences in canary. Disable that in CI for now until formatting changes have been promoted to stable. Then we can run the CI tests on both deno versions again.