### PR TITLE
feat: add nonce for inline scripts

### DIFF
--- a/src/server/rendering/fresh_tags.tsx
+++ b/src/server/rendering/fresh_tags.tsx
@@ -25,8 +25,6 @@ export function renderFreshTags(
     ];
   }
 
-  console.log(opts.csp, renderState.getNonce());
-
   const moduleScripts: [string, string][] = [];
   for (const url of opts.imports) {
     moduleScripts.push([url, renderState.getNonce()]);

--- a/src/server/rendering/preact_hooks.ts
+++ b/src/server/rendering/preact_hooks.ts
@@ -151,6 +151,13 @@ options.vnode = (vnode) => {
 };
 
 options.__b = (vnode: VNode<Record<string, unknown>>) => {
+  // Add CSP nonce to inline script tags
+  if (typeof vnode.type === "string" && vnode.type === "script") {
+    if (!vnode.props.nonce) {
+      vnode.props.nonce = current!.getNonce();
+    }
+  }
+
   if (
     current && current.renderingUserTemplate
   ) {

--- a/src/server/rendering/state.ts
+++ b/src/server/rendering/state.ts
@@ -35,6 +35,7 @@ export class RenderState {
   // Preact state
   ownerStack: VNode[] = [];
   owners = new Map<VNode, VNode>();
+  #nonce = "";
 
   constructor(
     routeOptions: RenderStateRouteOptions,
@@ -48,6 +49,13 @@ export class RenderState {
     this.componentStack = componentStack;
 
     if (error) this.routeOptions.error = error;
+  }
+
+  getNonce(): string {
+    if (this.#nonce === "") {
+      this.#nonce = crypto.randomUUID().replace(/-/g, "");
+    }
+    return this.#nonce;
   }
 
   clearTmpState() {

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -46,28 +46,29 @@ import * as $40 from "./routes/middleware-error-handler/index.tsx";
 import * as $41 from "./routes/middleware_root.ts";
 import * as $42 from "./routes/movies/[foo].json.ts";
 import * as $43 from "./routes/movies/[foo]@[bar].ts";
-import * as $44 from "./routes/not_found.ts";
-import * as $45 from "./routes/params.tsx";
-import * as $46 from "./routes/preact/boolean_attrs.tsx";
-import * as $47 from "./routes/props/[id].tsx";
-import * as $48 from "./routes/route-groups-islands/index.tsx";
-import * as $49 from "./routes/route-groups/(bar)/(baz)/_layout.tsx";
-import * as $50 from "./routes/route-groups/(bar)/(baz)/baz.tsx";
-import * as $51 from "./routes/route-groups/(bar)/_layout.tsx";
-import * as $52 from "./routes/route-groups/(bar)/bar.tsx";
-import * as $53 from "./routes/route-groups/(bar)/boof/index.tsx";
-import * as $54 from "./routes/route-groups/(foo)/_layout.tsx";
-import * as $55 from "./routes/route-groups/(foo)/index.tsx";
-import * as $56 from "./routes/signal_shared.tsx";
-import * as $57 from "./routes/state-in-props/_middleware.ts";
-import * as $58 from "./routes/state-in-props/index.tsx";
-import * as $59 from "./routes/state-middleware/_middleware.ts";
-import * as $60 from "./routes/state-middleware/foo/_middleware.ts";
-import * as $61 from "./routes/state-middleware/foo/index.tsx";
-import * as $62 from "./routes/static.tsx";
-import * as $63 from "./routes/status_overwrite.tsx";
-import * as $64 from "./routes/umlaut-äöüß.tsx";
-import * as $65 from "./routes/wildcard.tsx";
+import * as $44 from "./routes/nonce_inline.tsx";
+import * as $45 from "./routes/not_found.ts";
+import * as $46 from "./routes/params.tsx";
+import * as $47 from "./routes/preact/boolean_attrs.tsx";
+import * as $48 from "./routes/props/[id].tsx";
+import * as $49 from "./routes/route-groups-islands/index.tsx";
+import * as $50 from "./routes/route-groups/(bar)/(baz)/_layout.tsx";
+import * as $51 from "./routes/route-groups/(bar)/(baz)/baz.tsx";
+import * as $52 from "./routes/route-groups/(bar)/_layout.tsx";
+import * as $53 from "./routes/route-groups/(bar)/bar.tsx";
+import * as $54 from "./routes/route-groups/(bar)/boof/index.tsx";
+import * as $55 from "./routes/route-groups/(foo)/_layout.tsx";
+import * as $56 from "./routes/route-groups/(foo)/index.tsx";
+import * as $57 from "./routes/signal_shared.tsx";
+import * as $58 from "./routes/state-in-props/_middleware.ts";
+import * as $59 from "./routes/state-in-props/index.tsx";
+import * as $60 from "./routes/state-middleware/_middleware.ts";
+import * as $61 from "./routes/state-middleware/foo/_middleware.ts";
+import * as $62 from "./routes/state-middleware/foo/index.tsx";
+import * as $63 from "./routes/static.tsx";
+import * as $64 from "./routes/status_overwrite.tsx";
+import * as $65 from "./routes/umlaut-äöüß.tsx";
+import * as $66 from "./routes/wildcard.tsx";
 import * as $$0 from "./islands/Counter.tsx";
 import * as $$1 from "./islands/FormIsland.tsx";
 import * as $$2 from "./islands/Greeter.tsx";
@@ -129,28 +130,29 @@ const manifest = {
     "./routes/middleware_root.ts": $41,
     "./routes/movies/[foo].json.ts": $42,
     "./routes/movies/[foo]@[bar].ts": $43,
-    "./routes/not_found.ts": $44,
-    "./routes/params.tsx": $45,
-    "./routes/preact/boolean_attrs.tsx": $46,
-    "./routes/props/[id].tsx": $47,
-    "./routes/route-groups-islands/index.tsx": $48,
-    "./routes/route-groups/(bar)/(baz)/_layout.tsx": $49,
-    "./routes/route-groups/(bar)/(baz)/baz.tsx": $50,
-    "./routes/route-groups/(bar)/_layout.tsx": $51,
-    "./routes/route-groups/(bar)/bar.tsx": $52,
-    "./routes/route-groups/(bar)/boof/index.tsx": $53,
-    "./routes/route-groups/(foo)/_layout.tsx": $54,
-    "./routes/route-groups/(foo)/index.tsx": $55,
-    "./routes/signal_shared.tsx": $56,
-    "./routes/state-in-props/_middleware.ts": $57,
-    "./routes/state-in-props/index.tsx": $58,
-    "./routes/state-middleware/_middleware.ts": $59,
-    "./routes/state-middleware/foo/_middleware.ts": $60,
-    "./routes/state-middleware/foo/index.tsx": $61,
-    "./routes/static.tsx": $62,
-    "./routes/status_overwrite.tsx": $63,
-    "./routes/umlaut-äöüß.tsx": $64,
-    "./routes/wildcard.tsx": $65,
+    "./routes/nonce_inline.tsx": $44,
+    "./routes/not_found.ts": $45,
+    "./routes/params.tsx": $46,
+    "./routes/preact/boolean_attrs.tsx": $47,
+    "./routes/props/[id].tsx": $48,
+    "./routes/route-groups-islands/index.tsx": $49,
+    "./routes/route-groups/(bar)/(baz)/_layout.tsx": $50,
+    "./routes/route-groups/(bar)/(baz)/baz.tsx": $51,
+    "./routes/route-groups/(bar)/_layout.tsx": $52,
+    "./routes/route-groups/(bar)/bar.tsx": $53,
+    "./routes/route-groups/(bar)/boof/index.tsx": $54,
+    "./routes/route-groups/(foo)/_layout.tsx": $55,
+    "./routes/route-groups/(foo)/index.tsx": $56,
+    "./routes/signal_shared.tsx": $57,
+    "./routes/state-in-props/_middleware.ts": $58,
+    "./routes/state-in-props/index.tsx": $59,
+    "./routes/state-middleware/_middleware.ts": $60,
+    "./routes/state-middleware/foo/_middleware.ts": $61,
+    "./routes/state-middleware/foo/index.tsx": $62,
+    "./routes/static.tsx": $63,
+    "./routes/status_overwrite.tsx": $64,
+    "./routes/umlaut-äöüß.tsx": $65,
+    "./routes/wildcard.tsx": $66,
   },
   islands: {
     "./islands/Counter.tsx": $$0,

--- a/tests/fixture/routes/nonce_inline.tsx
+++ b/tests/fixture/routes/nonce_inline.tsx
@@ -1,0 +1,15 @@
+import { useSignal } from "@preact/signals";
+import Counter from "../islands/Counter.tsx";
+
+export default function Page() {
+  const sig = useSignal(0);
+  return (
+    <div>
+      <script
+        id="inline-script"
+        dangerouslySetInnerHTML={{ __html: "console.log('hey')" }}
+      />
+      <Counter id="foo" count={sig} />
+    </div>
+  );
+}

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -948,7 +948,7 @@ Deno.test("Generate a single nonce value per page", async () => {
   });
 });
 
-Deno.test("Addes nonce to inline scripts", async () => {
+Deno.test("Adds nonce to inline scripts", async () => {
   await withFresh("./tests/fixture/main.ts", async (address) => {
     const doc = await fetchHtml(`${address}/nonce_inline`);
 

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -948,6 +948,20 @@ Deno.test("Generate a single nonce value per page", async () => {
   });
 });
 
+Deno.test("Addes nonce to inline scripts", async () => {
+  await withFresh("./tests/fixture/main.ts", async (address) => {
+    const doc = await fetchHtml(`${address}/nonce_inline`);
+
+    const stateScript = doc.querySelector("#__FRSH_STATE")!;
+    const nonce = stateScript.getAttribute("nonce")!;
+
+    const el = doc.querySelector("#inline-script")!;
+    const inlineNonce = el.getAttribute("nonce")!;
+
+    assertEquals(inlineNonce, nonce);
+  });
+});
+
 Deno.test({
   name: "support string based event handlers during SSR",
   async fn() {


### PR DESCRIPTION
This PR changes our content security handling so that we'll automatically add a `nonce` attribute when we render an inline script tag. This will make it easier to integrate Google Tag Manager and things like that.