### PR TITLE
chore: Run all tests in parallel on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,5 @@ jobs:
       - name: Type check project
         run: deno task check:types
 
-      - name: Run tests Windows
-        if: matrix.os == 'windows-latest'
-        run: deno test -A --trace-ops --unstable
-
-      - name: Run tests macOS + Linux
-        if: matrix.os != 'windows-latest'
+      - name: Run tests
         run: deno test -A --parallel --trace-ops --unstable


### PR DESCRIPTION
With the flakyness of the test suite resolved we should be able to run tests in parallel on all platforms.