### PR TITLE
Add `NotFoundData` generic to `HandlerContext`

### DIFF
--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -118,14 +118,17 @@ export type ServeHandler = (
   info: ServeHandlerInfo,
 ) => Response | Promise<Response>;
 
-export interface HandlerContext<Data = unknown, State = Record<string, unknown>>
-  extends ServeHandlerInfo {
+export interface HandlerContext<
+  Data = unknown,
+  State = Record<string, unknown>,
+  NotFoundData = Data,
+> extends ServeHandlerInfo {
   params: Record<string, string>;
   render: (
     data?: Data,
     options?: RenderOptions,
   ) => Response | Promise<Response>;
-  renderNotFound: (data?: Data) => Response | Promise<Response>;
+  renderNotFound: (data?: NotFoundData) => Response | Promise<Response>;
   state: State;
 }
 


### PR DESCRIPTION
The type of data passed to `renderNotFound()` may need to be different to the type of data passed to `render()`.

`NotFoundData` defaults to `Data`, so this should not affect any existing usages of `HandlerContext`.