### PR TITLE
fix: docs islands not hydrated on safari 12

### DIFF
--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -1,3 +1,4 @@
+import "../polyfills.ts";
 import {
   Component,
   ComponentChildren,

--- a/src/runtime/polyfills.ts
+++ b/src/runtime/polyfills.ts
@@ -1,0 +1,5 @@
+// Polyfill for old safari versions
+if (typeof globalThis === "undefined") {
+  // @ts-ignore polyfill
+  window.globalThis = window;
+}

--- a/www/fresh.config.ts
+++ b/www/fresh.config.ts
@@ -3,5 +3,8 @@ import twindConfig from "./twind.config.ts";
 import { defineConfig } from "$fresh/server.ts";
 
 export default defineConfig({
+  build: {
+    target: "safari12",
+  },
   plugins: [twindPlugin(twindConfig)],
 });


### PR DESCRIPTION
Safari 12 is definitely a bit ancient, but supporting it isn't much effort.

Fixes https://github.com/denoland/fresh/issues/1834