### PR TITLE
feat: Add `InferOAuthProviders` utility type to KV OAuth plugin

### DIFF
--- a/plugins/kv_oauth.ts
+++ b/plugins/kv_oauth.ts
@@ -2,6 +2,40 @@ import { handleCallback, signIn, signOut } from "./kv_oauth/plugin_deps.ts";
 import { OAuth2Client } from "./kv_oauth/plugin_deps.ts";
 import type { Plugin } from "../server.ts";
 
+/**
+ * This is a helper type to infer the routes created by the `kvOAuthPlugin` function.
+ *
+ * Use a KV OAuth plugin instance to infer the routes paths.
+ *
+ * @example
+ * ```ts
+ * // main.ts
+ * import { start } from "$fresh/server.ts";
+ * import { createGitHubOAuth2Client } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
+ * import { kvOAuthPlugin } from "https://deno.land/x/deno_kv_oauth@$VERSION/fresh.ts";
+ * import manifest from "./fresh.gen.ts";
+ *
+ * const kvOAuth = kvOAuthPlugin({
+ *   github: createGitHubOAuth2Client(),
+ * });
+ *
+ * export type KVOAuthRoutes = InferOAuthProviders<typeof kvOAuth>;
+ * //            ^? type Foo = "/oauth/github/signin" | "/oauth/github/callback" | "/oauth/github/signout"
+ *
+ * await start(manifest, {
+ *   plugins: [kvOAuth],
+ * });
+ * ```
+ */
+export type InferOAuthProviders<T, U = T extends Plugin<infer U> ? U : never> =
+  {
+    [K in keyof U]: K extends string ?
+        | `/oauth/${K}/signin`
+        | `/oauth/${K}/callback`
+        | `/oauth/${K}/signout`
+      : never;
+  }[keyof U];
+
 export interface KvOAuthPluginOptions {
   /**
    * Sign-in page path

--- a/plugins/kv_oauth.ts
+++ b/plugins/kv_oauth.ts
@@ -70,7 +70,9 @@ export function kvOAuthPlugin(
  * });
  * ```
  */
-export function kvOAuthPlugin(providers: Record<string, OAuth2Client>): Plugin;
+export function kvOAuthPlugin<
+  const TProviders extends Record<string, OAuth2Client>,
+>(providers: TProviders): Plugin<TProviders>;
 
 /**
  * This creates handlers for the following routes:
@@ -92,14 +94,16 @@ export function kvOAuthPlugin(providers: Record<string, OAuth2Client>): Plugin;
  * });
  * ```
  */
-export default function kvOAuthPlugin(
+export default function kvOAuthPlugin<
+  const TProviders extends Record<string, OAuth2Client>,
+>(
   ...args: [
     oauth2Client: OAuth2Client,
     options?: KvOAuthPluginOptions,
   ] | [
-    providers: Record<string, OAuth2Client>,
+    providers: TProviders,
   ]
-): Plugin {
+): Plugin<Record<keyof TProviders, unknown>> {
   const routes: Plugin["routes"] = [];
 
   if (args.length >= 3 || args.length <= 0) {


### PR DESCRIPTION
### What is this change?

This is mainly a spitball idea that could offer a nice QoL improvement for those using TypeScript heavily, so of course open to feedback.

The basic idea is that for those using the Fresh KV OAuth plugin can move it out to a variable. That way they can pass it to the plugins array like normal, but also now use this new `InferOAuthProviders` type to get a union of strings for all the possible routes.

### What's been changed?

 - Updated Fresh KV OAuth plugin
	 - Added `const` type argument to both providers override alongside implementation signature.
	 - Added new `InferOAuthProviders` utility type to infer a union of strings from a Fresh `Plugin` type.

### Example

```ts
// main.ts
import { start } from "$fresh/server.ts";
import { createGitHubOAuth2Client } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
import { kvOAuthPlugin } from "https://deno.land/x/deno_kv_oauth@$VERSION/fresh.ts";
import manifest from "./fresh.gen.ts";

const kvOAuth = kvOAuthPlugin({
	github: createGitHubOAuth2Client(),
});

export type KVOAuthRoutes = InferOAuthProviders<typeof kvOAuth>;
//            ^? type Foo = "/oauth/github/signin" | "/oauth/github/callback" | "/oauth/github/signout"

await start(manifest, {
	plugins: [kvOAuth],
});
```

```tsx
// routes/index.tsx
import type { KVOAuthRoutes } from '../main.ts';

const url: KVOAuthRoutes = '/oauth/github/signin';

export default function Home () {
	return (
		<a href={url}>Sign In</a>
	)
}
```