### PR TITLE
chore: speed up tests

### DIFF
--- a/src/server/code_frame.ts
+++ b/src/server/code_frame.ts
@@ -7,6 +7,7 @@ function tabs2Spaces(str: string) {
 /**
  * Generate an excerpt of the location in the source around the
  * specified position.
+ * Taken from: https://github.com/marvinhagemeister/simple-code-frame/blob/e56f10acf2de6ece968b0de67d2d34e445dc8a66/src/index.ts
  */
 export function createCodeFrame(
   text: string,

--- a/src/server/code_frame.ts
+++ b/src/server/code_frame.ts
@@ -7,7 +7,6 @@ function tabs2Spaces(str: string) {
 /**
  * Generate an excerpt of the location in the source around the
  * specified position.
- * Taken from: https://github.com/marvinhagemeister/simple-code-frame/blob/e56f10acf2de6ece968b0de67d2d34e445dc8a66/src/index.ts
  */
 export function createCodeFrame(
   text: string,

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -903,13 +903,19 @@ export class ServerContext {
       ctx,
       error,
     ) => {
+      let codeFrame = undefined;
+      if (this.#dev && error instanceof Error) {
+        codeFrame = await getCodeFrame(error);
+        // deno-lint-ignore no-explicit-any
+        (error as any).codeFrame = codeFrame;
+      }
+
       console.error(
         "%cAn error occurred during route handling or page rendering.",
         "color:red",
       );
-      let codeFrame: string | undefined = undefined;
       if (this.#dev && error instanceof Error) {
-        codeFrame = await getCodeFrame(error);
+        const codeFrame = await getCodeFrame(error);
 
         if (codeFrame) {
           console.error();

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -91,6 +91,11 @@ interface StaticFile {
   etag: string;
 }
 
+export type FromManifestOptions = FreshOptions & {
+  skipSnapshot?: boolean;
+  dev?: boolean;
+};
+
 export class ServerContext {
   #dev: boolean;
   #routes: Route[];
@@ -149,7 +154,7 @@ export class ServerContext {
    */
   static async fromManifest(
     manifest: Manifest,
-    opts: FreshOptions & { skipSnapshot?: boolean; dev?: boolean },
+    opts: FromManifestOptions,
   ): Promise<ServerContext> {
     const dev = Deno.env.get("__FRSH_LEGACY_DEV") === "true" ||
       Boolean(opts.dev);

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -903,13 +903,6 @@ export class ServerContext {
       ctx,
       error,
     ) => {
-      let codeFrame = undefined;
-      if (this.#dev && error instanceof Error) {
-        codeFrame = await getCodeFrame(error);
-        // deno-lint-ignore no-explicit-any
-        (error as any).codeFrame = codeFrame;
-      }
-
       console.error(
         "%cAn error occurred during route handling or page rendering.",
         "color:red",

--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -1,6 +1,7 @@
 import { LayoutConfig } from "$fresh/server.ts";
 import { ComponentChildren } from "preact";
 import { ServerContext } from "./context.ts";
+export type { FromManifestOptions } from "./context.ts";
 export { Status } from "./deps.ts";
 import {
   ErrorHandler,

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -33,6 +33,7 @@ export { defineConfig, type Preset } from "https://esm.sh/@twind/core@1.1.3";
 export { default as presetTailwind } from "https://esm.sh/@twind/preset-tailwind@1.1.4";
 export * as fs from "https://deno.land/std@0.195.0/fs/mod.ts";
 export {
+  basename,
   dirname,
   fromFileUrl,
   join,

--- a/tests/explicit_app_template_test.ts
+++ b/tests/explicit_app_template_test.ts
@@ -2,16 +2,15 @@ import {
   assertNotSelector,
   assertSelector,
   assertTextMany,
-  fetchHtml,
-  withFresh,
+  withFakeServe,
 } from "$fresh/tests/test_utils.ts";
 import { assertNotMatch } from "$std/testing/asserts.ts";
 
 Deno.test("doesn't apply internal app template", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_explicit_app/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}`);
+    async (server) => {
+      const doc = await server.getHtml(`/`);
 
       // Doesn't render internal app template
       assertNotSelector(doc, "body body");
@@ -32,10 +31,10 @@ Deno.test("doesn't apply internal app template", async () => {
 });
 
 Deno.test("user _app works with <Head>", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_explicit_app/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}/head`);
+    async (server) => {
+      const doc = await server.getHtml(`/head`);
 
       // Doesn't render internal app template
       assertNotSelector(doc, "body body");
@@ -59,20 +58,20 @@ Deno.test("user _app works with <Head>", async () => {
 });
 
 Deno.test("don't duplicate <title>", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_explicit_app/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}/title`);
+    async (server) => {
+      const doc = await server.getHtml(`/title`);
       assertTextMany(doc, "title", ["foo bar"]);
     },
   );
 });
 
 Deno.test("sets <html> + <head> + <body> classes", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_explicit_app/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}`);
+    async (server) => {
+      const doc = await server.getHtml(``);
       assertSelector(doc, "html.html");
       assertSelector(doc, "head.head");
       assertSelector(doc, "body.body");
@@ -82,10 +81,10 @@ Deno.test("sets <html> + <head> + <body> classes", async () => {
 
 // Issue: https://github.com/denoland/fresh/issues/1666
 Deno.test("renders valid html document", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_explicit_app/main.ts",
-    async (address) => {
-      const res = await fetch(address);
+    async (server) => {
+      const res = await server.get("/");
       const text = await res.text();
 
       assertNotMatch(text, /<\/body><\/head>/);

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -10,9 +10,8 @@ import {
   assertSelector,
   assertTextMatch,
   clickWhenListenerReady,
-  fetchHtml,
   waitForText,
-  withFresh,
+  withFakeServe,
   withPageName,
 } from "./test_utils.ts";
 
@@ -503,21 +502,21 @@ Deno.test({
 });
 
 Deno.test("throws when passing non-jsx children to an island", async (t) => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_island_nesting/dev.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}/island_invalid_children`);
+    async (server) => {
+      const doc = await server.getHtml(`/island_invalid_children`);
 
       assertSelector(doc, ".frsh-error-page");
       assertTextMatch(doc, "pre", /Invalid JSX child passed to island/);
 
-      const doc2 = await fetchHtml(`${address}/island_invalid_children_fn`);
+      const doc2 = await server.getHtml(`/island_invalid_children_fn`);
 
       assertSelector(doc2, ".frsh-error-page");
       assertTextMatch(doc2, "pre", /Invalid JSX child passed to island/);
 
       await t.step("should not throw on valid children", async () => {
-        const doc2 = await fetchHtml(`${address}/island_valid_children`);
+        const doc2 = await server.getHtml(`/island_valid_children`);
 
         assertNotSelector(doc2, ".frsh-error-page");
       });

--- a/tests/layouts_test.ts
+++ b/tests/layouts_test.ts
@@ -3,70 +3,69 @@ import {
   assertNotSelector,
   assertSelector,
   clickWhenListenerReady,
-  fetchHtml,
   waitForText,
-  withFresh,
+  withFakeServe,
   withPageName,
 } from "./test_utils.ts";
 
 Deno.test("apply root _layout and _app", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_layouts/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(address);
+    async (server) => {
+      const doc = await server.getHtml("/");
       assert(doc.body.textContent?.includes("it works"));
       assertSelector(doc, ".app .root-layout .home-page");
 
-      const doc2 = await fetchHtml(`${address}/other`);
+      const doc2 = await server.getHtml("/other");
       assertSelector(doc2, ".app .root-layout .other-page");
     },
   );
 });
 
 Deno.test("apply sub layouts", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_layouts/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}/foo`);
+    async (server) => {
+      const doc = await server.getHtml("/foo");
       assertSelector(doc, ".app .root-layout .foo-layout .foo-page");
 
-      const doc2 = await fetchHtml(`${address}/foo/bar`);
+      const doc2 = await server.getHtml("/foo/bar");
       assertSelector(doc2, ".app .root-layout .foo-layout .bar-page");
     },
   );
 });
 
 Deno.test("skip layouts if not present", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_layouts/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}/skip/sub`);
+    async (server) => {
+      const doc = await server.getHtml(`/skip/sub`);
       assertSelector(doc, ".app .root-layout .sub-layout .sub-page");
     },
   );
 });
 
 Deno.test("check file types", async (t) => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_layouts/main.ts",
-    async (address) => {
+    async (server) => {
       await t.step(".js", async () => {
-        const doc = await fetchHtml(`${address}/files/js`);
+        const doc = await server.getHtml(`/files/js`);
         assertSelector(doc, ".app .root-layout .js-layout .js-page");
       });
 
       await t.step(".jsx", async () => {
-        const doc = await fetchHtml(`${address}/files/jsx`);
+        const doc = await server.getHtml(`/files/jsx`);
         assertSelector(doc, ".app .root-layout .jsx-layout .jsx-page");
       });
 
       await t.step(".ts", async () => {
-        const doc = await fetchHtml(`${address}/files/ts`);
+        const doc = await server.getHtml(`/files/ts`);
         assertSelector(doc, ".app .root-layout .ts-layout .ts-page");
       });
 
       await t.step(".tsx", async () => {
-        const doc = await fetchHtml(`${address}/files/tsx`);
+        const doc = await server.getHtml(`/files/tsx`);
         assertSelector(doc, ".app .root-layout .tsx-layout .tsx-page");
       });
     },
@@ -74,20 +73,20 @@ Deno.test("check file types", async (t) => {
 });
 
 Deno.test("render async layout", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_layouts/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}/async`);
+    async (server) => {
+      const doc = await server.getHtml(`/async`);
       assertSelector(doc, ".app .root-layout .async-layout .async-page");
     },
   );
 });
 
 Deno.test("render nested async layout", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_layouts/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}/async/sub`);
+    async (server) => {
+      const doc = await server.getHtml(`/async/sub`);
       assertSelector(
         doc,
         ".app .root-layout .async-layout .async-sub-layout .async-sub-page",
@@ -96,27 +95,24 @@ Deno.test("render nested async layout", async () => {
   );
 });
 
-Deno.test({
-  name: "can return Response from async layout",
-  fn: async () => {
-    await withFresh(
-      "./tests/fixture_layouts/main.ts",
-      async (address) => {
-        const doc = await fetchHtml(`${address}/async/redirect`);
-        assertSelector(
-          doc,
-          ".app .root-layout .async-layout .async-sub-layout .async-sub-page",
-        );
-      },
-    );
-  },
+Deno.test("can return Response from async layout", async () => {
+  await withFakeServe(
+    "./tests/fixture_layouts/main.ts",
+    async (server) => {
+      const doc = await server.getHtml(`/async/redirect`);
+      assertSelector(
+        doc,
+        ".app .root-layout .async-layout .async-sub-layout .async-sub-page",
+      );
+    },
+  );
 });
 
 Deno.test("disable _app layout", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_layouts/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}/override/no_app`);
+    async (server) => {
+      const doc = await server.getHtml(`/override/no_app`);
       assertNotSelector(doc, "body body");
       assertSelector(doc, "body > .override-layout >.no-app");
     },
@@ -124,10 +120,10 @@ Deno.test("disable _app layout", async () => {
 });
 
 Deno.test("disable _app in _layout", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_layouts/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}/override/layout_no_app`);
+    async (server) => {
+      const doc = await server.getHtml(`/override/layout_no_app`);
       assertNotSelector(doc, "body body");
       assertSelector(doc, "body > .override-layout > .no-app-layout > .page");
     },
@@ -135,30 +131,30 @@ Deno.test("disable _app in _layout", async () => {
 });
 
 Deno.test("override layouts", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_layouts/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}/override`);
+    async (server) => {
+      const doc = await server.getHtml(`/override`);
       assertSelector(doc, "body > .app > .override-layout > .override-page");
     },
   );
 });
 
 Deno.test("route overrides layout", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_layouts/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}/override/no_layout`);
+    async (server) => {
+      const doc = await server.getHtml(`/override/no_layout`);
       assertSelector(doc, "body > .app > .no-layouts");
     },
   );
 });
 
 Deno.test("route overrides layout and app", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_layouts/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}/override/no_layout_no_app`);
+    async (server) => {
+      const doc = await server.getHtml(`/override/no_layout_no_app`);
       assertSelector(doc, "body > .no-app-no-layouts");
     },
   );

--- a/tests/route_groups_test.ts
+++ b/tests/route_groups_test.ts
@@ -1,18 +1,17 @@
 import { assertEquals } from "$std/testing/asserts.ts";
 import {
   assertTextMany,
-  fetchHtml,
   parseHtml,
   waitForText,
-  withFresh,
+  withFakeServe,
   withPageName,
 } from "./test_utils.ts";
 
 Deno.test("applies only _layout file of one group", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}/route-groups`);
+    async (server) => {
+      const doc = await server.getHtml(`/route-groups`);
 
       assertTextMany(doc, "p", ["Foo layout", "Foo page"]);
     },
@@ -20,20 +19,20 @@ Deno.test("applies only _layout file of one group", async () => {
 });
 
 Deno.test("applies only _layout files in parent groups", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}/route-groups/baz`);
+    async (server) => {
+      const doc = await server.getHtml(`/route-groups/baz`);
       assertTextMany(doc, "p", ["Bar layout", "Baz layout", "Baz page"]);
     },
   );
 });
 
 Deno.test("applies only _layout files in parent groups #2", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}/route-groups/boof`);
+    async (server) => {
+      const doc = await server.getHtml(`/route-groups/boof`);
       assertTextMany(doc, "p", ["Bar layout", "Boof Page"]);
     },
   );
@@ -52,10 +51,10 @@ Deno.test("can co-locate islands inside routes folder", async () => {
 });
 
 Deno.test("does not treat files in (_islands) as routes", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture/main.ts",
-    async (address) => {
-      const res = await fetch(`${address}/route-groups-islands/invalid`);
+    async (server) => {
+      const res = await server.get(`/route-groups-islands/invalid`);
       assertEquals(res.status, 404);
       await res.body?.cancel();
     },
@@ -63,10 +62,10 @@ Deno.test("does not treat files in (_islands) as routes", async () => {
 });
 
 Deno.test("does not treat files in (_...) as routes", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture/main.ts",
-    async (address) => {
-      const res = await fetch(`${address}/route-groups-islands/sub`);
+    async (server) => {
+      const res = await server.get(`/route-groups-islands/sub`);
       assertEquals(res.status, 404);
       await res.body?.cancel();
     },
@@ -74,10 +73,10 @@ Deno.test("does not treat files in (_...) as routes", async () => {
 });
 
 Deno.test("resolve index route in group /(group)/index.tsx", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_group_index/main.ts",
-    async (address) => {
-      const res = await fetch(`${address}`);
+    async (server) => {
+      const res = await server.get(`/`);
       assertEquals(res.status, 200);
       const doc = parseHtml(await res.text());
       assertEquals(doc.querySelector("h1")?.textContent, "it works");

--- a/tests/server_components_test.ts
+++ b/tests/server_components_test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "./deps.ts";
 import {
   assertSelector,
   assertTextMany,
-  fetchHtml,
+  withFakeServe,
   withFresh,
   withPageName,
 } from "./test_utils.ts";
@@ -12,10 +12,10 @@ Deno.test({
   name: "render async server component",
 
   async fn() {
-    await withFresh(
+    await withFakeServe(
       "./tests/fixture_server_components/main.ts",
-      async (address) => {
-        const doc = await fetchHtml(`${address}/basic`);
+      async (server) => {
+        const doc = await server.getHtml(`/basic`);
         assertTextMany(doc, "h1", ["it works"]);
       },
     );
@@ -26,10 +26,10 @@ Deno.test({
   name: "uses returned response",
 
   async fn() {
-    await withFresh(
+    await withFakeServe(
       "./tests/fixture_server_components/main.ts",
-      async (address) => {
-        const res = await fetch(`${address}/response`);
+      async (server) => {
+        const res = await server.get(`/response`);
         const text = await res.text();
         assertEquals(text, "it works");
       },
@@ -104,10 +104,10 @@ Deno.test({
   name: "can call context.renderNotFound()",
 
   async fn() {
-    await withFresh(
+    await withFakeServe(
       "./tests/fixture_server_components/main.ts",
-      async (address) => {
-        const res = await fetch(`${address}/fail`);
+      async (server) => {
+        const res = await server.get(`/fail`);
 
         assertEquals(res.status, Status.NotFound);
         const html = await res.text();
@@ -144,10 +144,10 @@ Deno.test({
   name: "renders async app template",
 
   async fn() {
-    await withFresh(
+    await withFakeServe(
       "./tests/fixture_async_app/main.ts",
-      async (address) => {
-        const doc = await fetchHtml(`${address}`);
+      async (server) => {
+        const doc = await server.getHtml(``);
         assertSelector(doc, "html > body > .app > .layout > .page");
       },
     );
@@ -155,10 +155,10 @@ Deno.test({
 });
 
 Deno.test("define helpers", async () => {
-  await withFresh(
+  await withFakeServe(
     "./tests/fixture_define_helpers/main.ts",
-    async (address) => {
-      const doc = await fetchHtml(`${address}`);
+    async (server) => {
+      const doc = await server.getHtml(``);
       assertSelector(doc, "html > body > .app > .layout > .page");
       assertTextMany(doc, "p", ["Layout: it works", "Page: it works"]);
     },

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -1,4 +1,4 @@
-import { colors } from "$fresh/src/server/deps.ts";
+import { colors, toFileUrl } from "$fresh/src/server/deps.ts";
 import { assert } from "$std/_util/asserts.ts";
 import * as path from "$std/path/mod.ts";
 import {
@@ -288,7 +288,7 @@ export async function withFakeServe(
   const fixture = join(Deno.cwd(), name);
   const dev = basename(name) === "dev.ts";
 
-  const manifestPath = join(dirname(fixture), "fresh.gen.ts");
+  const manifestPath = toFileUrl(join(dirname(fixture), "fresh.gen.ts")).href;
   const manifestMod = await import(manifestPath);
 
   const server = await fakeServe(manifestMod.default, { dev });

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -2,19 +2,37 @@ import { colors } from "$fresh/src/server/deps.ts";
 import { assert } from "$std/_util/asserts.ts";
 import * as path from "$std/path/mod.ts";
 import {
+  FromManifestOptions,
+  Manifest,
+  ServeHandlerInfo,
+  ServerContext,
+} from "$fresh/server.ts";
+import {
   assertEquals,
+  basename,
   delay,
+  dirname,
   DOMParser,
   HTMLElement,
   HTMLMetaElement,
+  join,
   Page,
   puppeteer,
   TextLineStream,
 } from "./deps.ts";
 
-export function parseHtml(input: string): Document {
+export interface TestDocument extends Document {
+  debug(): void;
+}
+
+export function parseHtml(input: string): TestDocument {
   // deno-lint-ignore no-explicit-any
-  return new DOMParser().parseFromString(input, "text/html") as any;
+  const doc = new DOMParser().parseFromString(input, "text/html") as any;
+  Object.defineProperty(doc, "debug", {
+    value: () => console.log(prettyDom(doc)),
+    enumerable: false,
+  });
+  return doc;
 }
 
 export async function startFreshServer(options: Deno.CommandOptions) {
@@ -205,6 +223,76 @@ export async function withPageName(
     // Drain the lines stream
     for await (const _ of lines) { /* noop */ }
   }
+}
+
+export interface FakeServer {
+  request(req: Request): Promise<Response>;
+  getHtml(pathname: string): Promise<TestDocument>;
+  get(pathname: string): Promise<Response>;
+}
+
+async function handleRequest(
+  handler: ReturnType<ServerContext["handler"]>,
+  conn: ServeHandlerInfo,
+  req: Request,
+) {
+  let res = await handler(req, conn);
+
+  // Follow redirects
+  while (res.headers.has("location")) {
+    const loc = res.headers.get("location");
+    const hostname = conn.remoteAddr.hostname;
+    res = await handler(new Request(`https://${hostname}${loc}`), conn);
+  }
+
+  return res;
+}
+
+export async function fakeServe(
+  manifest: Manifest,
+  options: FromManifestOptions,
+): Promise<FakeServer> {
+  const ctx = await ServerContext.fromManifest(manifest, options);
+  const handler = ctx.handler();
+
+  const conn: ServeHandlerInfo = {
+    remoteAddr: {
+      transport: "tcp",
+      hostname: "127.0.0.1",
+      port: 80,
+    },
+  };
+
+  const origin = `https://127.0.0.1`;
+
+  return {
+    request(req) {
+      return handler(req, conn);
+    },
+    async getHtml(pathname) {
+      const req = new Request(`${origin}${pathname}`);
+      const res = await handleRequest(handler, conn, req);
+      return parseHtml(await res.text());
+    },
+    get(pathname: string) {
+      const req = new Request(`${origin}${pathname}`);
+      return handleRequest(handler, conn, req);
+    },
+  };
+}
+
+export async function withFakeServe(
+  name: string,
+  cb: (server: FakeServer) => Promise<void> | void,
+) {
+  const fixture = join(Deno.cwd(), name);
+  const dev = basename(name) === "dev.ts";
+
+  const manifestPath = join(dirname(fixture), "fresh.gen.ts");
+  const manifestMod = await import(manifestPath);
+
+  const server = await fakeServe(manifestMod.default, { dev });
+  await cb(server);
 }
 
 export async function startFreshServerExpectErrors(

--- a/tests/twind_test.ts
+++ b/tests/twind_test.ts
@@ -1,7 +1,12 @@
 import { assert, assertEquals, assertMatch, delay, puppeteer } from "./deps.ts";
 
 import { cmpStringArray } from "./fixture_twind_hydrate/utils/utils.ts";
-import { startFreshServer, withFresh, withPageName } from "./test_utils.ts";
+import {
+  startFreshServer,
+  withFakeServe,
+  withFresh,
+  withPageName,
+} from "./test_utils.ts";
 
 /**
  * Start the server with the main file.
@@ -339,24 +344,21 @@ Deno.test({
 });
 
 // Test for: https://github.com/denoland/fresh/issues/1655
-Deno.test({
-  name: "don't duplicate css class",
-  async fn() {
-    await withFresh(
-      "./tests/fixture_twind_app/main.ts",
-      async (address) => {
-        const res = await fetch(`${address}/app_class`);
-        assertEquals(res.status, 200);
+Deno.test("don't duplicate css class", async () => {
+  await withFakeServe(
+    "./tests/fixture_twind_app/main.ts",
+    async (server) => {
+      const res = await server.get(`/app_class`);
+      assertEquals(res.status, 200);
 
-        // Don't use an HTML parser here which would de-duplicate the
-        // class names automatically
-        const html = await res.text();
-        assertMatch(html, /html class="bg-slate-800">/);
-        assertMatch(html, /head class="bg-slate-800">/);
-        assertMatch(html, /body class="bg-slate-800">/);
-      },
-    );
-  },
+      // Don't use an HTML parser here which would de-duplicate the
+      // class names automatically
+      const html = await res.text();
+      assertMatch(html, /html class="bg-slate-800">/);
+      assertMatch(html, /head class="bg-slate-800">/);
+      assertMatch(html, /body class="bg-slate-800">/);
+    },
+  );
 });
 
 // Test for: https://github.com/denoland/fresh/issues/1655


### PR DESCRIPTION
This PR speeds up tests by handling custom created `Requests` object directly instead of binding a socket and making a real HTTP request. For most tests this is fine, and for those that aren't the existing testing methods are all preserved.