### PR TITLE
feat(dev): Allow setting host and port

### DIFF
--- a/docs/canary/getting-started/running-locally.md
+++ b/docs/canary/getting-started/running-locally.md
@@ -35,17 +35,29 @@ passing the extra folder as an argument: `--watch=static/`. You should also add
 `routes/` to the watch list, so that the server restarts automatically whenever
 you add a new route.
 
-If you want to change the port or host, modify the config bag of the `start()`
-call in `main.ts` to include an explicit port number:
+If you want to change the port or host, modify the config bag of the
+`defineConfig()` call in `fresh.config.ts` to include an explicit port number:
 
-```js main.ts
-await start(manifest, { port: 3000 });
+```js fresh.config.ts
+export default defineConfig({
+  server: {
+    port: 3000,
+    hostname: "0.0.0.0",
+  },
+});
 ```
 
-You can also change the port by setting the `PORT` environment variable:
+You can also change the port and hostname by setting the `PORT` and `HOST`
+environment variables:
 
 ```sh Terminal
-$ PORT=3000 deno task start
+$ HOST=0.0.0.0 PORT=3000 deno task start
+```
+
+There is also a `--port` and a `--host` flag that can be passed to set them.
+
+```sh Terminal
+$ deno task start --port 3000 --host 0.0.0.0
 ```
 
 Combining all of this we get the following `deno run` command:

--- a/docs/latest/getting-started/running-locally.md
+++ b/docs/latest/getting-started/running-locally.md
@@ -35,11 +35,16 @@ passing the extra folder as an argument: `--watch=static/`. You should also add
 `routes/` to the watch list, so that the server restarts automatically whenever
 you add a new route.
 
-If you want to change the port or host, modify the config bag of the `start()`
-call in `main.ts` to include an explicit port number:
+If you want to change the port or host, modify the config bag of the
+`defineConfig()` call in `fresh.config.ts` to include an explicit port number:
 
-```js main.ts
-await start(manifest, { port: 3000, hostname: "0.0.0.0" });
+```js fresh.config.ts
+export default defineConfig({
+  server: {
+    port: 3000,
+    hostname: "0.0.0.0",
+  },
+});
 ```
 
 You can also change the port and hostname by setting the `PORT` and `HOST`

--- a/docs/latest/getting-started/running-locally.md
+++ b/docs/latest/getting-started/running-locally.md
@@ -39,13 +39,20 @@ If you want to change the port or host, modify the config bag of the `start()`
 call in `main.ts` to include an explicit port number:
 
 ```js main.ts
-await start(manifest, { port: 3000 });
+await start(manifest, { port: 3000, hostname: "0.0.0.0" });
 ```
 
-You can also change the port by setting the `PORT` environment variable:
+You can also change the port and hostname by setting the `PORT` and `HOST`
+environment variables:
 
 ```sh Terminal
-$ PORT=3000 deno task start
+$ HOST=0.0.0.0 PORT=3000 deno task start
+```
+
+There is also a `--port` and a `--host` flag that can be passed to set them.
+
+```sh Terminal
+$ deno task start --port 3000 --host 0.0.0.0
 ```
 
 Combining all of this we get the following `deno run` command:

--- a/docs/toc.ts
+++ b/docs/toc.ts
@@ -30,7 +30,7 @@ const toc: RawTableOfContents = {
         link: "latest",
         pages: [
           ["create-a-project", "Create a project", "link:latest"],
-          ["running-locally", "Running locally", "link:latest"],
+          ["running-locally", "Running locally", "link:canary"],
           ["create-a-route", "Create a route", "link:latest"],
           ["dynamic-routes", "Dynamic routes", "link:latest"],
           ["custom-handlers", "Custom handlers", "link:latest"],

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -25,3 +25,4 @@ export {
   assertEquals,
   assertThrows,
 } from "https://deno.land/std@0.205.0/assert/mod.ts";
+export { parse } from "https://deno.land/std@0.205.0/flags/mod.ts";

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -887,16 +887,17 @@ Deno.test("PORT environment variable", async () => {
   for await (const _ of lines) { /* noop */ }
 });
 
-Deno.test("HOST environment variable", async () => {
+Deno.test("HOST & PORT environment variable", async () => {
   const HOST = "127.0.0.1";
+  const PORT = "8888";
   const { serverProcess, lines } = await startFreshServer({
     args: ["run", "-A", "./tests/fixture/main.ts"],
-    env: { HOST },
+    env: { HOST, PORT },
   });
 
   await delay(100);
 
-  const resp = await fetch(`http://${HOST}:8000`);
+  const resp = await fetch(`http://${HOST}:${PORT}`);
   await resp.body?.cancel();
   assert(resp);
   assertEquals(resp.status, Status.OK);

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -887,6 +887,27 @@ Deno.test("PORT environment variable", async () => {
   for await (const _ of lines) { /* noop */ }
 });
 
+Deno.test("HOST environment variable", async () => {
+  const HOST = "127.0.0.1";
+  const { serverProcess, lines } = await startFreshServer({
+    args: ["run", "-A", "./tests/fixture/main.ts"],
+    env: { HOST },
+  });
+
+  await delay(100);
+
+  const resp = await fetch(`http://${HOST}:8000`);
+  await resp.body?.cancel();
+  assert(resp);
+  assertEquals(resp.status, Status.OK);
+  await resp.body!.cancel();
+
+  serverProcess.kill("SIGTERM");
+  await serverProcess.status;
+
+  for await (const _ of lines) { /* noop */ }
+});
+
 Deno.test(
   "throw on route export 'handlers' instead of 'handler'",
   async () => {

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -459,7 +459,7 @@ async function spawnServer(
   // @ts-ignore yes it does
   for await (const line of lines.values({ preventCancel: true })) {
     output.push(line);
-    const match = line.match(/https?:\/\/localhost:\d+/g);
+    const match = line.match(/https?:\/\/.*:\d+/g);
     if (match) {
       address = match[0];
       break;


### PR DESCRIPTION
This adds `--host` and `--port` flags to allow running fresh with a custom IP and port to listen on for requests.