### PR TITLE
fix: only enable dev things in dev mode

### DIFF
--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -9,3 +9,8 @@ export const DEBUG = !Deno.env.get("DENO_DEPLOYMENT_ID");
 export function bundleAssetUrl(path: string) {
   return `${INTERNAL_PREFIX}${JS_PREFIX}/${BUILD_ID}${path}`;
 }
+
+export let DEV_MODE = false;
+export function setDevMode(value: boolean) {
+  DEV_MODE = value;
+}

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -150,8 +150,8 @@ export class ServerContext {
     manifest: Manifest,
     opts: FreshOptions & { skipSnapshot?: boolean; dev?: boolean },
   ): Promise<ServerContext> {
-    const dev = Deno.env.get("__FRSH_LEGACY_DEV") === "true" ?? opts.dev ??
-      false;
+    const dev = Deno.env.get("__FRSH_LEGACY_DEV") === "true" ||
+      Boolean(opts.dev);
     setDevMode(dev);
 
     // Get the manifest' base URL.

--- a/tests/error_test.ts
+++ b/tests/error_test.ts
@@ -28,14 +28,3 @@ Deno.test("error page rendered", async () => {
   assertStringIncludes(body, `Error: boom!`);
   assertStringIncludes(body, `at render`);
 });
-Deno.test("refresh.js rendered", async () => {
-  const resp = await router(
-    new Request("https://fresh.deno.dev" + REFRESH_JS_URL),
-  );
-  assert(resp);
-  assertEquals(resp.status, Status.OK);
-  assertEquals(
-    resp.headers.get("content-type"),
-    "application/javascript; charset=utf-8",
-  );
-});

--- a/tests/error_test.ts
+++ b/tests/error_test.ts
@@ -1,5 +1,4 @@
 import { ServerContext, Status } from "../server.ts";
-import { REFRESH_JS_URL } from "../src/server/constants.ts";
 import { assert, assertEquals, assertStringIncludes } from "./deps.ts";
 import manifest from "./fixture_error/fresh.gen.ts";
 


### PR DESCRIPTION
Although we always had `dev.ts` and `main.ts` these two modes were interleaved within each other behind the scenes. Running `main.ts` would still enable lots of dev only features such as `preact/debug`. This PR properly splits these modes up.