### PR TITLE
Fix default fresh config with twind to pass fmt check

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -504,7 +504,8 @@ try {
 let FRESH_CONFIG_TS = `import { defineConfig } from "$fresh/server.ts";\n`;
 if (useTwind) {
   FRESH_CONFIG_TS += `import twindPlugin from "$fresh/plugins/twind.ts";
-import twindConfig from "./twind.config.ts";`;
+import twindConfig from "./twind.config.ts";
+`;
 }
 
 FRESH_CONFIG_TS += `

--- a/init.ts
+++ b/init.ts
@@ -503,13 +503,13 @@ try {
 
 let FRESH_CONFIG_TS = `import { defineConfig } from "$fresh/server.ts";\n`;
 if (useTwind) {
-  FRESH_CONFIG_TS += `import twindPlugin from "$fresh/plugins/twind.ts"
+  FRESH_CONFIG_TS += `import twindPlugin from "$fresh/plugins/twind.ts";
 import twindConfig from "./twind.config.ts";`;
 }
 
 FRESH_CONFIG_TS += `
 export default defineConfig({${
-  useTwind ? `\n  plugins: [twindPlugin(twindConfig)]\n` : ""
+  useTwind ? `\n  plugins: [twindPlugin(twindConfig)],\n` : ""
 }});
 `;
 const CONFIG_TS_PATH = join(resolvedDirectory, "fresh.config.ts");


### PR DESCRIPTION
After starting a new Fresh project with twind, `fresh.config.ts` looked liked the following, which did not pass the initial the `deno fmt --check` portion within the `deno task check` command:
```
import { defineConfig } from "$fresh/server.ts";
import twindPlugin from "$fresh/plugins/twind.ts"
import twindConfig from "./twind.config.ts";
export default defineConfig({
  plugins: [twindPlugin(twindConfig)]
});
```

This pull request intends to make it look like the following, primarily to fix the errors that the `deno fmt --check` command emitted (see first commit's description for the emitted errors), and secondarily to be a tad bit prettier with a newline separator:
```
import { defineConfig } from "$fresh/server.ts";
import twindPlugin from "$fresh/plugins/twind.ts";
import twindConfig from "./twind.config.ts";

export default defineConfig({
  plugins: [twindPlugin(twindConfig)],
});
```