### PR TITLE
chore: append newline to produced json

### DIFF
--- a/update.ts
+++ b/update.ts
@@ -331,8 +331,7 @@ async function findSrcDirectory(
   return resolvedDirectory;
 }
 
-// deno-lint-ignore no-explicit-any
-export function stringifyFormattedJson(jsonStr: any): string {
-  // Ensure formatting rules are met
-  return JSON.stringify(jsonStr, null, 2) + "\n";
+export function stringifyFormattedJson(data: unknown): string {
+  // Append newline to ensure formatting rules are met
+  return JSON.stringify(data, null, 2) + "\n";
 }

--- a/update.ts
+++ b/update.ts
@@ -139,7 +139,7 @@ freshImports(denoJson.imports);
 if (denoJson.imports["twind"]) {
   twindImports(denoJson.imports);
 }
-denoJsonText = JSON.stringify(denoJson, null, 2);
+denoJsonText = stringifyFormattedJson(denoJson);
 await Deno.writeTextFile(DENO_JSON_PATH, denoJsonText);
 
 // Code mod for classic JSX -> automatic JSX.
@@ -152,7 +152,7 @@ if (denoJson.compilerOptions?.jsx !== "react-jsx" && confirm(JSX_CODEMOD)) {
   denoJson.compilerOptions = denoJson.compilerOptions || {};
   denoJson.compilerOptions.jsx = "react-jsx";
   denoJson.compilerOptions.jsxImportSource = "preact";
-  denoJsonText = JSON.stringify(denoJson, null, 2);
+  denoJsonText = stringifyFormattedJson(denoJson);
   await Deno.writeTextFile(DENO_JSON_PATH, denoJsonText);
 
   const project = new Project();
@@ -194,7 +194,7 @@ if (denoJson.imports["@twind"] && confirm(TWIND_CODEMOD)) {
   await Deno.remove(join(resolvedDirectory, denoJson.imports["@twind"]));
 
   delete denoJson.imports["@twind"];
-  denoJson = JSON.stringify(denoJson, null, 2);
+  denoJson = stringifyFormattedJson(denoJson);
   await Deno.writeTextFile(DENO_JSON_PATH, denoJson);
 
   const MAIN_TS = `/// <reference no-default-lib="true" />
@@ -329,4 +329,10 @@ async function findSrcDirectory(
     }
   }
   return resolvedDirectory;
+}
+
+// deno-lint-ignore no-explicit-any
+export function stringifyFormattedJson(jsonStr: any): string {
+  // Ensure formatting rules are met
+  return JSON.stringify(jsonStr, null, 2) + "\n";
 }


### PR DESCRIPTION
Every time ` deno run -Ar https://fresh.deno.dev/update .` is run, the `deno.json[c]` file gets a newline removed which contradicts formatting rules.