### PR TITLE
fix: Fix typo in hover rule for default non-twind CSS

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -423,7 +423,7 @@ html {
 .rounded {
   border-radius: 0.25rem;
 }
-.hover\:bg-gray-200:hover {
+.hover\\:bg-gray-200:hover {
   background-color: #e5e7eb;
 }
 `;


### PR DESCRIPTION
In a new Fresh project, I noticed a typo in the generated file `static/styles.css`. The generated CSS file has the line `.hover:bg-gray-200:hover {`, and the hover style did not work by default. When I locally replaced that line with `.hover\:bg-gray-200:hover {`, the hover style started to work as expected.