### PR TITLE
chore: fix update check tests downloading deps

### DIFF
--- a/tests/cli_update_check_test.ts
+++ b/tests/cli_update_check_test.ts
@@ -18,7 +18,7 @@ Deno.test({
       args: ["run", "-A", "./tests/fixture_update_check/mod.ts"],
       env: {
         CI: "false",
-        HOME: tmpDirName,
+        TEST_HOME: tmpDirName,
       },
     }).output();
 
@@ -45,7 +45,7 @@ Deno.test({
           args: ["run", "-A", "./tests/fixture_update_check/mod.ts"],
           env: {
             [env]: "true",
-            HOME: tmpDirName,
+            TEST_HOME: tmpDirName,
             LATEST_VERSION: "1.30.0",
           },
         }).output();
@@ -79,7 +79,7 @@ Deno.test({
       args: ["run", "-A", "./tests/fixture_update_check/mod.ts"],
       env: {
         CI: "false",
-        HOME: tmpDirName,
+        TEST_HOME: tmpDirName,
         LATEST_VERSION: "999.999.0",
       },
     }).output();
@@ -114,7 +114,7 @@ Deno.test({
         env: {
           CI: "false",
           UPDATE_INTERVAL: "100000",
-          HOME: tmpDirName,
+          TEST_HOME: tmpDirName,
           LATEST_VERSION: "1.30.0",
         },
       }).output();
@@ -129,7 +129,7 @@ Deno.test({
         env: {
           CI: "false",
           UPDATE_INTERVAL: "100000",
-          HOME: tmpDirName,
+          TEST_HOME: tmpDirName,
           LATEST_VERSION: "1.30.0",
         },
       }).output();
@@ -144,7 +144,7 @@ Deno.test({
         env: {
           CI: "false",
           UPDATE_INTERVAL: "1 ",
-          HOME: tmpDirName,
+          TEST_HOME: tmpDirName,
           LATEST_VERSION: "1.30.0",
         },
       }).output();
@@ -176,7 +176,7 @@ Deno.test({
     const out = await new Deno.Command(Deno.execPath(), {
       args: ["run", "-A", "./tests/fixture_update_check/mod.ts"],
       env: {
-        HOME: tmpDirName,
+        TEST_HOME: tmpDirName,
         LATEST_VERSION: versions[0],
       },
     }).output();
@@ -208,7 +208,7 @@ Deno.test({
     const out = await new Deno.Command(Deno.execPath(), {
       args: ["run", "-A", "./tests/fixture_update_check/mod.ts"],
       env: {
-        HOME: tmpDirName,
+        TEST_HOME: tmpDirName,
         LATEST_VERSION: versions[0],
         CURRENT_VERSION: "99999.9999.00",
       },

--- a/tests/fixture_update_check/mod.ts
+++ b/tests/fixture_update_check/mod.ts
@@ -14,7 +14,7 @@ async function getCurrentVersion() {
 const interval = +(Deno.env.get("UPDATE_INTERVAL") ?? 1000);
 await updateCheck(
   interval,
-  () => Deno.env.get("HOME")!,
+  () => Deno.env.get("TEST_HOME")!,
   getLatestVersion,
   Deno.env.has("CURRENT_VERSION") ? getCurrentVersion : undefined,
 );


### PR DESCRIPTION
Deno looks up the cache dir via `HOME`. We replaced that with a tmp dir in our tests, which lead to all dependencies being downloaded from scratch. This PR changes that so that we use a different environment variable for our tests. That way we can reuse the existing cache which is much faster.