### PR TITLE
fix: show marker confusion

### DIFF
--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -129,7 +129,7 @@ function hideMarker(marker: Marker) {
   const parent = endNode!.parentNode!;
 
   if (
-    SHOW_MARKERS && startNode !== null &&
+    !SHOW_MARKERS && startNode !== null &&
     startNode.nodeType === Node.COMMENT_NODE
   ) {
     const text = new Text("");
@@ -139,7 +139,7 @@ function hideMarker(marker: Marker) {
   }
 
   if (
-    SHOW_MARKERS && endNode !== null && endNode.nodeType === Node.COMMENT_NODE
+    !SHOW_MARKERS && endNode !== null && endNode.nodeType === Node.COMMENT_NODE
   ) {
     const text = new Text("");
     marker.endNode = text;

--- a/tests/fixture_island_nesting/fresh.gen.ts
+++ b/tests/fixture_island_nesting/fresh.gen.ts
@@ -31,6 +31,7 @@ import * as $$7 from "./islands/IslandFn.tsx";
 import * as $$8 from "./islands/IslandInsideIsland.tsx";
 import * as $$9 from "./islands/IslandWithProps.tsx";
 import * as $$10 from "./islands/PassThrough.tsx";
+import * as $$11 from "./islands/ReadyMarker.tsx";
 
 const manifest = {
   routes: {
@@ -65,6 +66,7 @@ const manifest = {
     "./islands/IslandInsideIsland.tsx": $$8,
     "./islands/IslandWithProps.tsx": $$9,
     "./islands/PassThrough.tsx": $$10,
+    "./islands/ReadyMarker.tsx": $$11,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/fixture_island_nesting/islands/ReadyMarker.tsx
+++ b/tests/fixture_island_nesting/islands/ReadyMarker.tsx
@@ -1,0 +1,15 @@
+import { useSignal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+
+export function ReadyMarker() {
+  const sig = useSignal(false);
+  useEffect(() => {
+    sig.value = true;
+  }, []);
+
+  return (
+    <p class={sig.value ? "mounted" : "pending"}>
+      {sig.value ? "mounted" : "pending"}
+    </p>
+  );
+}

--- a/tests/fixture_island_nesting/routes/island_conditional_lazy_island.tsx
+++ b/tests/fixture_island_nesting/routes/island_conditional_lazy_island.tsx
@@ -2,6 +2,7 @@ import IslandConditional from "../islands/IslandConditional.tsx";
 import BooleanButton from "../islands/BooleanButton.tsx";
 import { useSignal } from "@preact/signals";
 import Counter from "../islands/Counter.tsx";
+import { ReadyMarker } from "../islands/ReadyMarker.tsx";
 
 export default function Page() {
   const show = useSignal(true);
@@ -16,6 +17,7 @@ export default function Page() {
         </div>
       </IslandConditional>
       <BooleanButton signal={show} />
+      <ReadyMarker />
     </div>
   );
 }

--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -1,11 +1,6 @@
+import { assert, assertEquals, assertStringIncludes, Page } from "./deps.ts";
 import {
-  assert,
-  assertEquals,
-  assertStringIncludes,
-  delay,
-  Page,
-} from "./deps.ts";
-import {
+  assertNoPageComments,
   assertNotSelector,
   assertSelector,
   assertTextMatch,
@@ -16,139 +11,115 @@ import {
   withPageName,
 } from "./test_utils.ts";
 
-Deno.test({
-  name: "island tests",
-  async fn(t) {
-    await withPage(async (page, address) => {
-      async function counterTest(counterId: string, originalValue: number) {
-        const pElem = await page.waitForSelector(`#${counterId} > p`);
+Deno.test("island tests", async (t) => {
+  await withPage(async (page, address) => {
+    async function counterTest(counterId: string, originalValue: number) {
+      const pElem = await page.waitForSelector(`#${counterId} > p`);
 
-        const value = await pElem?.evaluate((el) => el.textContent);
-        assert(value === `${originalValue}`, `${counterId} first value`);
+      const value = await pElem?.evaluate((el) => el.textContent);
+      assert(value === `${originalValue}`, `${counterId} first value`);
 
-        await clickWhenListenerReady(page, `#b-${counterId}`);
-        await waitForText(page, `#${counterId} > p`, String(originalValue + 1));
-      }
+      await clickWhenListenerReady(page, `#b-${counterId}`);
+      await waitForText(page, `#${counterId} > p`, String(originalValue + 1));
+    }
 
-      await page.goto(`${address}/islands`, {
-        waitUntil: "networkidle2",
-      });
+    await page.goto(`${address}/islands`);
 
-      await t.step("Ensure 5 islands on 1 page are revived", async () => {
-        await counterTest("counter1", 3);
-        await counterTest("counter2", 10);
-        await counterTest("folder-counter", 3);
-        await counterTest("subfolder-counter", 3);
-        await counterTest("kebab-case-file-counter", 5);
-      });
-
-      await t.step("Ensure an island revive an img 'hash' path", async () => {
-        // Ensure src path has __frsh_c=
-        const pElem = await page.waitForSelector(`#img-in-island`);
-        const srcString = (await pElem?.getProperty("src"))?.toString()!;
-        assertStringIncludes(srcString, "image.png?__frsh_c=");
-
-        // Ensure src path is the same as server rendered
-        const resp = await fetch(new Request(`${address}/islands`));
-        const body = await resp.text();
-
-        const imgFilePath = body.match(/img id="img-in-island" src="(.*?)"/)
-          ?.[1]!;
-        assertStringIncludes(srcString, imgFilePath);
-      });
+    await t.step("Ensure 5 islands on 1 page are revived", async () => {
+      await counterTest("counter1", 3);
+      await counterTest("counter2", 10);
+      await counterTest("folder-counter", 3);
+      await counterTest("subfolder-counter", 3);
+      await counterTest("kebab-case-file-counter", 5);
     });
-  },
+
+    await t.step("Ensure an island revive an img 'hash' path", async () => {
+      // Ensure src path has __frsh_c=
+      const pElem = await page.waitForSelector(`#img-in-island`);
+      const srcString = (await pElem?.getProperty("src"))?.toString()!;
+      assertStringIncludes(srcString, "image.png?__frsh_c=");
+
+      // Ensure src path is the same as server rendered
+      const resp = await fetch(new Request(`${address}/islands`));
+      const body = await resp.text();
+
+      const imgFilePath = body.match(/img id="img-in-island" src="(.*?)"/)
+        ?.[1]!;
+      assertStringIncludes(srcString, imgFilePath);
+    });
+  });
 });
 
-Deno.test({
-  name: "multiple islands exported from one file",
-  async fn(t) {
-    await withPage(async (page, address) => {
-      async function counterTest(counterId: string, originalValue: number) {
-        const pElem = await page.waitForSelector(`#${counterId} > p`);
+Deno.test("multiple islands exported from one file", async (t) => {
+  await withPage(async (page, address) => {
+    async function counterTest(counterId: string, originalValue: number) {
+      const pElem = await page.waitForSelector(`#${counterId} > p`);
 
-        const value = await pElem?.evaluate((el) => el.textContent);
-        assert(value === `${originalValue}`, `${counterId} first value`);
+      const value = await pElem?.evaluate((el) => el.textContent);
+      assert(value === `${originalValue}`, `${counterId} first value`);
 
-        await clickWhenListenerReady(page, `#b-${counterId}`);
-        await waitForText(page, `#${counterId} > p`, String(originalValue + 1));
-      }
+      await clickWhenListenerReady(page, `#b-${counterId}`);
+      await waitForText(page, `#${counterId} > p`, String(originalValue + 1));
+    }
 
-      await page.goto(`${address}/islands/multiple_island_exports`, {
-        waitUntil: "networkidle2",
-      });
+    await page.goto(`${address}/islands/multiple_island_exports`);
 
-      await t.step("Ensure 3 islands on 1 page are revived", async () => {
-        await counterTest("counter0", 4);
-        await counterTest("counter1", 3);
-        await counterTest("counter2", 10);
-      });
+    await t.step("Ensure 3 islands on 1 page are revived", async () => {
+      await counterTest("counter0", 4);
+      await counterTest("counter1", 3);
+      await counterTest("counter2", 10);
     });
-  },
+  });
 });
 
 function withPage(fn: (page: Page, address: string) => Promise<void>) {
   return withPageName("./tests/fixture/main.ts", fn);
 }
 
-Deno.test({
-  name: "island tests with </script>",
-
-  async fn(t) {
-    await withPage(async (page, address) => {
-      page.on("dialog", () => {
-        assert(false, "There is XSS");
-      });
-
-      await page.goto(`${address}/evil`, {
-        waitUntil: "networkidle2",
-      });
-
-      await t.step("prevent XSS on Island", async () => {
-        const bodyElem = await page.waitForSelector(`body`);
-        const value = await bodyElem?.evaluate((el) => el.getInnerHTML());
-
-        assertStringIncludes(
-          value,
-          `{"message":"\\u003c/script\\u003e\\u003cscript\\u003ealert('test')\\u003c/script\\u003e"}`,
-          `XSS is not escaped`,
-        );
-      });
+Deno.test("island tests with </script>", async (t) => {
+  await withPage(async (page, address) => {
+    page.on("dialog", () => {
+      assert(false, "There is XSS");
     });
-  },
+
+    await page.goto(`${address}/evil`, {
+      waitUntil: "networkidle2",
+    });
+
+    await t.step("prevent XSS on Island", async () => {
+      const bodyElem = await page.waitForSelector(`body`);
+      const value = await bodyElem?.evaluate((el) => el.getInnerHTML());
+
+      assertStringIncludes(
+        value,
+        `{"message":"\\u003c/script\\u003e\\u003cscript\\u003ealert('test')\\u003c/script\\u003e"}`,
+        `XSS is not escaped`,
+      );
+    });
+  });
 });
 
-Deno.test({
-  name: "island with fragment as root",
+Deno.test("island with fragment as root", async () => {
+  await withPage(async (page, address) => {
+    await page.goto(`${address}/islands/root_fragment`);
 
-  async fn(_t) {
-    await withPage(async (page, address) => {
-      await page.goto(`${address}/islands/root_fragment`, {
-        waitUntil: "networkidle2",
-      });
+    const clickableSelector = "#root-fragment-click-me";
 
-      const clickableSelector = "#root-fragment-click-me";
+    await page.waitForSelector(clickableSelector);
 
-      await page.waitForSelector(clickableSelector);
+    await waitForText(page, `#island-parent`, "HelloWorld");
 
-      await waitForText(page, `#island-parent`, "HelloWorld");
-
-      await clickWhenListenerReady(page, clickableSelector);
-      await waitForText(page, `#island-parent`, "HelloWorldI'm rendered now");
-    });
-  },
+    await clickWhenListenerReady(page, clickableSelector);
+    await waitForText(page, `#island-parent`, "HelloWorldI'm rendered now");
+  });
 });
 
-Deno.test({
-  name: "island with fragment as root and conditional child first",
-
-  async fn(_t) {
+Deno.test(
+  "island with fragment as root and conditional child first",
+  async () => {
     await withPage(async (page, address) => {
       await page.goto(
         `${address}/islands/root_fragment_conditional_first`,
-        {
-          waitUntil: "networkidle2",
-        },
       );
 
       const clickableSelector = "#root-fragment-conditional-first-click-me";
@@ -164,149 +135,104 @@ Deno.test({
       );
     });
   },
+);
+
+Deno.test("island that returns `null`", async () => {
+  await withPage(async (page, address) => {
+    await page.goto(`${address}/islands/returning_null`);
+    await page.waitForSelector(".added-by-use-effect");
+  });
 });
 
-Deno.test({
-  name: "island that returns `null`",
+Deno.test("island using `npm:` specifiers", async () => {
+  await withPageName("./tests/fixture_npm/main.ts", async (page, address) => {
+    await page.setJavaScriptEnabled(false);
+    await page.goto(address);
+    await page.waitForSelector("#server-true");
 
-  async fn(_t) {
-    await withPage(async (page, address) => {
-      await page.goto(`${address}/islands/returning_null`, {
-        waitUntil: "networkidle2",
-      });
-
-      await page.waitForSelector(".added-by-use-effect");
-    });
-  },
+    await page.setJavaScriptEnabled(true);
+    await page.reload();
+    await page.waitForSelector("#browser-true");
+  });
 });
 
-Deno.test({
-  name: "island using `npm:` specifiers",
-
-  async fn(_t) {
-    await withPageName("./tests/fixture_npm/main.ts", async (page, address) => {
-      await page.setJavaScriptEnabled(false);
-      await page.goto(address, { waitUntil: "networkidle2" });
-      assert(await page.waitForSelector("#server-true"));
-
-      await page.setJavaScriptEnabled(true);
-      await page.reload({ waitUntil: "networkidle2" });
-      assert(await page.waitForSelector("#browser-true"));
-    });
-  },
+Deno.test("works with older preact-render-to-string v5", async () => {
+  await withPageName(
+    "./tests/fixture_preact_rts_v5/main.ts",
+    async (page, address) => {
+      await page.goto(address);
+      await page.waitForSelector("#foo");
+      await waitForText(page, "#foo", "it works");
+      +await assertNoPageComments(page);
+    },
+  );
 });
 
-Deno.test({
-  name: "works with older preact-render-to-string v5",
-
-  async fn(_t) {
-    await withPageName(
-      "./tests/fixture_preact_rts_v5/main.ts",
-      async (page, address) => {
-        await page.goto(address, {
-          waitUntil: "networkidle2",
-        });
-        await page.waitForSelector("#foo");
-        await waitForText(page, "#foo", "it works");
-      },
-    );
-  },
+Deno.test("pass single JSX child to island", async () => {
+  await withPageName(
+    "./tests/fixture_island_nesting/main.ts",
+    async (page, address) => {
+      await page.goto(`${address}/island_jsx_child`);
+      await page.waitForSelector(".island");
+      await waitForText(page, ".island", "it works");
+      await assertNoPageComments(page);
+    },
+  );
 });
 
-Deno.test({
-  name: "pass single JSX child to island",
+Deno.test("pass multiple JSX children to island", async () => {
+  await withPageName(
+    "./tests/fixture_island_nesting/main.ts",
+    async (page, address) => {
+      await page.goto(`${address}/island_jsx_children`);
+      await page.waitForSelector(".island");
 
-  async fn(_t) {
-    await withPageName(
-      "./tests/fixture_island_nesting/main.ts",
-      async (page, address) => {
-        await page.goto(`${address}/island_jsx_child`, {
-          waitUntil: "networkidle2",
-        });
-        await page.waitForSelector(".island");
-        await waitForText(page, ".island", "it works");
-      },
-    );
-  },
+      await waitForText(page, ".island", "it works");
+      await assertNoPageComments(page);
+    },
+  );
 });
 
-Deno.test({
-  name: "pass multiple JSX children to island",
+Deno.test("pass multiple text JSX children to island", async () => {
+  await withPageName(
+    "./tests/fixture_island_nesting/main.ts",
+    async (page, address) => {
+      await page.goto(`${address}/island_jsx_text`);
+      await page.waitForSelector(".island");
 
-  async fn(_t) {
-    await withPageName(
-      "./tests/fixture_island_nesting/main.ts",
-      async (page, address) => {
-        await page.goto(`${address}/island_jsx_children`, {
-          waitUntil: "networkidle2",
-        });
-        await page.waitForSelector(".island");
-
-        await delay(100);
-        const text = await page.$eval(".island", (el) => el.textContent);
-        assertEquals(text, "it works");
-      },
-    );
-  },
+      await waitForText(page, ".island", "it works");
+      await assertNoPageComments(page);
+    },
+  );
 });
 
-Deno.test({
-  name: "pass multiple text JSX children to island",
-
-  async fn(_t) {
-    await withPageName(
-      "./tests/fixture_island_nesting/main.ts",
-      async (page, address) => {
-        await page.goto(`${address}/island_jsx_text`, {
-          waitUntil: "networkidle2",
-        });
-        await page.waitForSelector(".island");
-
-        await delay(100);
-        const text = await page.$eval(".island", (el) => el.textContent);
-        assertEquals(text, "it works");
-      },
-    );
-  },
+Deno.test("render island in island", async () => {
+  await withPageName(
+    "./tests/fixture_island_nesting/main.ts",
+    async (page, address) => {
+      await page.goto(`${address}/island_in_island`);
+      await page.waitForSelector(".island");
+      await waitForText(page, ".island .island p", "it works");
+      await assertNoPageComments(page);
+    },
+  );
 });
 
-Deno.test({
-  name: "render island in island",
+Deno.test("render island inside island definition", async () => {
+  await withPageName(
+    "./tests/fixture_island_nesting/main.ts",
+    async (page, address) => {
+      await page.goto(`${address}/island_in_island_definition`);
+      await page.waitForSelector(".island");
 
-  async fn(_t) {
-    await withPageName(
-      "./tests/fixture_island_nesting/main.ts",
-      async (page, address) => {
-        await page.goto(`${address}/island_in_island`, {
-          waitUntil: "networkidle2",
-        });
-        await page.waitForSelector(".island");
-        await waitForText(page, ".island .island p", "it works");
-      },
-    );
-  },
-});
+      await waitForText(page, ".island .island p", "it works");
 
-Deno.test({
-  name: "render island inside island definition",
-
-  async fn(_t) {
-    await withPageName(
-      "./tests/fixture_island_nesting/main.ts",
-      async (page, address) => {
-        await page.goto(`${address}/island_in_island_definition`, {
-          waitUntil: "networkidle2",
-        });
-        await page.waitForSelector(".island");
-
-        await waitForText(page, ".island .island p", "it works");
-
-        // Check that there is no duplicated content which could happen
-        // when islands aren't initialized correctly
-        await waitForText(page, "#page", "it works");
-      },
-    );
-  },
+      // Check that there is no duplicated content which could happen
+      // when islands aren't initialized correctly
+      await waitForText(page, "#page", "it works");
+      await assertNoPageComments(page);
+    },
+  );
 });
 
 Deno.test("render island inside island with conditional children", async () => {
@@ -315,27 +241,25 @@ Deno.test("render island inside island with conditional children", async () => {
     async (page, address) => {
       await page.goto(`${address}/dropdown`);
       await page.waitForSelector("button");
+      await assertNoPageComments(page);
 
       const doc = parseHtml(await page.content());
       assertNotSelector(doc, ".result");
 
       await page.click("button");
       await page.waitForSelector(".result");
+      await assertNoPageComments(page);
     },
   );
 });
 
-Deno.test({
-  name:
-    "render island with JSX children that render another island with JSX children",
-
-  async fn(_t) {
+Deno.test(
+  "render island with JSX children that render another island with JSX children",
+  async () => {
     await withPageName(
       "./tests/fixture_island_nesting/main.ts",
       async (page, address) => {
-        await page.goto(`${address}/island_jsx_island_jsx`, {
-          waitUntil: "networkidle2",
-        });
+        await page.goto(`${address}/island_jsx_island_jsx`);
         await page.waitForSelector(".island");
 
         await waitForText(
@@ -343,94 +267,81 @@ Deno.test({
           ".island .server .island .server p",
           "it works",
         );
+
+        await assertNoPageComments(page);
       },
     );
   },
+);
+
+Deno.test("render sibling islands", async () => {
+  await withPageName(
+    "./tests/fixture_island_nesting/main.ts",
+    async (page, address) => {
+      await page.goto(`${address}/island_siblings`);
+      await page.waitForSelector(".island");
+
+      await waitForText(page, ".island .a", "it works");
+      await waitForText(page, ".island + .island .b", "it works");
+      await assertNoPageComments(page);
+    },
+  );
 });
 
-Deno.test({
-  name: "render sibling islands",
+Deno.test("render sibling islands that render nothing initially", async () => {
+  await withPageName(
+    "./tests/fixture_island_nesting/main.ts",
+    async (page, address) => {
+      await page.goto(`${address}/island_conditional`);
+      await page.waitForSelector(".island");
+      await assertNoPageComments(page);
 
-  async fn(_t) {
-    await withPageName(
-      "./tests/fixture_island_nesting/main.ts",
-      async (page, address) => {
-        await page.goto(`${address}/island_siblings`, {
-          waitUntil: "networkidle2",
-        });
-        await page.waitForSelector(".island");
+      await page.click("button");
 
-        await waitForText(page, ".island .a", "it works");
-        await waitForText(page, ".island + .island .b", "it works");
-      },
-    );
-  },
+      // Button text is matched too, but this allows us
+      // to assert correct ordering. The "island content" should
+      // be left of "Toggle"
+      await waitForText(page, "#page", "island contentToggle");
+      await assertNoPageComments(page);
+    },
+  );
 });
 
-Deno.test({
-  name: "render sibling islands that render nothing initially",
+Deno.test("serialize inner island props", async () => {
+  await withPageName(
+    "./tests/fixture_island_nesting/main.ts",
+    async (page, address) => {
+      await page.goto(`${address}/island_nested_props`);
+      await page.waitForSelector(".island");
 
-  async fn(_t) {
-    await withPageName(
-      "./tests/fixture_island_nesting/main.ts",
-      async (page, address) => {
-        await page.goto(`${address}/island_conditional`);
-        await page.waitForSelector(".island");
-
-        await page.click("button");
-
-        // Button text is matched too, but this allows us
-        // to assert correct ordering. The "island content" should
-        // be left of "Toggle"
-        await waitForText(page, "#page", "island contentToggle");
-      },
-    );
-  },
+      await waitForText(page, ".island .island p", "it works");
+      await assertNoPageComments(page);
+    },
+  );
 });
 
-Deno.test({
-  name: "serialize inner island props",
-  async fn(_t) {
-    await withPageName(
-      "./tests/fixture_island_nesting/main.ts",
-      async (page, address) => {
-        await page.goto(`${address}/island_nested_props`);
-        await page.waitForSelector(".island");
-
-        await waitForText(page, ".island .island p", "it works");
-      },
-    );
-  },
+Deno.test("render island inside island when passed as fn child", async () => {
+  await withPageName(
+    "./tests/fixture_island_nesting/main.ts",
+    async (page, address) => {
+      await page.goto(`${address}/island_fn_child`);
+      await page.waitForSelector(".island");
+      await waitForText(page, "#page", "it works");
+      await assertNoPageComments(page);
+    },
+  );
 });
 
-Deno.test({
-  name: "render island inside island when passed as fn child",
-
-  async fn(_t) {
-    await withPageName(
-      "./tests/fixture_island_nesting/main.ts",
-      async (page, address) => {
-        await page.goto(`${address}/island_fn_child`);
-        await page.waitForSelector(".island");
-        await waitForText(page, "#page", "it works");
-      },
-    );
-  },
-});
-
-Deno.test({
-  name: "render nested islands in correct order",
-
-  async fn(_t) {
-    await withPageName(
-      "./tests/fixture_island_nesting/main.ts",
-      async (page, address) => {
-        await page.goto(`${address}/island_order`);
-        await page.waitForSelector(".island");
-        await waitForText(page, "#page", "leftcenterright");
-      },
-    );
-  },
+Deno.test("render nested islands in correct order", async () => {
+  await withPageName(
+    "./tests/fixture_island_nesting/main.ts",
+    async (page, address) => {
+      await page.goto(`${address}/island_order`);
+      await page.waitForSelector(".island");
+      await waitForText(page, "#page", "leftcenterright");
+      await assertNoPageComments(page);
+    },
+  );
 });
 
 Deno.test({
@@ -442,74 +353,76 @@ Deno.test({
       async (page, address) => {
         await page.goto(`${address}/island_conditional_lazy`);
         await waitForText(page, ".island p", "island content");
+        await assertNoPageComments(page);
 
         await page.click("button");
         await waitForText(page, ".island p", "server rendered");
+        await assertNoPageComments(page);
       },
     );
   },
 });
 
-Deno.test({
-  name: "revive island in lazy server rendered children conditionally",
-
-  async fn() {
+Deno.test(
+  "revive island in lazy server rendered children conditionally",
+  async () => {
     await withPageName(
       "./tests/fixture_island_nesting/main.ts",
       async (page, address) => {
         await page.goto(`${address}/island_conditional_lazy_island`);
         await waitForText(page, ".island p", "island content");
+        await page.waitForSelector(".mounted");
+        await assertNoPageComments(page);
 
         await page.click("button");
         await waitForText(page, ".island .server", "server rendered");
+        await assertNoPageComments(page);
 
         await page.click("button.counter");
         await waitForText(page, ".island .count", "1");
+        await assertNoPageComments(page);
       },
     );
   },
-});
+);
 
-Deno.test({
-  name: "revive boolean attributes",
+Deno.test("revive boolean attributes", async () => {
+  await withPageName(
+    "./tests/fixture/main.ts",
+    async (page, address) => {
+      await page.goto(`${address}/preact/boolean_attrs`);
+      await waitForText(page, ".form-revived", "Revived: true");
+      await assertNoPageComments(page);
 
-  async fn() {
-    await withPageName(
-      "./tests/fixture/main.ts",
-      async (page, address) => {
-        await page.goto(`${address}/preact/boolean_attrs`);
-        await waitForText(page, ".form-revived", "Revived: true");
+      const checked = await page.$eval(
+        "input[type=checkbox]",
+        (el) => el.checked,
+      );
+      assertEquals(checked, true, "Checkbox is not checked");
 
-        const checked = await page.$eval(
-          "input[type=checkbox]",
-          (el) => el.checked,
-        );
-        assertEquals(checked, true, "Checkbox is not checked");
+      const required = await page.$eval(
+        "input[type=text]",
+        (el) => el.required,
+      );
+      assertEquals(required, true, "Text input is not marked as required");
 
-        const required = await page.$eval(
-          "input[type=text]",
-          (el) => el.required,
-        );
-        assertEquals(required, true, "Text input is not marked as required");
+      const radioChecked = await page.$eval(
+        "input[type=radio][value='2']",
+        (el) => el.checked,
+      );
+      assertEquals(
+        radioChecked,
+        true,
+        "Text input is not marked as required",
+      );
 
-        const radioChecked = await page.$eval(
-          "input[type=radio][value='2']",
-          (el) => el.checked,
-        );
-        assertEquals(
-          radioChecked,
-          true,
-          "Text input is not marked as required",
-        );
-
-        const selected = await page.$eval(
-          "select",
-          (el) => el.options[el.selectedIndex].text,
-        );
-        assertEquals(selected, "bar", "'bar' value is not selected");
-      },
-    );
-  },
+      const selected = await page.$eval(
+        "select",
+        (el) => el.options[el.selectedIndex].text,
+      );
+      assertEquals(selected, "bar", "'bar' value is not selected");
+    },
+  );
 });
 
 Deno.test("throws when passing non-jsx children to an island", async (t) => {


### PR DESCRIPTION
Noticed myself getting confused by marker state, so I've updated the island tests to assert that they are not visible after reviving islands.