### PR TITLE
feat: exclude _fresh dir from everything

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,6 +8,9 @@
     "check:types": "deno check **/*.ts && deno check **/*.tsx",
     "ok": "deno fmt --check && deno lint && deno task check:types && deno task test"
   },
+  "exclude": [
+    "**/_fresh/*"
+  ],
   "importMap": "./.vscode/import_map.json",
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/init.ts
+++ b/init.ts
@@ -564,11 +564,8 @@ const config = {
     rules: {
       tags: ["fresh", "recommended"],
     },
-    exclude: ["_fresh"],
   },
-  fmt: {
-    exclude: ["_fresh"],
-  },
+  exclude: ["**/_fresh/*"],
   imports: {} as Record<string, string>,
   compilerOptions: {
     jsx: "react-jsx",

--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -91,6 +91,7 @@ export interface DenoConfig {
   fmt?: {
     exclude?: string[];
   };
+  exclude?: string[];
   compilerOptions?: {
     jsx?: string;
     jsxImportSource?: string;

--- a/tests/init_test.ts
+++ b/tests/init_test.ts
@@ -92,11 +92,10 @@ Deno.test({
       assert(json.tasks.preview, "Missing 'preview' task");
 
       // Check lint settings
-      assertEquals(json.lint.exclude, ["_fresh"]);
       assertEquals(json.lint.rules.tags, ["fresh", "recommended"]);
 
-      // Check fmt settings
-      assertEquals(json.fmt.exclude, ["_fresh"]);
+      // Check exclude settings
+      assertEquals(json.exclude, ["**/_fresh/*"]);
     });
 
     await t.step("start up the server and access the root page", async () => {

--- a/update.ts
+++ b/update.ts
@@ -87,22 +87,37 @@ if (!denoJson.lint.rules.tags.includes("fresh")) {
 if (!denoJson.lint.rules.tags.includes("recommended")) {
   denoJson.lint.rules.tags.push("recommended");
 }
-if (!denoJson.lint.exclude) {
-  denoJson.lint.exclude = [];
-}
-if (!denoJson.lint.exclude.includes("_fresh")) {
-  denoJson.lint.exclude.push("_fresh");
+
+// Remove old _fresh exclude where we added it separately to
+// "lint" and "fmt"
+const fmtExcludeIdx = denoJson?.fmt?.exclude?.indexOf("_fresh");
+if (fmtExcludeIdx > -1) {
+  denoJson.fmt.exclude.splice(fmtExcludeIdx, 1);
+  if (denoJson.fmt.exclude.length === 0) {
+    delete denoJson.fmt.exclude;
+  }
+  if (Object.keys(denoJson.fmt).length === 0) {
+    delete denoJson.fmt;
+  }
 }
 
-// Exclude _fresh dir from linting
-if (!denoJson.fmt) {
-  denoJson.fmt = {};
+const lintExcludeIdx = denoJson?.lint?.exclude?.indexOf("_fresh");
+if (lintExcludeIdx > -1) {
+  denoJson.lint.exclude.splice(lintExcludeIdx, 1);
+  if (denoJson.lint.exclude.length === 0) {
+    delete denoJson.lint.exclude;
+  }
+  if (Object.keys(denoJson.lint).length === 0) {
+    delete denoJson.lint;
+  }
 }
-if (!denoJson.fmt.exclude) {
-  denoJson.fmt.exclude = [];
+
+// Exclude _fresh dir from everything
+if (!denoJson.exclude) {
+  denoJson.exclude = [];
 }
-if (!denoJson.fmt.exclude.includes("_fresh")) {
-  denoJson.fmt.exclude.push("_fresh");
+if (!denoJson.exclude.includes("**/_fresh/*")) {
+  denoJson.exclude.push("**/_fresh/*");
 }
 
 if (!denoJson.tasks) {


### PR DESCRIPTION
Turns out that we can set a top level `exclude` property in `deno.json` to exclude it from everything. This simplifies the configuration generated by Fresh to exclude the `_fresh` directory quite a bit.