### PR TITLE
feat: Add support for mapped providers to Fresh plugin

### DIFF
--- a/plugins/kv_oauth.ts
+++ b/plugins/kv_oauth.ts
@@ -1,5 +1,5 @@
 import { handleCallback, signIn, signOut } from "./kv_oauth/plugin_deps.ts";
-import type { OAuth2Client } from "./kv_oauth/plugin_deps.ts";
+import { OAuth2Client } from "./kv_oauth/plugin_deps.ts";
 import type { Plugin } from "../server.ts";
 
 export interface KvOAuthPluginOptions {
@@ -43,22 +43,88 @@ export interface KvOAuthPluginOptions {
  * });
  * ```
  */
-export default function kvOAuthPlugin(
+export function kvOAuthPlugin(
   oauth2Client: OAuth2Client,
   options?: KvOAuthPluginOptions,
+): Plugin;
+
+/**
+ * This creates handlers for the following routes:
+ * - `GET /oauth/[PROVIDER_SLUG]/signin` for the sign-in page
+ * - `GET /oauth/[PROVIDER_SLUG]/callback` for the callback page
+ * - `GET /oauth/[PROVIDER_SLUG]/signout` for the sign-out page
+ *
+ * ```ts
+ * // main.ts
+ * import { start } from "$fresh/server.ts";
+ * import { createGitHubOAuth2Client } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
+ * import { kvOAuthPlugin } from "https://deno.land/x/deno_kv_oauth@$VERSION/fresh.ts";
+ * import manifest from "./fresh.gen.ts";
+ *
+ * await start(manifest, {
+ *   plugins: [
+ *      kvOAuthPlugin({
+ *          github: createGitHubOAuth2Client(),
+ *      })
+ *   ]
+ * });
+ * ```
+ */
+export function kvOAuthPlugin(providers: Record<string, OAuth2Client>): Plugin;
+
+/**
+ * This creates handlers for the following routes:
+ * - `GET /oauth/signin` for the sign-in page
+ * - `GET /oauth/callback` for the callback page
+ * - `GET /oauth/signout` for the sign-out page
+ *
+ * ```ts
+ * // main.ts
+ * import { start } from "$fresh/server.ts";
+ * import kvOAuthPlugin from "$fresh/plugins/kv_oauth.ts";
+ * import { createGitHubOAuth2Client } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
+ * import manifest from "./fresh.gen.ts";
+ *
+ * await start(manifest, {
+ *   plugins: [
+ *     kvOAuthPlugin(createGitHubOAuth2Client())
+ *   ]
+ * });
+ * ```
+ */
+export default function kvOAuthPlugin(
+  ...args: [
+    oauth2Client: OAuth2Client,
+    options?: KvOAuthPluginOptions,
+  ] | [
+    providers: Record<string, OAuth2Client>,
+  ]
 ): Plugin {
-  return {
-    name: "kv-oauth",
-    routes: [
+  const routes: Plugin["routes"] = [];
+
+  if (args.length >= 3 || args.length <= 0) {
+    throw new Error(
+      `Unable to initialise kv-oauth plugin with. Expected 1-2 arguments, got ${args.length}.`,
+    );
+  }
+
+  const [providersOrOAuth2Client] = args;
+
+  if (providersOrOAuth2Client instanceof OAuth2Client) {
+    const [_, options] = args;
+    routes.push(
       {
         path: options?.signInPath ?? "/oauth/signin",
-        handler: async (req) => await signIn(req, oauth2Client),
+        handler: async (req) => await signIn(req, providersOrOAuth2Client),
       },
       {
         path: options?.callbackPath ?? "/oauth/callback",
         handler: async (req) => {
           // Return object also includes `accessToken` and `sessionId` properties.
-          const { response } = await handleCallback(req, oauth2Client);
+          const { response } = await handleCallback(
+            req,
+            providersOrOAuth2Client,
+          );
           return response;
         },
       },
@@ -66,6 +132,37 @@ export default function kvOAuthPlugin(
         path: options?.signOutPath ?? "/oauth/signout",
         handler: signOut,
       },
-    ],
+    );
+  } else {
+    Object.entries(providersOrOAuth2Client).forEach((
+      [providerName, oauth2Client],
+    ) =>
+      routes.push(
+        {
+          path: `/oauth/${providerName}/signin`,
+          handler: async (req) => await signIn(req, oauth2Client),
+        },
+        {
+          path: `/oauth/${providerName}/callback`,
+          handler: async (req) => {
+            // Return object also includes `accessToken` and `sessionId` properties.
+            const { response } = await handleCallback(
+              req,
+              oauth2Client,
+            );
+            return response;
+          },
+        },
+        {
+          path: `/oauth/${providerName}/signout`,
+          handler: signOut,
+        },
+      )
+    );
+  }
+
+  return {
+    name: "kv-oauth",
+    routes,
   };
 }

--- a/plugins/kv_oauth/plugin_test.ts
+++ b/plugins/kv_oauth/plugin_test.ts
@@ -36,4 +36,18 @@ Deno.test("kvOAuthPlugin() works correctly", async (test) => {
       signOutPath,
     ]);
   });
+
+  await test.step("with mapped providers", () => {
+    const providerKey = "customProvider";
+    const plugin = kvOAuthPlugin({
+      [providerKey]: oauth2Client,
+    });
+    assertNotEquals(plugin.routes, undefined);
+    assert(plugin.routes!.every((route) => route.handler !== undefined));
+    assertArrayIncludes(plugin.routes!.map((route) => route.path), [
+      `/oauth/${providerKey}/signin`,
+      `/oauth/${providerKey}/callback`,
+      `/oauth/${providerKey}/signout`,
+    ]);
+  });
 });


### PR DESCRIPTION
This change was originally proposed in denoland/deno_kv_oauth#189 but was postponed until the plugin was moved to the `denoland/fresh` repository.

### What is this change?

A nice quality of life improvement that allows developers to pass in an object where each key is used to create a dynamic URL for the routes added by following this pattern: `/oauth/[PROVIDER_SLUG]/...`. This makes it simpler to add multiple OAuth2 providers.

### What's been changed?

 - Updated Deno Fresh plugin
	 - Added function override to `kvOAuthPlugin` function
	 - Added new test step to account for the above

### Example

```ts
// main.ts
import { start } from "$fresh/server.ts";
import { createGitHubOAuth2Client } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
import { kvOAuthPlugin } from "https://deno.land/x/deno_kv_oauth@$VERSION/fresh.ts";
import manifest from "./fresh.gen.ts";

await start(manifest, {
  plugins: [
	kvOAuthPlugin({
		// Generates the following routes:
		// `/oauth/github/signin`
		// `/oauth/github/callback`
		// `/oauth/github/signout`
		github: createGitHubOAuth2Client(),
	}),
  ],
});
```