### PR TITLE
ci: run on latest stable version of Deno

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deno: ["canary"]
+        deno: ["canary", "v1.x"]
         os: [macOS-latest, windows-latest, ubuntu-latest]
         include:
         - os: ubuntu-latest

--- a/src/server/code_frame.ts
+++ b/src/server/code_frame.ts
@@ -63,7 +63,7 @@ export function createCodeFrame(
       (padding + (i + start + 1)).slice(-maxLineNum),
     );
 
-    // Line where the error occured
+    // Line where the error occurred
     if (i === lineNum - start) {
       out += colors.red(">") +
         ` ${currentLine} ${sep} ${line}\n`;


### PR DESCRIPTION
This PR changes CI to include the latest stable version of Deno, alongside canary. This is important for picking up bugs in canary. This seems like a reasonable thing to have for overall stability.

Possible prerequisite for #1819