### PR TITLE
feat: error if `useState` or `useReducer` is used outside of an island.

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -366,7 +366,15 @@ export class ServerContext {
           pattern: pathToPattern(baseRoute),
           url,
           name,
-          component,
+          // deno-lint-ignore no-explicit-any
+          component: (props: any) => {
+            // Show our nice error page during dev mode.
+            if (dev && props.error) {
+              return h(DefaultErrorHandler, props);
+            }
+            // deno-lint-ignore no-explicit-any
+            return h((component ?? DefaultErrorHandler) as any, props);
+          },
           handler: handler ??
             ((req, ctx) => router.defaultErrorHandler(req, ctx, ctx.error)),
           csp: Boolean(config?.csp ?? false),

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -366,15 +366,7 @@ export class ServerContext {
           pattern: pathToPattern(baseRoute),
           url,
           name,
-          // deno-lint-ignore no-explicit-any
-          component: (props: any) => {
-            // Show our nice error page during dev mode.
-            if (dev && props.error) {
-              return h(DefaultErrorHandler, props);
-            }
-            // deno-lint-ignore no-explicit-any
-            return h((component ?? DefaultErrorHandler) as any, props);
-          },
+          component,
           handler: handler ??
             ((req, ctx) => router.defaultErrorHandler(req, ctx, ctx.error)),
           csp: Boolean(config?.csp ?? false),

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -311,6 +311,9 @@ export async function render<Data>(
   }
 
   await renderAsync();
+  if (renderState.error !== null) {
+    throw renderState.error;
+  }
 
   const idx = renderState.headVNodes.findIndex((vnode) =>
     vnode !== null && typeof vnode === "object" && "type" in vnode &&

--- a/src/server/rendering/preact_hooks.ts
+++ b/src/server/rendering/preact_hooks.ts
@@ -12,7 +12,6 @@ import { assetHashingHook } from "../../runtime/utils.ts";
 import { renderToString } from "preact-render-to-string";
 import { RenderState } from "./state.ts";
 import { Island } from "../types.ts";
-import { RenderError } from "$fresh/src/server/constants.ts";
 
 // See: https://github.com/preactjs/preact/blob/7748dcb83cedd02e37b3713634e35b97b26028fd/src/internal.d.ts#L3C1-L16
 enum HookType {
@@ -346,10 +345,15 @@ options.__h = (component, idx, type) => {
     current.islandCounter === 0 &&
     !current.error
   ) {
+    const name = HookType[type];
+    const message =
+      `Hook "${name}" cannot be used outside of an island component.`;
+    const hint = type === HookType.useState
+      ? `\n\nUse the "useSignal" hook instead to share state across islands.`
+      : "";
+
     // Don't throw here because that messes up internal Preact state
-    current.error = new RenderError(
-      `Hook "${HookType[type]}" cannot be used outside of an island component.`,
-    );
+    current.error = new Error(message + hint);
   }
   oldHook?.(component, idx, type);
 };

--- a/src/server/rendering/preact_hooks.ts
+++ b/src/server/rendering/preact_hooks.ts
@@ -349,7 +349,7 @@ options.__h = (component, idx, type) => {
     const message =
       `Hook "${name}" cannot be used outside of an island component.`;
     const hint = type === HookType.useState
-      ? `\n\nUse the "useSignal" hook instead to share state across islands.`
+      ? `\n\nInstead, use the "useSignal" hook to share state across islands.`
       : "";
 
     // Don't throw here because that messes up internal Preact state

--- a/src/server/rendering/state.ts
+++ b/src/server/rendering/state.ts
@@ -36,6 +36,8 @@ export class RenderState {
   ownerStack: VNode[] = [];
   owners = new Map<VNode, VNode>();
   #nonce = "";
+  islandCounter = 0;
+  error: Error | null = null;
 
   constructor(
     routeOptions: RenderStateRouteOptions,

--- a/tests/dev_command_test.ts
+++ b/tests/dev_command_test.ts
@@ -1,7 +1,10 @@
 import { assertEquals, assertStringIncludes } from "./deps.ts";
 import { Status } from "../server.ts";
 import {
+  assertNotSelector,
   assertSelector,
+  assertTextMany,
+  assertTextMatch,
   fetchHtml,
   waitForStyle,
   withFresh,
@@ -73,5 +76,46 @@ Deno.test("middleware destination internal", async () => {
     const resp = await fetch(`${address}/_frsh/refresh.js`);
     assertEquals(resp.headers.get("destination"), "internal");
     await resp.body?.cancel();
+  });
+});
+
+Deno.test("warns when using hooks in server components", async (t) => {
+  await withFresh("./tests/fixture/main.ts", async (address) => {
+    await t.step("useState", async () => {
+      const doc = await fetchHtml(`${address}/hooks-server/useState`);
+      assertTextMatch(doc, "pre", /Hook "useState" cannot be used/);
+    });
+
+    await t.step("useReducer", async () => {
+      const doc = await fetchHtml(`${address}/hooks-server/useReducer`);
+      assertTextMatch(doc, "pre", /Hook "useReducer" cannot be used/);
+    });
+
+    // Valid
+    await t.step("does not warn in island", async () => {
+      const doc = await fetchHtml(`${address}/hooks-server/island`);
+      assertTextMany(doc, "p", ["0"]);
+    });
+  });
+});
+
+Deno.test("shows custom 500 page for rendering errors when not in dev", async (t) => {
+  await withFresh({
+    name: "./tests/fixture/main.ts",
+    options: {
+      env: {
+        DENO_DEPLOYMENT_ID: "foo",
+      },
+    },
+  }, async (address) => {
+    await t.step("useState", async () => {
+      const doc = await fetchHtml(`${address}/hooks-server/useState`);
+      assertNotSelector(doc, "pre");
+    });
+
+    await t.step("useReducer", async () => {
+      const doc = await fetchHtml(`${address}/hooks-server/useReducer`);
+      assertNotSelector(doc, "pre");
+    });
   });
 });

--- a/tests/dev_command_test.ts
+++ b/tests/dev_command_test.ts
@@ -84,6 +84,8 @@ Deno.test("warns when using hooks in server components", async (t) => {
     await t.step("useState", async () => {
       const doc = await fetchHtml(`${address}/hooks-server/useState`);
       assertTextMatch(doc, "p", /Hook "useState" cannot be used/);
+      // Check for hint
+      assertTextMatch(doc, "p", /Instead, use the "useSignal" hook/);
     });
 
     await t.step("useReducer", async () => {

--- a/tests/dev_command_test.ts
+++ b/tests/dev_command_test.ts
@@ -83,12 +83,12 @@ Deno.test("warns when using hooks in server components", async (t) => {
   await withFresh("./tests/fixture/main.ts", async (address) => {
     await t.step("useState", async () => {
       const doc = await fetchHtml(`${address}/hooks-server/useState`);
-      assertTextMatch(doc, "pre", /Hook "useState" cannot be used/);
+      assertTextMatch(doc, "p", /Hook "useState" cannot be used/);
     });
 
     await t.step("useReducer", async () => {
       const doc = await fetchHtml(`${address}/hooks-server/useReducer`);
-      assertTextMatch(doc, "pre", /Hook "useReducer" cannot be used/);
+      assertTextMatch(doc, "p", /Hook "useReducer" cannot be used/);
     });
 
     // Valid

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -18,71 +18,75 @@ import * as $12 from "./routes/event_handler_string.tsx";
 import * as $13 from "./routes/event_handler_string_island.tsx";
 import * as $14 from "./routes/evil.tsx";
 import * as $15 from "./routes/failure.ts";
-import * as $16 from "./routes/i18n/[[lang]]/lang.tsx";
-import * as $17 from "./routes/index.tsx";
-import * as $18 from "./routes/intercept.tsx";
-import * as $19 from "./routes/intercept_args.tsx";
-import * as $20 from "./routes/islands/index.tsx";
-import * as $21 from "./routes/islands/multiple_island_exports.tsx";
-import * as $22 from "./routes/islands/returning_null.tsx";
-import * as $23 from "./routes/islands/root_fragment.tsx";
-import * as $24 from "./routes/islands/root_fragment_conditional_first.tsx";
-import * as $25 from "./routes/layeredMdw/_middleware.ts";
-import * as $26 from "./routes/layeredMdw/layer2-no-mw/without_mw.ts";
-import * as $27 from "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts";
-import * as $28 from "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts";
-import * as $29 from "./routes/layeredMdw/layer2-with-params/_middleware.ts";
-import * as $30 from "./routes/layeredMdw/layer2/_middleware.ts";
-import * as $31 from "./routes/layeredMdw/layer2/abc.ts";
-import * as $32 from "./routes/layeredMdw/layer2/index.ts";
-import * as $33 from "./routes/layeredMdw/layer2/layer3/[id].ts";
-import * as $34 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
-import * as $35 from "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx";
-import * as $36 from "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts";
-import * as $37 from "./routes/layeredMdw/nesting/[tenant]/_middleware.ts";
-import * as $38 from "./routes/layeredMdw/nesting/_middleware.ts";
-import * as $39 from "./routes/middleware-error-handler/_middleware.ts";
-import * as $40 from "./routes/middleware-error-handler/index.tsx";
-import * as $41 from "./routes/middleware_root.ts";
-import * as $42 from "./routes/movies/[foo].json.ts";
-import * as $43 from "./routes/movies/[foo]@[bar].ts";
-import * as $44 from "./routes/nonce_inline.tsx";
-import * as $45 from "./routes/not_found.ts";
-import * as $46 from "./routes/params.tsx";
-import * as $47 from "./routes/preact/boolean_attrs.tsx";
-import * as $48 from "./routes/props/[id].tsx";
-import * as $49 from "./routes/route-groups-islands/index.tsx";
-import * as $50 from "./routes/route-groups/(bar)/(baz)/_layout.tsx";
-import * as $51 from "./routes/route-groups/(bar)/(baz)/baz.tsx";
-import * as $52 from "./routes/route-groups/(bar)/_layout.tsx";
-import * as $53 from "./routes/route-groups/(bar)/bar.tsx";
-import * as $54 from "./routes/route-groups/(bar)/boof/index.tsx";
-import * as $55 from "./routes/route-groups/(foo)/_layout.tsx";
-import * as $56 from "./routes/route-groups/(foo)/index.tsx";
-import * as $57 from "./routes/signal_shared.tsx";
-import * as $58 from "./routes/state-in-props/_middleware.ts";
-import * as $59 from "./routes/state-in-props/index.tsx";
-import * as $60 from "./routes/state-middleware/_middleware.ts";
-import * as $61 from "./routes/state-middleware/foo/_middleware.ts";
-import * as $62 from "./routes/state-middleware/foo/index.tsx";
-import * as $63 from "./routes/static.tsx";
-import * as $64 from "./routes/status_overwrite.tsx";
-import * as $65 from "./routes/umlaut-äöüß.tsx";
-import * as $66 from "./routes/wildcard.tsx";
+import * as $16 from "./routes/hooks-server/island.tsx";
+import * as $17 from "./routes/hooks-server/useReducer.tsx";
+import * as $18 from "./routes/hooks-server/useState.tsx";
+import * as $19 from "./routes/i18n/[[lang]]/lang.tsx";
+import * as $20 from "./routes/index.tsx";
+import * as $21 from "./routes/intercept.tsx";
+import * as $22 from "./routes/intercept_args.tsx";
+import * as $23 from "./routes/islands/index.tsx";
+import * as $24 from "./routes/islands/multiple_island_exports.tsx";
+import * as $25 from "./routes/islands/returning_null.tsx";
+import * as $26 from "./routes/islands/root_fragment.tsx";
+import * as $27 from "./routes/islands/root_fragment_conditional_first.tsx";
+import * as $28 from "./routes/layeredMdw/_middleware.ts";
+import * as $29 from "./routes/layeredMdw/layer2-no-mw/without_mw.ts";
+import * as $30 from "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts";
+import * as $31 from "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts";
+import * as $32 from "./routes/layeredMdw/layer2-with-params/_middleware.ts";
+import * as $33 from "./routes/layeredMdw/layer2/_middleware.ts";
+import * as $34 from "./routes/layeredMdw/layer2/abc.ts";
+import * as $35 from "./routes/layeredMdw/layer2/index.ts";
+import * as $36 from "./routes/layeredMdw/layer2/layer3/[id].ts";
+import * as $37 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
+import * as $38 from "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx";
+import * as $39 from "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts";
+import * as $40 from "./routes/layeredMdw/nesting/[tenant]/_middleware.ts";
+import * as $41 from "./routes/layeredMdw/nesting/_middleware.ts";
+import * as $42 from "./routes/middleware-error-handler/_middleware.ts";
+import * as $43 from "./routes/middleware-error-handler/index.tsx";
+import * as $44 from "./routes/middleware_root.ts";
+import * as $45 from "./routes/movies/[foo].json.ts";
+import * as $46 from "./routes/movies/[foo]@[bar].ts";
+import * as $47 from "./routes/nonce_inline.tsx";
+import * as $48 from "./routes/not_found.ts";
+import * as $49 from "./routes/params.tsx";
+import * as $50 from "./routes/preact/boolean_attrs.tsx";
+import * as $51 from "./routes/props/[id].tsx";
+import * as $52 from "./routes/route-groups-islands/index.tsx";
+import * as $53 from "./routes/route-groups/(bar)/(baz)/_layout.tsx";
+import * as $54 from "./routes/route-groups/(bar)/(baz)/baz.tsx";
+import * as $55 from "./routes/route-groups/(bar)/_layout.tsx";
+import * as $56 from "./routes/route-groups/(bar)/bar.tsx";
+import * as $57 from "./routes/route-groups/(bar)/boof/index.tsx";
+import * as $58 from "./routes/route-groups/(foo)/_layout.tsx";
+import * as $59 from "./routes/route-groups/(foo)/index.tsx";
+import * as $60 from "./routes/signal_shared.tsx";
+import * as $61 from "./routes/state-in-props/_middleware.ts";
+import * as $62 from "./routes/state-in-props/index.tsx";
+import * as $63 from "./routes/state-middleware/_middleware.ts";
+import * as $64 from "./routes/state-middleware/foo/_middleware.ts";
+import * as $65 from "./routes/state-middleware/foo/index.tsx";
+import * as $66 from "./routes/static.tsx";
+import * as $67 from "./routes/status_overwrite.tsx";
+import * as $68 from "./routes/umlaut-äöüß.tsx";
+import * as $69 from "./routes/wildcard.tsx";
 import * as $$0 from "./islands/Counter.tsx";
 import * as $$1 from "./islands/FormIsland.tsx";
 import * as $$2 from "./islands/Greeter.tsx";
-import * as $$3 from "./islands/MultipleCounters.tsx";
-import * as $$4 from "./islands/ReturningNull.tsx";
-import * as $$5 from "./islands/RootFragment.tsx";
-import * as $$6 from "./islands/RootFragmentWithConditionalFirst.tsx";
-import * as $$7 from "./islands/StringEventIsland.tsx";
-import * as $$8 from "./islands/Test.tsx";
-import * as $$9 from "./islands/folder/Counter.tsx";
-import * as $$10 from "./islands/folder/subfolder/Counter.tsx";
-import * as $$11 from "./islands/kebab-case-counter-test.tsx";
-import * as $$12 from "./routes/route-groups-islands/(_islands)/Counter.tsx";
-import * as $$13 from "./routes/route-groups-islands/(_islands)/invalid.tsx";
+import * as $$3 from "./islands/HookIsland.tsx";
+import * as $$4 from "./islands/MultipleCounters.tsx";
+import * as $$5 from "./islands/ReturningNull.tsx";
+import * as $$6 from "./islands/RootFragment.tsx";
+import * as $$7 from "./islands/RootFragmentWithConditionalFirst.tsx";
+import * as $$8 from "./islands/StringEventIsland.tsx";
+import * as $$9 from "./islands/Test.tsx";
+import * as $$10 from "./islands/folder/Counter.tsx";
+import * as $$11 from "./islands/folder/subfolder/Counter.tsx";
+import * as $$12 from "./islands/kebab-case-counter-test.tsx";
+import * as $$13 from "./routes/route-groups-islands/(_islands)/Counter.tsx";
+import * as $$14 from "./routes/route-groups-islands/(_islands)/invalid.tsx";
 
 const manifest = {
   routes: {
@@ -102,73 +106,77 @@ const manifest = {
     "./routes/event_handler_string_island.tsx": $13,
     "./routes/evil.tsx": $14,
     "./routes/failure.ts": $15,
-    "./routes/i18n/[[lang]]/lang.tsx": $16,
-    "./routes/index.tsx": $17,
-    "./routes/intercept.tsx": $18,
-    "./routes/intercept_args.tsx": $19,
-    "./routes/islands/index.tsx": $20,
-    "./routes/islands/multiple_island_exports.tsx": $21,
-    "./routes/islands/returning_null.tsx": $22,
-    "./routes/islands/root_fragment.tsx": $23,
-    "./routes/islands/root_fragment_conditional_first.tsx": $24,
-    "./routes/layeredMdw/_middleware.ts": $25,
-    "./routes/layeredMdw/layer2-no-mw/without_mw.ts": $26,
-    "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts": $27,
-    "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts": $28,
-    "./routes/layeredMdw/layer2-with-params/_middleware.ts": $29,
-    "./routes/layeredMdw/layer2/_middleware.ts": $30,
-    "./routes/layeredMdw/layer2/abc.ts": $31,
-    "./routes/layeredMdw/layer2/index.ts": $32,
-    "./routes/layeredMdw/layer2/layer3/[id].ts": $33,
-    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $34,
-    "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx": $35,
-    "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts": $36,
-    "./routes/layeredMdw/nesting/[tenant]/_middleware.ts": $37,
-    "./routes/layeredMdw/nesting/_middleware.ts": $38,
-    "./routes/middleware-error-handler/_middleware.ts": $39,
-    "./routes/middleware-error-handler/index.tsx": $40,
-    "./routes/middleware_root.ts": $41,
-    "./routes/movies/[foo].json.ts": $42,
-    "./routes/movies/[foo]@[bar].ts": $43,
-    "./routes/nonce_inline.tsx": $44,
-    "./routes/not_found.ts": $45,
-    "./routes/params.tsx": $46,
-    "./routes/preact/boolean_attrs.tsx": $47,
-    "./routes/props/[id].tsx": $48,
-    "./routes/route-groups-islands/index.tsx": $49,
-    "./routes/route-groups/(bar)/(baz)/_layout.tsx": $50,
-    "./routes/route-groups/(bar)/(baz)/baz.tsx": $51,
-    "./routes/route-groups/(bar)/_layout.tsx": $52,
-    "./routes/route-groups/(bar)/bar.tsx": $53,
-    "./routes/route-groups/(bar)/boof/index.tsx": $54,
-    "./routes/route-groups/(foo)/_layout.tsx": $55,
-    "./routes/route-groups/(foo)/index.tsx": $56,
-    "./routes/signal_shared.tsx": $57,
-    "./routes/state-in-props/_middleware.ts": $58,
-    "./routes/state-in-props/index.tsx": $59,
-    "./routes/state-middleware/_middleware.ts": $60,
-    "./routes/state-middleware/foo/_middleware.ts": $61,
-    "./routes/state-middleware/foo/index.tsx": $62,
-    "./routes/static.tsx": $63,
-    "./routes/status_overwrite.tsx": $64,
-    "./routes/umlaut-äöüß.tsx": $65,
-    "./routes/wildcard.tsx": $66,
+    "./routes/hooks-server/island.tsx": $16,
+    "./routes/hooks-server/useReducer.tsx": $17,
+    "./routes/hooks-server/useState.tsx": $18,
+    "./routes/i18n/[[lang]]/lang.tsx": $19,
+    "./routes/index.tsx": $20,
+    "./routes/intercept.tsx": $21,
+    "./routes/intercept_args.tsx": $22,
+    "./routes/islands/index.tsx": $23,
+    "./routes/islands/multiple_island_exports.tsx": $24,
+    "./routes/islands/returning_null.tsx": $25,
+    "./routes/islands/root_fragment.tsx": $26,
+    "./routes/islands/root_fragment_conditional_first.tsx": $27,
+    "./routes/layeredMdw/_middleware.ts": $28,
+    "./routes/layeredMdw/layer2-no-mw/without_mw.ts": $29,
+    "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts": $30,
+    "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts": $31,
+    "./routes/layeredMdw/layer2-with-params/_middleware.ts": $32,
+    "./routes/layeredMdw/layer2/_middleware.ts": $33,
+    "./routes/layeredMdw/layer2/abc.ts": $34,
+    "./routes/layeredMdw/layer2/index.ts": $35,
+    "./routes/layeredMdw/layer2/layer3/[id].ts": $36,
+    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $37,
+    "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx": $38,
+    "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts": $39,
+    "./routes/layeredMdw/nesting/[tenant]/_middleware.ts": $40,
+    "./routes/layeredMdw/nesting/_middleware.ts": $41,
+    "./routes/middleware-error-handler/_middleware.ts": $42,
+    "./routes/middleware-error-handler/index.tsx": $43,
+    "./routes/middleware_root.ts": $44,
+    "./routes/movies/[foo].json.ts": $45,
+    "./routes/movies/[foo]@[bar].ts": $46,
+    "./routes/nonce_inline.tsx": $47,
+    "./routes/not_found.ts": $48,
+    "./routes/params.tsx": $49,
+    "./routes/preact/boolean_attrs.tsx": $50,
+    "./routes/props/[id].tsx": $51,
+    "./routes/route-groups-islands/index.tsx": $52,
+    "./routes/route-groups/(bar)/(baz)/_layout.tsx": $53,
+    "./routes/route-groups/(bar)/(baz)/baz.tsx": $54,
+    "./routes/route-groups/(bar)/_layout.tsx": $55,
+    "./routes/route-groups/(bar)/bar.tsx": $56,
+    "./routes/route-groups/(bar)/boof/index.tsx": $57,
+    "./routes/route-groups/(foo)/_layout.tsx": $58,
+    "./routes/route-groups/(foo)/index.tsx": $59,
+    "./routes/signal_shared.tsx": $60,
+    "./routes/state-in-props/_middleware.ts": $61,
+    "./routes/state-in-props/index.tsx": $62,
+    "./routes/state-middleware/_middleware.ts": $63,
+    "./routes/state-middleware/foo/_middleware.ts": $64,
+    "./routes/state-middleware/foo/index.tsx": $65,
+    "./routes/static.tsx": $66,
+    "./routes/status_overwrite.tsx": $67,
+    "./routes/umlaut-äöüß.tsx": $68,
+    "./routes/wildcard.tsx": $69,
   },
   islands: {
     "./islands/Counter.tsx": $$0,
     "./islands/FormIsland.tsx": $$1,
     "./islands/Greeter.tsx": $$2,
-    "./islands/MultipleCounters.tsx": $$3,
-    "./islands/ReturningNull.tsx": $$4,
-    "./islands/RootFragment.tsx": $$5,
-    "./islands/RootFragmentWithConditionalFirst.tsx": $$6,
-    "./islands/StringEventIsland.tsx": $$7,
-    "./islands/Test.tsx": $$8,
-    "./islands/folder/Counter.tsx": $$9,
-    "./islands/folder/subfolder/Counter.tsx": $$10,
-    "./islands/kebab-case-counter-test.tsx": $$11,
-    "./routes/route-groups-islands/(_islands)/Counter.tsx": $$12,
-    "./routes/route-groups-islands/(_islands)/invalid.tsx": $$13,
+    "./islands/HookIsland.tsx": $$3,
+    "./islands/MultipleCounters.tsx": $$4,
+    "./islands/ReturningNull.tsx": $$5,
+    "./islands/RootFragment.tsx": $$6,
+    "./islands/RootFragmentWithConditionalFirst.tsx": $$7,
+    "./islands/StringEventIsland.tsx": $$8,
+    "./islands/Test.tsx": $$9,
+    "./islands/folder/Counter.tsx": $$10,
+    "./islands/folder/subfolder/Counter.tsx": $$11,
+    "./islands/kebab-case-counter-test.tsx": $$12,
+    "./routes/route-groups-islands/(_islands)/Counter.tsx": $$13,
+    "./routes/route-groups-islands/(_islands)/invalid.tsx": $$14,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/fixture/islands/HookIsland.tsx
+++ b/tests/fixture/islands/HookIsland.tsx
@@ -1,0 +1,11 @@
+import { useState } from "preact/hooks";
+
+export function HookIsland() {
+  const [v, set] = useState(0);
+  return (
+    <div>
+      <p>{v}</p>
+      <button onClick={() => set((v) => v + 1)}>update</button>
+    </div>
+  );
+}

--- a/tests/fixture/routes/hooks-server/island.tsx
+++ b/tests/fixture/routes/hooks-server/island.tsx
@@ -1,0 +1,5 @@
+import { HookIsland } from "../../islands/HookIsland.tsx";
+
+export default function Page() {
+  return <HookIsland />;
+}

--- a/tests/fixture/routes/hooks-server/useReducer.tsx
+++ b/tests/fixture/routes/hooks-server/useReducer.tsx
@@ -1,0 +1,6 @@
+import { useReducer } from "preact/hooks";
+
+export default function Page() {
+  useReducer(() => {}, undefined);
+  return <h1>useReducer</h1>;
+}

--- a/tests/fixture/routes/hooks-server/useState.tsx
+++ b/tests/fixture/routes/hooks-server/useState.tsx
@@ -1,0 +1,6 @@
+import { useState } from "preact/hooks";
+
+export default function Page() {
+  useState();
+  return <h1>useState</h1>;
+}


### PR DESCRIPTION
A common issue folks run into is that `useState` or `useReducer` doesn't work outside of an island. Route components are only ever on the server and those renders are not stateful. With this PR we'll throw an error when we detect such a case.

```sh
An error occurred during route handling or page rendering.
Error: Hook "useState" cannot be used outside of an island component.
```

Based on #1789 