### PR TITLE
fix: server initialized twice in old dev mode

### DIFF
--- a/src/dev/dev_command.ts
+++ b/src/dev/dev_command.ts
@@ -43,17 +43,16 @@ export async function dev(
   const outDir = join(dir, "_fresh");
 
   const isBuild = Deno.args.includes("build");
-  const ctx = await ServerContext.fromManifest(manifest, {
-    ...options,
-    skipSnapshot: true,
-    dev: !isBuild,
-  });
-
   if (isBuild) {
     // Ensure that build dir is empty
     await fs.emptyDir(outDir);
     await build(join(dir, "fresh.gen.ts"), options ?? {});
   } else if (options) {
+    const ctx = await ServerContext.fromManifest(manifest, {
+      ...options,
+      skipSnapshot: true,
+      dev: !isBuild,
+    });
     await startFromContext(ctx, options);
   } else {
     // Legacy entry point: Back then `dev.ts` would call `main.ts` but

--- a/src/dev/dev_command.ts
+++ b/src/dev/dev_command.ts
@@ -51,7 +51,7 @@ export async function dev(
     const ctx = await ServerContext.fromManifest(manifest, {
       ...options,
       skipSnapshot: true,
-      dev: !isBuild,
+      dev: true,
     });
     await startFromContext(ctx, options);
   } else {


### PR DESCRIPTION
Noticed this will working on #1780 . Initializing the server twice didn't lead to any errors, but makes dev bootup time a hair split slower.