### PR TITLE
fix(server): pass context into 500 handlers

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -904,7 +904,7 @@ export class ServerContext {
         {
           ...ctx,
           error,
-          render: errorHandlerRender(req, {}, undefined, error),
+          render: errorHandlerRender(req, {}, ctx, error),
         },
       );
     };

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -267,6 +267,10 @@ Deno.test("/failure", async () => {
   assertEquals(resp.status, Status.InternalServerError);
   const body = await resp.text();
   assert(body.includes("500 internal error: it errored!"));
+  assertStringIncludes(
+    body,
+    `<meta name="generator" content="The freshest framework!"/>`,
+  );
 });
 
 Deno.test("/foo/:path*", async () => {


### PR DESCRIPTION
closes #1717

This allows state to properly get passed into `_app.tsx` when rendering `_500.tsx` pages, as evidenced by the test.