### PR TITLE
fix: wrong type for html boolean attrs

### DIFF
--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -84,9 +84,6 @@ function addPropsChild(parent: VNode, vnode: ComponentChildren) {
   }
 }
 
-const BOOLEAN_ATTR =
-  /(async|autofocus|autoplay|checked|controls|default|defer|disabled|formnovalidate|inert|ismap|itemscope|loop|multiple|muted|nomodule|novalidate|open|playsinline|readonly|required|reversed|selected)/;
-
 const enum MarkerKind {
   Island,
   Slot,
@@ -329,9 +326,11 @@ function _walkInner(
 
           // Boolean attributes are always `true` when present.
           // See: https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML
-          props[attr.nodeName] = BOOLEAN_ATTR.test(attr.nodeName)
-            ? true
-            : attr.nodeValue;
+          props[attr.nodeName] =
+            // deno-lint-ignore no-explicit-any
+            typeof (sib as any)[attr.nodeName] === "boolean"
+              ? true
+              : attr.nodeValue;
         }
         const vnode = h(sib.localName, props);
         addPropsChild(parentVNode, vnode);

--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -84,6 +84,9 @@ function addPropsChild(parent: VNode, vnode: ComponentChildren) {
   }
 }
 
+const BOOLEAN_ATTR =
+  /(async|autofocus|autoplay|checked|controls|default|defer|disabled|formnovalidate|inert|ismap|itemscope|loop|multiple|muted|nomodule|novalidate|open|playsinline|readonly|required|reversed|selected)/;
+
 const enum MarkerKind {
   Island,
   Slot,
@@ -323,7 +326,12 @@ function _walkInner(
         };
         for (let i = 0; i < sib.attributes.length; i++) {
           const attr = sib.attributes[i];
-          props[attr.nodeName] = attr.nodeValue;
+
+          // Boolean attributes are always `true` when present.
+          // See: https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML
+          props[attr.nodeName] = BOOLEAN_ATTR.test(attr.nodeName)
+            ? true
+            : attr.nodeValue;
         }
         const vnode = h(sib.localName, props);
         addPropsChild(parentVNode, vnode);

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -47,38 +47,40 @@ import * as $41 from "./routes/movies/[foo].json.ts";
 import * as $42 from "./routes/movies/[foo]@[bar].ts";
 import * as $43 from "./routes/not_found.ts";
 import * as $44 from "./routes/params.tsx";
-import * as $45 from "./routes/props/[id].tsx";
-import * as $46 from "./routes/route-groups-islands/index.tsx";
-import * as $47 from "./routes/route-groups/(bar)/(baz)/_layout.tsx";
-import * as $48 from "./routes/route-groups/(bar)/(baz)/baz.tsx";
-import * as $49 from "./routes/route-groups/(bar)/_layout.tsx";
-import * as $50 from "./routes/route-groups/(bar)/bar.tsx";
-import * as $51 from "./routes/route-groups/(bar)/boof/index.tsx";
-import * as $52 from "./routes/route-groups/(foo)/_layout.tsx";
-import * as $53 from "./routes/route-groups/(foo)/index.tsx";
-import * as $54 from "./routes/signal_shared.tsx";
-import * as $55 from "./routes/state-in-props/_middleware.ts";
-import * as $56 from "./routes/state-in-props/index.tsx";
-import * as $57 from "./routes/state-middleware/_middleware.ts";
-import * as $58 from "./routes/state-middleware/foo/_middleware.ts";
-import * as $59 from "./routes/state-middleware/foo/index.tsx";
-import * as $60 from "./routes/static.tsx";
-import * as $61 from "./routes/status_overwrite.tsx";
-import * as $62 from "./routes/umlaut-äöüß.tsx";
-import * as $63 from "./routes/wildcard.tsx";
+import * as $45 from "./routes/preact/boolean_attrs.tsx";
+import * as $46 from "./routes/props/[id].tsx";
+import * as $47 from "./routes/route-groups-islands/index.tsx";
+import * as $48 from "./routes/route-groups/(bar)/(baz)/_layout.tsx";
+import * as $49 from "./routes/route-groups/(bar)/(baz)/baz.tsx";
+import * as $50 from "./routes/route-groups/(bar)/_layout.tsx";
+import * as $51 from "./routes/route-groups/(bar)/bar.tsx";
+import * as $52 from "./routes/route-groups/(bar)/boof/index.tsx";
+import * as $53 from "./routes/route-groups/(foo)/_layout.tsx";
+import * as $54 from "./routes/route-groups/(foo)/index.tsx";
+import * as $55 from "./routes/signal_shared.tsx";
+import * as $56 from "./routes/state-in-props/_middleware.ts";
+import * as $57 from "./routes/state-in-props/index.tsx";
+import * as $58 from "./routes/state-middleware/_middleware.ts";
+import * as $59 from "./routes/state-middleware/foo/_middleware.ts";
+import * as $60 from "./routes/state-middleware/foo/index.tsx";
+import * as $61 from "./routes/static.tsx";
+import * as $62 from "./routes/status_overwrite.tsx";
+import * as $63 from "./routes/umlaut-äöüß.tsx";
+import * as $64 from "./routes/wildcard.tsx";
 import * as $$0 from "./islands/Counter.tsx";
-import * as $$1 from "./islands/Greeter.tsx";
-import * as $$2 from "./islands/MultipleCounters.tsx";
-import * as $$3 from "./islands/ReturningNull.tsx";
-import * as $$4 from "./islands/RootFragment.tsx";
-import * as $$5 from "./islands/RootFragmentWithConditionalFirst.tsx";
-import * as $$6 from "./islands/StringEventIsland.tsx";
-import * as $$7 from "./islands/Test.tsx";
-import * as $$8 from "./islands/folder/Counter.tsx";
-import * as $$9 from "./islands/folder/subfolder/Counter.tsx";
-import * as $$10 from "./islands/kebab-case-counter-test.tsx";
-import * as $$11 from "./routes/route-groups-islands/(_islands)/Counter.tsx";
-import * as $$12 from "./routes/route-groups-islands/(_islands)/invalid.tsx";
+import * as $$1 from "./islands/FormIsland.tsx";
+import * as $$2 from "./islands/Greeter.tsx";
+import * as $$3 from "./islands/MultipleCounters.tsx";
+import * as $$4 from "./islands/ReturningNull.tsx";
+import * as $$5 from "./islands/RootFragment.tsx";
+import * as $$6 from "./islands/RootFragmentWithConditionalFirst.tsx";
+import * as $$7 from "./islands/StringEventIsland.tsx";
+import * as $$8 from "./islands/Test.tsx";
+import * as $$9 from "./islands/folder/Counter.tsx";
+import * as $$10 from "./islands/folder/subfolder/Counter.tsx";
+import * as $$11 from "./islands/kebab-case-counter-test.tsx";
+import * as $$12 from "./routes/route-groups-islands/(_islands)/Counter.tsx";
+import * as $$13 from "./routes/route-groups-islands/(_islands)/invalid.tsx";
 
 const manifest = {
   routes: {
@@ -127,40 +129,42 @@ const manifest = {
     "./routes/movies/[foo]@[bar].ts": $42,
     "./routes/not_found.ts": $43,
     "./routes/params.tsx": $44,
-    "./routes/props/[id].tsx": $45,
-    "./routes/route-groups-islands/index.tsx": $46,
-    "./routes/route-groups/(bar)/(baz)/_layout.tsx": $47,
-    "./routes/route-groups/(bar)/(baz)/baz.tsx": $48,
-    "./routes/route-groups/(bar)/_layout.tsx": $49,
-    "./routes/route-groups/(bar)/bar.tsx": $50,
-    "./routes/route-groups/(bar)/boof/index.tsx": $51,
-    "./routes/route-groups/(foo)/_layout.tsx": $52,
-    "./routes/route-groups/(foo)/index.tsx": $53,
-    "./routes/signal_shared.tsx": $54,
-    "./routes/state-in-props/_middleware.ts": $55,
-    "./routes/state-in-props/index.tsx": $56,
-    "./routes/state-middleware/_middleware.ts": $57,
-    "./routes/state-middleware/foo/_middleware.ts": $58,
-    "./routes/state-middleware/foo/index.tsx": $59,
-    "./routes/static.tsx": $60,
-    "./routes/status_overwrite.tsx": $61,
-    "./routes/umlaut-äöüß.tsx": $62,
-    "./routes/wildcard.tsx": $63,
+    "./routes/preact/boolean_attrs.tsx": $45,
+    "./routes/props/[id].tsx": $46,
+    "./routes/route-groups-islands/index.tsx": $47,
+    "./routes/route-groups/(bar)/(baz)/_layout.tsx": $48,
+    "./routes/route-groups/(bar)/(baz)/baz.tsx": $49,
+    "./routes/route-groups/(bar)/_layout.tsx": $50,
+    "./routes/route-groups/(bar)/bar.tsx": $51,
+    "./routes/route-groups/(bar)/boof/index.tsx": $52,
+    "./routes/route-groups/(foo)/_layout.tsx": $53,
+    "./routes/route-groups/(foo)/index.tsx": $54,
+    "./routes/signal_shared.tsx": $55,
+    "./routes/state-in-props/_middleware.ts": $56,
+    "./routes/state-in-props/index.tsx": $57,
+    "./routes/state-middleware/_middleware.ts": $58,
+    "./routes/state-middleware/foo/_middleware.ts": $59,
+    "./routes/state-middleware/foo/index.tsx": $60,
+    "./routes/static.tsx": $61,
+    "./routes/status_overwrite.tsx": $62,
+    "./routes/umlaut-äöüß.tsx": $63,
+    "./routes/wildcard.tsx": $64,
   },
   islands: {
     "./islands/Counter.tsx": $$0,
-    "./islands/Greeter.tsx": $$1,
-    "./islands/MultipleCounters.tsx": $$2,
-    "./islands/ReturningNull.tsx": $$3,
-    "./islands/RootFragment.tsx": $$4,
-    "./islands/RootFragmentWithConditionalFirst.tsx": $$5,
-    "./islands/StringEventIsland.tsx": $$6,
-    "./islands/Test.tsx": $$7,
-    "./islands/folder/Counter.tsx": $$8,
-    "./islands/folder/subfolder/Counter.tsx": $$9,
-    "./islands/kebab-case-counter-test.tsx": $$10,
-    "./routes/route-groups-islands/(_islands)/Counter.tsx": $$11,
-    "./routes/route-groups-islands/(_islands)/invalid.tsx": $$12,
+    "./islands/FormIsland.tsx": $$1,
+    "./islands/Greeter.tsx": $$2,
+    "./islands/MultipleCounters.tsx": $$3,
+    "./islands/ReturningNull.tsx": $$4,
+    "./islands/RootFragment.tsx": $$5,
+    "./islands/RootFragmentWithConditionalFirst.tsx": $$6,
+    "./islands/StringEventIsland.tsx": $$7,
+    "./islands/Test.tsx": $$8,
+    "./islands/folder/Counter.tsx": $$9,
+    "./islands/folder/subfolder/Counter.tsx": $$10,
+    "./islands/kebab-case-counter-test.tsx": $$11,
+    "./routes/route-groups-islands/(_islands)/Counter.tsx": $$12,
+    "./routes/route-groups-islands/(_islands)/invalid.tsx": $$13,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/fixture/islands/FormIsland.tsx
+++ b/tests/fixture/islands/FormIsland.tsx
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from "preact/hooks";
+import { ComponentChildren } from "preact";
+
+export function FormIsland({ children }: { children: ComponentChildren }) {
+  const ref = useRef<HTMLParagraphElement | null>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    ref.current.textContent = "Revived: true";
+  }, []);
+
+  return (
+    <form onSubmit={(e) => e.preventDefault()}>
+      <p class="form-revived" ref={ref}>Revived: false</p>
+      {children}
+    </form>
+  );
+}

--- a/tests/fixture/routes/preact/boolean_attrs.tsx
+++ b/tests/fixture/routes/preact/boolean_attrs.tsx
@@ -1,0 +1,45 @@
+import { defineRoute } from "$fresh/src/server/defines.ts";
+import { FormIsland } from "$fresh/tests/fixture/islands/FormIsland.tsx";
+
+export default defineRoute(() => {
+  return (
+    <div>
+      <h1>Boolean attributes</h1>
+      <p>All input elements should be checked or selected</p>
+      <FormIsland>
+        <p>
+          <label for="check">
+            checked
+          </label>
+          <input name="check" type="checkbox" checked />
+        </p>
+        <p>
+          <label for="text">
+            is required
+          </label>
+          <input name="text" type="text" required />
+        </p>
+        <p>
+          <label for="foo-1">
+            not selected
+          </label>
+          <input id="foo-1" type="radio" name="foo" value="1" />
+          <label for="foo-2">
+            selected
+          </label>
+
+          <input id="foo-2" type="radio" name="foo" value="2" checked />
+        </p>
+        <p>
+          <label for="select">
+            select value should be "bar"
+          </label>
+          <select name="select">
+            <option value="foo">foo</option>
+            <option value="bar" selected>bar</option>
+          </select>
+        </p>
+      </FormIsland>
+    </div>
+  );
+});

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -514,3 +514,48 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "revive boolean attributes",
+
+  async fn() {
+    await withPageName(
+      "./tests/fixture/main.ts",
+      async (page, address) => {
+        await page.goto(`${address}/preact/boolean_attrs`);
+        await waitForText(page, ".form-revived", "Revived: true");
+
+        const checked = await page.$eval(
+          "input[type=checkbox]",
+          (el) => el.checked,
+        );
+        assertEquals(checked, true, "Checkbox is not checked");
+
+        const required = await page.$eval(
+          "input[type=text]",
+          (el) => el.required,
+        );
+        assertEquals(required, true, "Text input is not marked as required");
+
+        const radioChecked = await page.$eval(
+          "input[type=radio][value='2']",
+          (el) => el.checked,
+        );
+        assertEquals(
+          radioChecked,
+          true,
+          "Text input is not marked as required",
+        );
+
+        const selected = await page.$eval(
+          "select",
+          (el) => el.options[el.selectedIndex].text,
+        );
+        assertEquals(selected, "bar", "'bar' value is not selected");
+      },
+    );
+  },
+
+  sanitizeOps: false,
+  sanitizeResources: false,
+});


### PR DESCRIPTION
HTML boolean attributes must be treated as being `true` when present. See: https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML

Fixes https://github.com/denoland/fresh/issues/1725