### PR TITLE
chore: speed up e2e tests

### DIFF
--- a/tests/build_test.ts
+++ b/tests/build_test.ts
@@ -1,10 +1,8 @@
 import * as path from "$std/path/mod.ts";
-import { puppeteer } from "./deps.ts";
 import { assert } from "$std/_util/asserts.ts";
-import { startFreshServer, waitForText } from "$fresh/tests/test_utils.ts";
+import { waitForText, withPageName } from "$fresh/tests/test_utils.ts";
 import { BuildSnapshotJson } from "$fresh/src/build/mod.ts";
 import { assertStringIncludes } from "$std/testing/asserts.ts";
-import { assertNotMatch } from "$std/testing/asserts.ts";
 
 Deno.test("build snapshot and restore from it", async (t) => {
   const fixture = path.join(Deno.cwd(), "tests", "fixture_build");
@@ -42,7 +40,7 @@ Deno.test("build snapshot and restore from it", async (t) => {
       await Deno.readTextFile(path.join(outDir, "snapshot.json")),
     ) as BuildSnapshotJson;
 
-    await t.step("check snapshot file", async () => {
+    await t.step("check snapshot file", () => {
       assert(
         Array.isArray(snapshot.files["island-counter_default.js"]),
         "Island output file not found in snapshot",
@@ -59,32 +57,18 @@ Deno.test("build snapshot and restore from it", async (t) => {
         Array.isArray(snapshot.files["deserializer.js"]),
         "deserializer.js output file not found in snapshot",
       );
-
-      // Should not include `preact/debug`
-      const mainJs = await Deno.readTextFile(path.join(outDir, "main.js"));
-      assertNotMatch(mainJs, /Undefined parent passed to render()/);
     });
 
     await t.step("restore from snapshot", async () => {
-      const { lines, serverProcess, address, output } = await startFreshServer({
-        args: [
-          "run",
-          "-A",
-          path.join(fixture, "./main.ts"),
-        ],
-      });
+      await withPageName(
+        path.join(fixture, "./main.ts"),
+        async (page, address, output) => {
+          // Check if restore snapshot message was printed
+          assert(
+            output.find((line) => line.includes("Using snapshot found at")),
+            "Did not print restoring from snapshot line",
+          );
 
-      // Check if restore snapshot message was printed
-      assert(
-        output.find((line) => line.includes("Using snapshot found at")),
-        "Did not print restoring from snapshot line",
-      );
-
-      try {
-        const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
-
-        try {
-          const page = await browser.newPage();
           await page.goto(address);
 
           await page.waitForSelector("button:not([disabled])");
@@ -108,36 +92,8 @@ Deno.test("build snapshot and restore from it", async (t) => {
           for (let i = 0; i < assetUrls.length; i++) {
             assertStringIncludes(assetUrls[i], snapshot.build_id);
           }
-        } finally {
-          await browser.close();
-        }
-      } finally {
-        await lines.cancel();
-        serverProcess.kill("SIGTERM");
-        await serverProcess.status;
-      }
-    });
-
-    await t.step("should not restore from snapshot in dev mode", async () => {
-      const { lines, serverProcess, output } = await startFreshServer({
-        args: [
-          "run",
-          "-A",
-          path.join(fixture, "./dev.ts"),
-        ],
-      });
-
-      try {
-        // Check that restore snapshot message was NOT printed
-        assert(
-          !output.find((line) => line.includes("Using snapshot found at")),
-          "Restoring from snapshot message should not appear in dev mode",
-        );
-      } finally {
-        await lines.cancel();
-        serverProcess.kill("SIGTERM");
-        await serverProcess.status;
-      }
+        },
+      );
     });
   } finally {
     await Deno.remove(path.join(fixture, "_fresh"), { recursive: true });

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -29,9 +29,7 @@ Deno.test({
         await waitForText(page, `#${counterId} > p`, String(originalValue + 1));
       }
 
-      await page.goto(`${address}/islands`, {
-        waitUntil: "networkidle2",
-      });
+      await page.goto(`${address}/islands`);
 
       await t.step("Ensure 5 islands on 1 page are revived", async () => {
         await counterTest("counter1", 3);
@@ -76,9 +74,7 @@ Deno.test({
         await waitForText(page, `#${counterId} > p`, String(originalValue + 1));
       }
 
-      await page.goto(`${address}/islands/multiple_island_exports`, {
-        waitUntil: "networkidle2",
-      });
+      await page.goto(`${address}/islands/multiple_island_exports`);
 
       await t.step("Ensure 3 islands on 1 page are revived", async () => {
         await counterTest("counter0", 4);
@@ -105,9 +101,7 @@ Deno.test({
         assert(false, "There is XSS");
       });
 
-      await page.goto(`${address}/evil`, {
-        waitUntil: "networkidle2",
-      });
+      await page.goto(`${address}/evil`);
 
       await t.step("prevent XSS on Island", async () => {
         const bodyElem = await page.waitForSelector(`body`);
@@ -131,9 +125,7 @@ Deno.test({
 
   async fn(_t) {
     await withPage(async (page, address) => {
-      await page.goto(`${address}/islands/root_fragment`, {
-        waitUntil: "networkidle2",
-      });
+      await page.goto(`${address}/islands/root_fragment`);
 
       const clickableSelector = "#root-fragment-click-me";
 
@@ -157,9 +149,6 @@ Deno.test({
     await withPage(async (page, address) => {
       await page.goto(
         `${address}/islands/root_fragment_conditional_first`,
-        {
-          waitUntil: "networkidle2",
-        },
       );
 
       const clickableSelector = "#root-fragment-conditional-first-click-me";
@@ -185,9 +174,7 @@ Deno.test({
 
   async fn(_t) {
     await withPage(async (page, address) => {
-      await page.goto(`${address}/islands/returning_null`, {
-        waitUntil: "networkidle2",
-      });
+      await page.goto(`${address}/islands/returning_null`);
 
       await page.waitForSelector(".added-by-use-effect");
     });
@@ -203,11 +190,11 @@ Deno.test({
   async fn(_t) {
     await withPageName("./tests/fixture_npm/main.ts", async (page, address) => {
       await page.setJavaScriptEnabled(false);
-      await page.goto(address, { waitUntil: "networkidle2" });
+      await page.goto(address);
       assert(await page.waitForSelector("#server-true"));
 
       await page.setJavaScriptEnabled(true);
-      await page.reload({ waitUntil: "networkidle2" });
+      await page.reload();
       assert(await page.waitForSelector("#browser-true"));
     });
   },
@@ -223,9 +210,7 @@ Deno.test({
     await withPageName(
       "./tests/fixture_preact_rts_v5/main.ts",
       async (page, address) => {
-        await page.goto(address, {
-          waitUntil: "networkidle2",
-        });
+        await page.goto(address);
         await page.waitForSelector("#foo");
         await waitForText(page, "#foo", "it works");
       },
@@ -243,9 +228,7 @@ Deno.test({
     await withPageName(
       "./tests/fixture_island_nesting/main.ts",
       async (page, address) => {
-        await page.goto(`${address}/island_jsx_child`, {
-          waitUntil: "networkidle2",
-        });
+        await page.goto(`${address}/island_jsx_child`);
         await page.waitForSelector(".island");
         await waitForText(page, ".island", "it works");
       },
@@ -263,9 +246,7 @@ Deno.test({
     await withPageName(
       "./tests/fixture_island_nesting/main.ts",
       async (page, address) => {
-        await page.goto(`${address}/island_jsx_children`, {
-          waitUntil: "networkidle2",
-        });
+        await page.goto(`${address}/island_jsx_children`);
         await page.waitForSelector(".island");
 
         await delay(100);
@@ -286,9 +267,7 @@ Deno.test({
     await withPageName(
       "./tests/fixture_island_nesting/main.ts",
       async (page, address) => {
-        await page.goto(`${address}/island_jsx_text`, {
-          waitUntil: "networkidle2",
-        });
+        await page.goto(`${address}/island_jsx_text`);
         await page.waitForSelector(".island");
 
         await delay(100);
@@ -309,9 +288,7 @@ Deno.test({
     await withPageName(
       "./tests/fixture_island_nesting/main.ts",
       async (page, address) => {
-        await page.goto(`${address}/island_in_island`, {
-          waitUntil: "networkidle2",
-        });
+        await page.goto(`${address}/island_in_island`);
         await page.waitForSelector(".island");
         await waitForText(page, ".island .island p", "it works");
       },
@@ -329,9 +306,7 @@ Deno.test({
     await withPageName(
       "./tests/fixture_island_nesting/main.ts",
       async (page, address) => {
-        await page.goto(`${address}/island_in_island_definition`, {
-          waitUntil: "networkidle2",
-        });
+        await page.goto(`${address}/island_in_island_definition`);
         await page.waitForSelector(".island");
 
         await waitForText(page, ".island .island p", "it works");
@@ -355,9 +330,7 @@ Deno.test({
     await withPageName(
       "./tests/fixture_island_nesting/main.ts",
       async (page, address) => {
-        await page.goto(`${address}/island_jsx_island_jsx`, {
-          waitUntil: "networkidle2",
-        });
+        await page.goto(`${address}/island_jsx_island_jsx`);
         await page.waitForSelector(".island");
 
         await waitForText(
@@ -380,9 +353,7 @@ Deno.test({
     await withPageName(
       "./tests/fixture_island_nesting/main.ts",
       async (page, address) => {
-        await page.goto(`${address}/island_siblings`, {
-          waitUntil: "networkidle2",
-        });
+        await page.goto(`${address}/island_siblings`);
         await page.waitForSelector(".island");
 
         await waitForText(page, ".island .a", "it works");
@@ -402,9 +373,7 @@ Deno.test({
     await withPageName(
       "./tests/fixture_island_nesting/main.ts",
       async (page, address) => {
-        await page.goto(`${address}/island_conditional`, {
-          waitUntil: "networkidle2",
-        });
+        await page.goto(`${address}/island_conditional`);
         await page.waitForSelector("button");
 
         await delay(100);
@@ -429,9 +398,7 @@ Deno.test({
     await withPageName(
       "./tests/fixture_island_nesting/main.ts",
       async (page, address) => {
-        await page.goto(`${address}/island_nested_props`, {
-          waitUntil: "networkidle2",
-        });
+        await page.goto(`${address}/island_nested_props`);
         await page.waitForSelector(".island");
 
         await waitForText(page, ".island .island p", "it works");

--- a/tests/islands_wasm_test.ts
+++ b/tests/islands_wasm_test.ts
@@ -27,9 +27,7 @@ Deno.test({
       assert(value === `${originalValue + 1}`, `${counterId} click`);
     }
 
-    await page.goto(`${address}/islands`, {
-      waitUntil: "networkidle2",
-    });
+    await page.goto(`${address}/islands`);
 
     await t.step("Ensure 3 islands on 1 page are revived", async () => {
       await counterTest("counter1", 3);

--- a/tests/islands_wasm_test.ts
+++ b/tests/islands_wasm_test.ts
@@ -1,44 +1,34 @@
-import { assert, delay, puppeteer } from "./deps.ts";
-import { startFreshServer } from "./test_utils.ts";
+import { assert, delay } from "./deps.ts";
+import { withPageName } from "./test_utils.ts";
 
 Deno.test({
   name: "wasm island tests",
   ignore: Deno.build.os === "windows",
   async fn(t) {
-    // Preparation
-    const { lines, serverProcess, address } = await startFreshServer({
-      args: ["run", "-A", "./tests/fixture/main_wasm.ts"],
-    });
+    await withPageName(
+      "./tests/fixture/main_wasm.ts",
+      async (page, address) => {
+        async function counterTest(counterId: string, originalValue: number) {
+          const pElem = await page.waitForSelector(`#${counterId} > p`);
+          let value = await pElem?.evaluate((el) => el.textContent);
+          assert(value === `${originalValue}`, `${counterId} first value`);
 
-    await delay(100);
+          const buttonPlus = await page.$(`#b-${counterId}`);
+          await buttonPlus?.click();
+          await delay(100);
+          value = await pElem?.evaluate((el) => el.textContent);
+          assert(value === `${originalValue + 1}`, `${counterId} click`);
+        }
 
-    const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
-    const page = await browser.newPage();
+        await page.goto(`${address}/islands`);
 
-    async function counterTest(counterId: string, originalValue: number) {
-      const pElem = await page.waitForSelector(`#${counterId} > p`);
-      let value = await pElem?.evaluate((el) => el.textContent);
-      assert(value === `${originalValue}`, `${counterId} first value`);
-
-      const buttonPlus = await page.$(`#b-${counterId}`);
-      await buttonPlus?.click();
-      await delay(100);
-      value = await pElem?.evaluate((el) => el.textContent);
-      assert(value === `${originalValue + 1}`, `${counterId} click`);
-    }
-
-    await page.goto(`${address}/islands`);
-
-    await t.step("Ensure 3 islands on 1 page are revived", async () => {
-      await counterTest("counter1", 3);
-      await counterTest("counter2", 10);
-      await counterTest("kebab-case-file-counter", 5);
-    });
-
-    await browser.close();
-
-    await lines.cancel();
-    serverProcess.kill("SIGTERM");
+        await t.step("Ensure 3 islands on 1 page are revived", async () => {
+          await counterTest("counter1", 3);
+          await counterTest("counter2", 10);
+          await counterTest("kebab-case-file-counter", 5);
+        });
+      },
+    );
   },
   sanitizeOps: false,
   sanitizeResources: false,

--- a/tests/layouts_test.ts
+++ b/tests/layouts_test.ts
@@ -184,9 +184,7 @@ Deno.test({
           );
         }
 
-        await page.goto(`${address}/dynamic/acme-corp`, {
-          waitUntil: "networkidle2",
-        });
+        await page.goto(`${address}/dynamic/acme-corp`);
 
         await t.step("Ensure 1 island on 1 page are revived", async () => {
           await counterTest("counter", 3);

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -726,9 +726,7 @@ Deno.test("jsx pragma works", {
   const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
   const page = await browser.newPage();
 
-  await page.goto(address, {
-    waitUntil: "networkidle2",
-  });
+  await page.goto(address);
 
   await t.step("island is revived", async () => {
     await page.waitForSelector("#csr");
@@ -761,9 +759,7 @@ Deno.test("preact/debug is active in dev mode", {
   const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
   const page = await browser.newPage();
 
-  await page.goto(address, {
-    waitUntil: "networkidle2",
-  });
+  await page.goto(address);
 
   await t.step("error page is shown with error message", async () => {
     const el = await page.waitForSelector(".frsh-error-page");

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -5,7 +5,6 @@ import {
   assertMatch,
   assertStringIncludes,
   delay,
-  puppeteer,
   retry,
 } from "./deps.ts";
 import manifest from "./fixture/fresh.gen.ts";

--- a/tests/plugin_test.ts
+++ b/tests/plugin_test.ts
@@ -107,9 +107,7 @@ Deno.test({
     const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
     const page = await browser.newPage();
 
-    await page.goto(`${address}/with-island`, {
-      waitUntil: "networkidle2",
-    });
+    await page.goto(`${address}/with-island`);
 
     await t.step("island is revived", async () => {
       await page.waitForSelector("#csr");

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -273,6 +273,24 @@ export async function waitForText(
   selector: string,
   text: string,
 ) {
+  const logs: string[] = [];
+  page
+    .on(
+      "console",
+      (message) =>
+        logs.push(
+          `${message.type().substr(0, 3).toUpperCase()} ${message.text()}`,
+        ),
+    )
+    .on("pageerror", ({ message }) => logs.push(message))
+    .on(
+      "response",
+      (response) => logs.push(`${response.status()} ${response.url()}`),
+    )
+    .on(
+      "requestfailed",
+      (request) => logs.push(`${request.failure().errorText} ${request.url()}`),
+    );
   try {
     await page.waitForSelector(selector);
     await page.waitForFunction(
@@ -288,6 +306,10 @@ export async function waitForText(
       `Could not find text "${text}" on selector "${selector}" in document.`,
     );
     await printPage(page);
+
+    console.log(
+      `The page printed the following messages: \n\n${logs.join("\n")}`,
+    );
     throw err;
   }
 }

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -1,7 +1,6 @@
 import { colors } from "$fresh/src/server/deps.ts";
 import {
   assertEquals,
-  delay,
   DOMParser,
   HTMLElement,
   HTMLMetaElement,

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -183,14 +183,14 @@ globalThis.addEventListener("beforeunload", async () => {
 
 export async function withPageName(
   name: string,
-  fn: (page: Page, address: string) => Promise<void>,
+  fn: (page: Page, address: string, output: string[]) => Promise<void>,
 ) {
-  const { lines, serverProcess, address } = await startFreshServer({
+  const { lines, serverProcess, address, output } = await startFreshServer({
     args: ["run", "-A", name],
   });
 
   try {
-    await fn(PAGE, address);
+    await fn(PAGE, address, output);
   } finally {
     await lines.cancel();
 

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -251,20 +251,40 @@ export async function clickWhenListenerReady(page: Page, selector: string) {
   await page.click(selector);
 }
 
+async function printPage(page: Page) {
+  let html;
+  try {
+    html = await page.content();
+    const doc = parseHtml(html);
+    // deno-lint-ignore no-explicit-any
+    console.log(prettyDom(doc as any));
+  } catch {
+    // Check if we at least can show the page content as texrt
+    if (typeof html === "string") {
+      console.log(html);
+    }
+  }
+}
+
 export async function waitForText(
   page: Page,
   selector: string,
   text: string,
 ) {
-  await page.waitForSelector(selector);
-  await page.waitForFunction(
-    (sel, value) => {
-      return document.querySelector(sel)!.textContent === value;
-    },
-    { timeout: 2000 },
-    selector,
-    String(text),
-  );
+  try {
+    await page.waitForSelector(selector);
+    await page.waitForFunction(
+      (sel, value) => {
+        return document.querySelector(sel)!.textContent === value;
+      },
+      { timeout: 2000 },
+      selector,
+      String(text),
+    );
+  } catch (err) {
+    await printPage(page);
+    throw err;
+  }
 }
 
 async function spawnServer(

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -175,6 +175,13 @@ export async function withFresh(
   }
 }
 
+const BROWSER = await puppeteer.launch({ args: ["--no-sandbox"] });
+const PAGE = await BROWSER.newPage();
+globalThis.addEventListener("beforeunload", async () => {
+  await PAGE.close();
+  await BROWSER.close();
+});
+
 export async function withPageName(
   name: string,
   fn: (page: Page, address: string) => Promise<void>,
@@ -184,15 +191,7 @@ export async function withPageName(
   });
 
   try {
-    await delay(100);
-    const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
-
-    try {
-      const page = await browser.newPage();
-      await fn(page, address);
-    } finally {
-      await browser.close();
-    }
+    await fn(PAGE, address);
   } finally {
     await lines.cancel();
 

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -13,6 +13,8 @@ export function parseHtml(input: string) {
   return new DOMParser().parseFromString(input, "text/html");
 }
 
+const isCI = Deno.env.has("CI");
+
 export async function startFreshServer(options: Deno.CommandOptions) {
   const { serverProcess, lines, address, output } = await spawnServer(options);
 
@@ -277,7 +279,7 @@ export async function waitForText(
       (sel, value) => {
         return document.querySelector(sel)!.textContent === value;
       },
-      { timeout: 2000 },
+      { timeout: isCI ? 10000 : 2000 },
       selector,
       String(text),
     );

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -175,9 +175,7 @@ export async function withFresh(
 }
 
 const BROWSER = await puppeteer.launch({ args: ["--no-sandbox"] });
-const PAGE = await BROWSER.newPage();
 globalThis.addEventListener("beforeunload", async () => {
-  await PAGE.close();
   await BROWSER.close();
 });
 
@@ -189,9 +187,11 @@ export async function withPageName(
     args: ["run", "-A", name],
   });
 
+  const page = await BROWSER.newPage();
   try {
-    await fn(PAGE, address, output);
+    await fn(page, address, output);
   } finally {
+    await page.close();
     await lines.cancel();
 
     serverProcess.kill("SIGTERM");

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -282,6 +282,9 @@ export async function waitForText(
       String(text),
     );
   } catch (err) {
+    console.log(
+      `Could not find text "${text}" on selector "${selector}" in document.`,
+    );
     await printPage(page);
     throw err;
   }

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -297,7 +297,7 @@ export async function waitForText(
       (sel, value) => {
         return document.querySelector(sel)!.textContent === value;
       },
-      { timeout: isCI ? 10000 : 2000 },
+      { timeout: isCI ? 30000 : 2000 },
       selector,
       String(text),
     );

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -1,4 +1,5 @@
 import { colors } from "$fresh/src/server/deps.ts";
+import { HTTPRequest } from "https://deno.land/x/puppeteer@16.2.0/mod.ts";
 import {
   assertEquals,
   DOMParser,
@@ -207,8 +208,16 @@ export async function withPageName(
     )
     .on(
       "requestfailed",
-      (request) => logs.push(`${request.failure().errorText} ${request.url()}`),
+      (request: HTTPRequest) => {
+        console.log(
+          request.method(),
+          request.url(),
+          request.response()?.status,
+        );
+        logs.push(`${request.failure()?.errorText} ${request.url()}`);
+      },
     );
+
   try {
     await fn(page, address, output);
   } catch (err) {


### PR DESCRIPTION
- Use a shared browser instance 
- Don't wait for `networkidle2` which is unnecessary.