### PR TITLE
fix: stream static files from disk

### DIFF
--- a/src/build/aot_snapshot.ts
+++ b/src/build/aot_snapshot.ts
@@ -1,14 +1,23 @@
 import type { BuildSnapshot } from "./mod.ts";
 
 export class AotSnapshot implements BuildSnapshot {
-  readonly paths: string[] = [];
+  #files: Map<string, string>;
+  #dependencies: Map<string, string[]>;
+
   constructor(
-    private files: Map<string, string>,
-    private _dependencies: Map<string, string[]>,
-  ) {}
+    files: Map<string, string>,
+    dependencies: Map<string, string[]>,
+  ) {
+    this.#files = files;
+    this.#dependencies = dependencies;
+  }
+
+  get paths(): string[] {
+    return Array.from(this.#files.keys());
+  }
 
   async read(path: string): Promise<ReadableStream<Uint8Array> | null> {
-    const filePath = this.files.get(path);
+    const filePath = this.#files.get(path);
     if (filePath !== undefined) {
       try {
         const file = await Deno.open(filePath, { read: true });
@@ -23,6 +32,6 @@ export class AotSnapshot implements BuildSnapshot {
   }
 
   dependencies(path: string): string[] {
-    return this._dependencies.get(path) ?? [];
+    return this.#dependencies.get(path) ?? [];
   }
 }

--- a/src/build/aot_snapshot.ts
+++ b/src/build/aot_snapshot.ts
@@ -1,0 +1,28 @@
+import type { BuildSnapshot } from "./mod.ts";
+
+export class AotSnapshot implements BuildSnapshot {
+  readonly paths: string[] = [];
+  constructor(
+    private files: Map<string, string>,
+    private _dependencies: Map<string, string[]>,
+  ) {}
+
+  async read(path: string): Promise<ReadableStream<Uint8Array> | null> {
+    const filePath = this.files.get(path);
+    if (filePath !== undefined) {
+      try {
+        const file = await Deno.open(filePath, { read: true });
+        return file.readable;
+      } catch (_err) {
+        return null;
+      }
+    }
+
+    // Handler will turn this into a 404
+    return null;
+  }
+
+  dependencies(path: string): string[] {
+    return this._dependencies.get(path) ?? [];
+  }
+}

--- a/src/build/mod.ts
+++ b/src/build/mod.ts
@@ -4,6 +4,7 @@ export {
   EsbuildSnapshot,
   type JSXConfig,
 } from "./esbuild.ts";
+export { AotSnapshot } from "./aot_snapshot.ts";
 export interface Builder {
   build(): Promise<BuildSnapshot>;
 }
@@ -14,7 +15,13 @@ export interface BuildSnapshot {
 
   /** For a given file, return it's contents.
    * @throws If the file is not contained in this snapshot. */
-  read(path: string): ReadableStream<Uint8Array> | Uint8Array | null;
+  read(
+    path: string,
+  ):
+    | ReadableStream<Uint8Array>
+    | Uint8Array
+    | null
+    | Promise<ReadableStream<Uint8Array> | Uint8Array | null>;
 
   /** For a given entrypoint, return it's list of dependencies.
    *

--- a/src/dev/build.ts
+++ b/src/dev/build.ts
@@ -26,8 +26,8 @@ export async function build(
   const snapshot = await ctx.buildSnapshot();
 
   // Write output files to disk
-  await Promise.all(snapshot.paths.map((fileName) => {
-    const data = snapshot.read(fileName);
+  await Promise.all(snapshot.paths.map(async (fileName) => {
+    const data = await snapshot.read(fileName);
     if (data === null) return;
 
     return Deno.writeFile(join(outDir, fileName), data);


### PR DESCRIPTION
This avoids reading them into memory upfront. This is mostly a performance optimization and reduces memory consumption. This will likely reduce cold start time too.

This should help in mitigating https://github.com/denoland/deploy_feedback/issues/481