### PR TITLE
fix: Missing error on invalid island children

### DIFF
--- a/src/server/rendering/preact_hooks.ts
+++ b/src/server/rendering/preact_hooks.ts
@@ -3,6 +3,7 @@ import {
   type ComponentChildren,
   Fragment,
   h,
+  isValidElement,
   type Options as PreactOptions,
   options as preactOptions,
   type VNode,
@@ -233,6 +234,20 @@ options.__b = (vnode: VNode<Record<string, unknown>>) => {
           const id = islandProps.length;
           if ("children" in props) {
             let children = props.children;
+
+            // Guard against passing objects as children to JSX
+            if (
+              children !== null && !Array.isArray(children) &&
+              !isValidElement(children)
+            ) {
+              const name = originalType.displayName || originalType.name ||
+                "Anonymous";
+
+              throw new Error(
+                `Invalid JSX child passed to island <${name} />. Only JSX elements can be passed as children to an island. To resolve this error, pass the data as a standard prop instead.`,
+              );
+            }
+
             const markerText =
               `frsh-slot-${island.id}:${island.exportName}:${id}:children`;
             // @ts-ignore nonono

--- a/tests/fixture_island_nesting/fresh.gen.ts
+++ b/tests/fixture_island_nesting/fresh.gen.ts
@@ -9,13 +9,15 @@ import * as $3 from "./routes/island_conditional_lazy_island.tsx";
 import * as $4 from "./routes/island_fn_child.tsx";
 import * as $5 from "./routes/island_in_island.tsx";
 import * as $6 from "./routes/island_in_island_definition.tsx";
-import * as $7 from "./routes/island_jsx_child.tsx";
-import * as $8 from "./routes/island_jsx_children.tsx";
-import * as $9 from "./routes/island_jsx_island_jsx.tsx";
-import * as $10 from "./routes/island_jsx_text.tsx";
-import * as $11 from "./routes/island_nested_props.tsx";
-import * as $12 from "./routes/island_order.tsx";
-import * as $13 from "./routes/island_siblings.tsx";
+import * as $7 from "./routes/island_invalid_children.tsx";
+import * as $8 from "./routes/island_invalid_children_fn.tsx";
+import * as $9 from "./routes/island_jsx_child.tsx";
+import * as $10 from "./routes/island_jsx_children.tsx";
+import * as $11 from "./routes/island_jsx_island_jsx.tsx";
+import * as $12 from "./routes/island_jsx_text.tsx";
+import * as $13 from "./routes/island_nested_props.tsx";
+import * as $14 from "./routes/island_order.tsx";
+import * as $15 from "./routes/island_siblings.tsx";
 import * as $$0 from "./islands/BooleanButton.tsx";
 import * as $$1 from "./islands/Counter.tsx";
 import * as $$2 from "./islands/FragmentIsland.tsx";
@@ -25,6 +27,7 @@ import * as $$5 from "./islands/IslandConditional.tsx";
 import * as $$6 from "./islands/IslandFn.tsx";
 import * as $$7 from "./islands/IslandInsideIsland.tsx";
 import * as $$8 from "./islands/IslandWithProps.tsx";
+import * as $$9 from "./islands/PassThrough.tsx";
 
 const manifest = {
   routes: {
@@ -35,13 +38,15 @@ const manifest = {
     "./routes/island_fn_child.tsx": $4,
     "./routes/island_in_island.tsx": $5,
     "./routes/island_in_island_definition.tsx": $6,
-    "./routes/island_jsx_child.tsx": $7,
-    "./routes/island_jsx_children.tsx": $8,
-    "./routes/island_jsx_island_jsx.tsx": $9,
-    "./routes/island_jsx_text.tsx": $10,
-    "./routes/island_nested_props.tsx": $11,
-    "./routes/island_order.tsx": $12,
-    "./routes/island_siblings.tsx": $13,
+    "./routes/island_invalid_children.tsx": $7,
+    "./routes/island_invalid_children_fn.tsx": $8,
+    "./routes/island_jsx_child.tsx": $9,
+    "./routes/island_jsx_children.tsx": $10,
+    "./routes/island_jsx_island_jsx.tsx": $11,
+    "./routes/island_jsx_text.tsx": $12,
+    "./routes/island_nested_props.tsx": $13,
+    "./routes/island_order.tsx": $14,
+    "./routes/island_siblings.tsx": $15,
   },
   islands: {
     "./islands/BooleanButton.tsx": $$0,
@@ -53,6 +58,7 @@ const manifest = {
     "./islands/IslandFn.tsx": $$6,
     "./islands/IslandInsideIsland.tsx": $$7,
     "./islands/IslandWithProps.tsx": $$8,
+    "./islands/PassThrough.tsx": $$9,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/fixture_island_nesting/islands/PassThrough.tsx
+++ b/tests/fixture_island_nesting/islands/PassThrough.tsx
@@ -1,0 +1,5 @@
+import { ComponentChildren } from "preact";
+
+export function PassThrough(props: { children: ComponentChildren }) {
+  return <div>{props.children}</div>;
+}

--- a/tests/fixture_island_nesting/routes/island_invalid_children.tsx
+++ b/tests/fixture_island_nesting/routes/island_invalid_children.tsx
@@ -1,0 +1,9 @@
+import { PassThrough } from "../islands/PassThrough.tsx";
+
+export default function Page() {
+  return (
+    <div id="page">
+      <PassThrough>{{ foo: 123 }}</PassThrough>
+    </div>
+  );
+}

--- a/tests/fixture_island_nesting/routes/island_invalid_children_fn.tsx
+++ b/tests/fixture_island_nesting/routes/island_invalid_children_fn.tsx
@@ -1,0 +1,9 @@
+import { PassThrough } from "../islands/PassThrough.tsx";
+
+export default function Page() {
+  return (
+    <div id="page">
+      <PassThrough>{() => {}}</PassThrough>
+    </div>
+  );
+}

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -6,8 +6,12 @@ import {
   Page,
 } from "./deps.ts";
 import {
+  assertSelector,
+  assertTextMatch,
   clickWhenListenerReady,
+  fetchHtml,
   waitForText,
+  withFresh,
   withPageName,
 } from "./test_utils.ts";
 
@@ -558,4 +562,21 @@ Deno.test({
 
   sanitizeOps: false,
   sanitizeResources: false,
+});
+
+Deno.test("throws when passing non-jsx children to an island", async () => {
+  await withFresh(
+    "./tests/fixture_island_nesting/dev.ts",
+    async (address) => {
+      const doc = await fetchHtml(`${address}/island_invalid_children`);
+
+      assertSelector(doc, ".frsh-error-page");
+      assertTextMatch(doc, "pre", /Invalid JSX child passed to island/);
+
+      const doc2 = await fetchHtml(`${address}/island_invalid_children_fn`);
+
+      assertSelector(doc2, ".frsh-error-page");
+      assertTextMatch(doc2, "pre", /Invalid JSX child passed to island/);
+    },
+  );
 });

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -66,6 +66,23 @@ export function assertTextMany(
   }
 }
 
+export function assertTextMatch(
+  doc: Document,
+  selector: string,
+  regex: RegExp,
+) {
+  const texts = Array.from(doc.querySelectorAll(selector)).map((el) =>
+    el.textContent
+  ).filter(Boolean) as string[];
+
+  if (!texts.some((text) => regex.test(text))) {
+    const html = "\n\n" + prettyDom(doc);
+    throw new Error(
+      `Regex ${regex} did not match any text elements in HTML.\n\n${html}`,
+    );
+  }
+}
+
 export const VOID_ELEMENTS =
   /^(?:area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)$/;
 function prettyDom(doc: Document) {


### PR DESCRIPTION
In #1674 a reproduction was posted where a json object was passed to an island instead of an expected JSX element.

```jsx
<Island>{{ foo: 123 }}</Island>
```

Whilst this is technically possible in Preact, _if_ the receiving component knows how to deal with that, it's not something that's encouraged. It breaks the compositional nature of components and leads to difficult to understand errors.

Instead users should pass data via any other prop where the already existing serialization mechanism we have in Fresh will kick in. The `children` prop is reserved for JSX nodes only.

All this PR does, is throw an error when it detects that the user is trying to pass something invalid via `children` to an island