### PR TITLE
fix: `remoteAddr` hardcoded to `localhost:1234`

### DIFF
--- a/src/server/boot.ts
+++ b/src/server/boot.ts
@@ -67,7 +67,7 @@ async function bootServer(handler: ServeHandler, opts: StartOptions) {
           remoteAddr,
           localAddr: {
             transport: "tcp",
-            hostname: opts.hostname,
+            hostname: opts.hostname ?? "localhost",
             port: opts.port,
           } as Deno.NetAddr,
         }),

--- a/src/server/boot.ts
+++ b/src/server/boot.ts
@@ -60,7 +60,18 @@ async function bootServer(handler: ServeHandler, opts: StartOptions) {
   // @ts-ignore Ignore type error when type checking with Deno versions
   if (typeof Deno.serve === "function") {
     // @ts-ignore Ignore type error when type checking with Deno versions
-    await Deno.serve(opts, handler).finished;
+    await Deno.serve(
+      opts,
+      (r, { remoteAddr }) =>
+        handler(r, {
+          remoteAddr,
+          localAddr: {
+            transport: "tcp",
+            hostname: opts.hostname,
+            port: opts.port,
+          } as Deno.NetAddr,
+        }),
+    ).finished;
   } else {
     // @ts-ignore Deprecated std serve way
     await serve(handler, opts);

--- a/tests/server_components_test.ts
+++ b/tests/server_components_test.ts
@@ -82,7 +82,7 @@ Deno.test({
               transport: "tcp",
             },
             remoteAddr: {
-              hostname: "localhost",
+              hostname: "127.0.0.1",
               port: 8000,
               transport: "tcp",
             },


### PR DESCRIPTION
Fixes #1585.

This fix is based on the implementation of [Jabolol](https://github.com/Jabolol) which he [linked](https://github.com/Jabolol/fresh/blob/ee0d00c717e9acbad44080599696e9ea27144ead/src/server/mod.ts#L168-L181) in the issue.