### PR TITLE
twindv1: Enable setting tailwind theme variables in Options parameter

### DIFF
--- a/plugins/twindv1/shared.ts
+++ b/plugins/twindv1/shared.ts
@@ -1,11 +1,18 @@
 import { JSX, options as preactOptions, VNode } from "preact";
-import { setup as twSetup, Sheet, tw, TwindConfig } from "../twindv1_deps.ts";
+import {
+  BaseTheme,
+  setup as twSetup,
+  Sheet,
+  tw,
+  TwindConfig,
+} from "$fresh/plugins/twindv1_deps.ts";
 
 type PreactOptions = typeof preactOptions & { __b?: (vnode: VNode) => void };
 
 export const STYLE_ELEMENT_ID = "__FRSH_TWIND";
 
-export interface Options extends TwindConfig {
+export interface Options<Theme extends BaseTheme = BaseTheme>
+  extends TwindConfig<Theme> {
   /** The import.meta.url of the module defining these options. */
   selfURL: string;
 }
@@ -19,7 +26,10 @@ declare module "preact" {
   }
 }
 
-export function setup({ selfURL: _selfURL, ...config }: Options, sheet: Sheet) {
+export function setup<Theme extends BaseTheme = BaseTheme>(
+  { selfURL: _selfURL, ...config }: Options<Theme>,
+  sheet: Sheet,
+) {
   twSetup(config, sheet);
 
   // Hook into options._diff which is called whenever a new comparison

--- a/plugins/twindv1_deps.ts
+++ b/plugins/twindv1_deps.ts
@@ -1,1 +1,2 @@
 export * from "https://esm.sh/@twind/core@1.1.3";
+export * from "https://esm.sh/@twind/preset-tailwind@1.1.4";

--- a/plugins/twindv1_deps.ts
+++ b/plugins/twindv1_deps.ts
@@ -1,2 +1,1 @@
 export * from "https://esm.sh/@twind/core@1.1.3";
-export * from "https://esm.sh/@twind/preset-tailwind@1.1.4";


### PR DESCRIPTION
currently, the v1 plugin locks the Options to BaseTheme from @twind/core

this change aims to allow other options to be passed, for example TailwindTheme from @twind/preset-tailwind
dunno if this is desirable, but when i migrated my project from 0.16 to v1 i could not set `config.theme.fontFamily`
This should fix that issue.