### PR TITLE
fix(server): sanitize brackets from island names

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1218,7 +1218,7 @@ function toPascalCase(text: string): string {
 }
 
 function sanitizeIslandName(name: string): string {
-  const fileName = name.replaceAll(/[/\\\\\(\)]/g, "_");
+  const fileName = name.replaceAll(/[/\\\\\(\)\[\]]/g, "_");
   return toPascalCase(fileName);
 }
 

--- a/tests/fixture_layouts/fresh.gen.ts
+++ b/tests/fixture_layouts/fresh.gen.ts
@@ -11,28 +11,30 @@ import * as $5 from "./routes/async/redirect/_layout.tsx";
 import * as $6 from "./routes/async/redirect/index.tsx";
 import * as $7 from "./routes/async/sub/_layout.tsx";
 import * as $8 from "./routes/async/sub/index.tsx";
-import * as $9 from "./routes/files/js/_layout.js";
-import * as $10 from "./routes/files/js/index.js";
-import * as $11 from "./routes/files/jsx/_layout.jsx";
-import * as $12 from "./routes/files/jsx/index.jsx";
-import * as $13 from "./routes/files/ts/_layout.ts";
-import * as $14 from "./routes/files/ts/index.ts";
-import * as $15 from "./routes/files/tsx/_layout.tsx";
-import * as $16 from "./routes/files/tsx/index.tsx";
-import * as $17 from "./routes/foo/_layout.tsx";
-import * as $18 from "./routes/foo/bar.tsx";
-import * as $19 from "./routes/foo/index.tsx";
-import * as $20 from "./routes/index.tsx";
-import * as $21 from "./routes/other.tsx";
-import * as $22 from "./routes/override/_layout.tsx";
-import * as $23 from "./routes/override/index.tsx";
-import * as $24 from "./routes/override/layout_no_app/_layout.tsx";
-import * as $25 from "./routes/override/layout_no_app/index.tsx";
-import * as $26 from "./routes/override/no_app.tsx";
-import * as $27 from "./routes/override/no_layout.tsx";
-import * as $28 from "./routes/override/no_layout_no_app.tsx";
-import * as $29 from "./routes/skip/sub/_layout.tsx";
-import * as $30 from "./routes/skip/sub/index.tsx";
+import * as $9 from "./routes/dynamic/[tenant]/index.tsx";
+import * as $10 from "./routes/files/js/_layout.js";
+import * as $11 from "./routes/files/js/index.js";
+import * as $12 from "./routes/files/jsx/_layout.jsx";
+import * as $13 from "./routes/files/jsx/index.jsx";
+import * as $14 from "./routes/files/ts/_layout.ts";
+import * as $15 from "./routes/files/ts/index.ts";
+import * as $16 from "./routes/files/tsx/_layout.tsx";
+import * as $17 from "./routes/files/tsx/index.tsx";
+import * as $18 from "./routes/foo/_layout.tsx";
+import * as $19 from "./routes/foo/bar.tsx";
+import * as $20 from "./routes/foo/index.tsx";
+import * as $21 from "./routes/index.tsx";
+import * as $22 from "./routes/other.tsx";
+import * as $23 from "./routes/override/_layout.tsx";
+import * as $24 from "./routes/override/index.tsx";
+import * as $25 from "./routes/override/layout_no_app/_layout.tsx";
+import * as $26 from "./routes/override/layout_no_app/index.tsx";
+import * as $27 from "./routes/override/no_app.tsx";
+import * as $28 from "./routes/override/no_layout.tsx";
+import * as $29 from "./routes/override/no_layout_no_app.tsx";
+import * as $30 from "./routes/skip/sub/_layout.tsx";
+import * as $31 from "./routes/skip/sub/index.tsx";
+import * as $$0 from "./routes/dynamic/[tenant]/(_islands)/Counter.tsx";
 
 const manifest = {
   routes: {
@@ -45,30 +47,33 @@ const manifest = {
     "./routes/async/redirect/index.tsx": $6,
     "./routes/async/sub/_layout.tsx": $7,
     "./routes/async/sub/index.tsx": $8,
-    "./routes/files/js/_layout.js": $9,
-    "./routes/files/js/index.js": $10,
-    "./routes/files/jsx/_layout.jsx": $11,
-    "./routes/files/jsx/index.jsx": $12,
-    "./routes/files/ts/_layout.ts": $13,
-    "./routes/files/ts/index.ts": $14,
-    "./routes/files/tsx/_layout.tsx": $15,
-    "./routes/files/tsx/index.tsx": $16,
-    "./routes/foo/_layout.tsx": $17,
-    "./routes/foo/bar.tsx": $18,
-    "./routes/foo/index.tsx": $19,
-    "./routes/index.tsx": $20,
-    "./routes/other.tsx": $21,
-    "./routes/override/_layout.tsx": $22,
-    "./routes/override/index.tsx": $23,
-    "./routes/override/layout_no_app/_layout.tsx": $24,
-    "./routes/override/layout_no_app/index.tsx": $25,
-    "./routes/override/no_app.tsx": $26,
-    "./routes/override/no_layout.tsx": $27,
-    "./routes/override/no_layout_no_app.tsx": $28,
-    "./routes/skip/sub/_layout.tsx": $29,
-    "./routes/skip/sub/index.tsx": $30,
+    "./routes/dynamic/[tenant]/index.tsx": $9,
+    "./routes/files/js/_layout.js": $10,
+    "./routes/files/js/index.js": $11,
+    "./routes/files/jsx/_layout.jsx": $12,
+    "./routes/files/jsx/index.jsx": $13,
+    "./routes/files/ts/_layout.ts": $14,
+    "./routes/files/ts/index.ts": $15,
+    "./routes/files/tsx/_layout.tsx": $16,
+    "./routes/files/tsx/index.tsx": $17,
+    "./routes/foo/_layout.tsx": $18,
+    "./routes/foo/bar.tsx": $19,
+    "./routes/foo/index.tsx": $20,
+    "./routes/index.tsx": $21,
+    "./routes/other.tsx": $22,
+    "./routes/override/_layout.tsx": $23,
+    "./routes/override/index.tsx": $24,
+    "./routes/override/layout_no_app/_layout.tsx": $25,
+    "./routes/override/layout_no_app/index.tsx": $26,
+    "./routes/override/no_app.tsx": $27,
+    "./routes/override/no_layout.tsx": $28,
+    "./routes/override/no_layout_no_app.tsx": $29,
+    "./routes/skip/sub/_layout.tsx": $30,
+    "./routes/skip/sub/index.tsx": $31,
   },
-  islands: {},
+  islands: {
+    "./routes/dynamic/[tenant]/(_islands)/Counter.tsx": $$0,
+  },
   baseUrl: import.meta.url,
 };
 

--- a/tests/fixture_layouts/routes/dynamic/[tenant]/(_islands)/Counter.tsx
+++ b/tests/fixture_layouts/routes/dynamic/[tenant]/(_islands)/Counter.tsx
@@ -1,0 +1,22 @@
+import type { Signal } from "@preact/signals";
+import { IS_BROWSER } from "$fresh/runtime.ts";
+
+interface CounterProps {
+  count: Signal<number>;
+  id: string;
+}
+
+export default function Counter(props: CounterProps) {
+  return (
+    <div id={props.id}>
+      <p>{props.count}</p>
+      <button
+        id={`b-${props.id}`}
+        onClick={() => props.count.value += 1}
+        disabled={!IS_BROWSER}
+      >
+        +1
+      </button>
+    </div>
+  );
+}

--- a/tests/fixture_layouts/routes/dynamic/[tenant]/index.tsx
+++ b/tests/fixture_layouts/routes/dynamic/[tenant]/index.tsx
@@ -1,0 +1,10 @@
+import { useSignal } from "@preact/signals";
+import Counter from "./(_islands)/Counter.tsx";
+
+export default function Home() {
+  return (
+    <div>
+      <Counter id="counter" count={useSignal(3)} />
+    </div>
+  );
+}


### PR DESCRIPTION
closes #1708

Need to get rid of brackets from island names as well, because brackets aren't valid in javascript variable names.