### PR TITLE
docs: remove unneeded `Counter` import from Head page

### DIFF
--- a/docs/latest/examples/modifying-the-head.md
+++ b/docs/latest/examples/modifying-the-head.md
@@ -15,7 +15,6 @@ the web page. Some uses include:
 
 ```tsx routes/index.tsx
 import { Head } from "$fresh/runtime.ts";
-import Counter from "../islands/Counter.tsx";
 
 export default function Home() {
   return (


### PR DESCRIPTION
The `Counter` import isn't used in the example and likely copypasta?