### PR TITLE
feat: mark active or ancestor links

### DIFF
--- a/src/runtime/active_url.ts
+++ b/src/runtime/active_url.ts
@@ -1,0 +1,24 @@
+/**
+ * Mark active or ancestor link
+ * Note: This function is used both on the server and the client
+ */
+export function setActiveUrl(vnode: VNode, url: URL) {
+  const hrefProp = vnode.props.href;
+  if (typeof hrefProp === "string" && hrefProp.startsWith("/")) {
+    let href = new URL(hrefProp, "http://localhost").pathname;
+    if (href !== "/" && href.endsWith("/")) {
+      href = href.slice(0, -1);
+    }
+
+    let pathname = url.pathname;
+    if (pathname !== "/" && pathname.endsWith("/")) {
+      pathname = pathname.slice(0, -1);
+    }
+
+    if (pathname === href) {
+      vnode.props["data-current"] = "true";
+    } else if (pathname.startsWith(href + "/") || href === "/") {
+      vnode.props["data-ancestor"] = "true";
+    }
+  }
+}

--- a/src/runtime/active_url.ts
+++ b/src/runtime/active_url.ts
@@ -4,23 +4,23 @@ import { VNode } from "preact";
  * Mark active or ancestor link
  * Note: This function is used both on the server and the client
  */
-export function setActiveUrl(vnode: VNode, url: URL) {
-  const hrefProp = vnode.props.href;
+export function setActiveUrl(vnode: VNode, pathname: string) {
+  const props = vnode.props as Record<string, unknown>;
+  const hrefProp = props.href;
   if (typeof hrefProp === "string" && hrefProp.startsWith("/")) {
     let href = new URL(hrefProp, "http://localhost").pathname;
     if (href !== "/" && href.endsWith("/")) {
       href = href.slice(0, -1);
     }
 
-    let pathname = url.pathname;
     if (pathname !== "/" && pathname.endsWith("/")) {
       pathname = pathname.slice(0, -1);
     }
 
     if (pathname === href) {
-      vnode.props["data-current"] = "true";
+      props["data-current"] = "true";
     } else if (pathname.startsWith(href + "/") || href === "/") {
-      vnode.props["data-ancestor"] = "true";
+      props["data-ancestor"] = "true";
     }
   }
 }

--- a/src/runtime/active_url.ts
+++ b/src/runtime/active_url.ts
@@ -1,3 +1,5 @@
+import { VNode } from "preact";
+
 /**
  * Mark active or ancestor link
  * Note: This function is used both on the server and the client

--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -708,7 +708,7 @@ options.vnode = (vnode) => {
 
   // Mark active or ancestor links
   if (vnode.type === "a") {
-    setActiveUrl(vnode, location);
+    setActiveUrl(vnode, location.pathname);
   }
 
   if (originalHook) originalHook(vnode);

--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -19,6 +19,7 @@ import {
   PARTIAL_SEARCH_PARAM,
   PartialMode,
 } from "../../constants.ts";
+import { setActiveUrl } from "../active_url.ts";
 
 function createRootFragment(
   parent: Element,
@@ -704,6 +705,12 @@ export async function applyPartials(res: Response): Promise<void> {
 const originalHook = options.vnode;
 options.vnode = (vnode) => {
   assetHashingHook(vnode);
+
+  // Mark active or ancestor links
+  if (vnode.type === "a") {
+    setActiveUrl(vnode, location);
+  }
+
   if (originalHook) originalHook(vnode);
 };
 

--- a/src/server/rendering/preact_hooks.ts
+++ b/src/server/rendering/preact_hooks.ts
@@ -15,6 +15,7 @@ import { renderToString } from "preact-render-to-string";
 import { RenderState } from "./state.ts";
 import { Island } from "../types.ts";
 import { DATA_KEY_ATTR, LOADING_ATTR, PartialMode } from "../../constants.ts";
+import { setActiveUrl } from "../../runtime/active_url.ts";
 
 // See: https://github.com/preactjs/preact/blob/7748dcb83cedd02e37b3713634e35b97b26028fd/src/internal.d.ts#L3C1-L16
 enum HookType {
@@ -262,6 +263,8 @@ options.__b = (vnode: VNode<Record<string, unknown>>) => {
           [LOADING_ATTR]: vnode.props[LOADING_ATTR],
         });
         vnode.props[LOADING_ATTR] = current.islandProps.length - 1;
+      } else if (vnode.type === "a") {
+        setActiveUrl(vnode, current.url);
       }
     } else if (typeof vnode.type === "function") {
       // Detect island vnodes and wrap them with a marker

--- a/src/server/rendering/preact_hooks.ts
+++ b/src/server/rendering/preact_hooks.ts
@@ -264,7 +264,7 @@ options.__b = (vnode: VNode<Record<string, unknown>>) => {
         });
         vnode.props[LOADING_ATTR] = current.islandProps.length - 1;
       } else if (vnode.type === "a") {
-        setActiveUrl(vnode, current.url);
+        setActiveUrl(vnode, current.url.pathname);
       }
     } else if (typeof vnode.type === "function") {
       // Detect island vnodes and wrap them with a marker

--- a/src/server/rendering/state.ts
+++ b/src/server/rendering/state.ts
@@ -40,6 +40,7 @@ export class RenderState {
   error: Error | null = null;
   isPartial: boolean;
   partialCount = 0;
+  url: URL;
 
   constructor(
     routeOptions: RenderStateRouteOptions,
@@ -51,6 +52,7 @@ export class RenderState {
     this.routeOptions = routeOptions;
     this.csp = csp;
     this.componentStack = componentStack;
+    this.url = routeOptions.url;
     this.isPartial = routeOptions.url.searchParams.has(PARTIAL_SEARCH_PARAM);
 
     if (error) this.routeOptions.error = error;

--- a/tests/fixture_partials/fresh.gen.ts
+++ b/tests/fixture_partials/fresh.gen.ts
@@ -3,143 +3,152 @@
 // This file is automatically updated during development when running `dev.ts`.
 
 import * as $0 from "./routes/_app.tsx";
-import * as $1 from "./routes/client_nav/_layout.tsx";
-import * as $2 from "./routes/client_nav/index.tsx";
-import * as $3 from "./routes/client_nav/injected.tsx";
-import * as $4 from "./routes/client_nav/page-a.tsx";
-import * as $5 from "./routes/client_nav/page-b.tsx";
-import * as $6 from "./routes/client_nav/page-c.tsx";
-import * as $7 from "./routes/client_nav_opt_out/_layout.tsx";
-import * as $8 from "./routes/client_nav_opt_out/index.tsx";
-import * as $9 from "./routes/client_nav_opt_out/injected.tsx";
-import * as $10 from "./routes/client_nav_opt_out/page-a.tsx";
-import * as $11 from "./routes/client_nav_opt_out/page-b.tsx";
-import * as $12 from "./routes/client_nav_opt_out/page-c.tsx";
-import * as $13 from "./routes/form/index.tsx";
-import * as $14 from "./routes/form/injected.tsx";
-import * as $15 from "./routes/form/update.tsx";
-import * as $16 from "./routes/fragment_nav.tsx";
-import * as $17 from "./routes/index.tsx";
-import * as $18 from "./routes/island_instance/index.tsx";
-import * as $19 from "./routes/island_instance/injected.tsx";
-import * as $20 from "./routes/island_instance/partial.tsx";
-import * as $21 from "./routes/island_instance/partial_remove.tsx";
-import * as $22 from "./routes/island_instance/partial_replace.tsx";
-import * as $23 from "./routes/island_instance_multiple/index.tsx";
-import * as $24 from "./routes/island_instance_multiple/injected.tsx";
-import * as $25 from "./routes/island_instance_multiple/partial.tsx";
-import * as $26 from "./routes/island_instance_multiple/partial_both.tsx";
-import * as $27 from "./routes/island_instance_nested/index.tsx";
-import * as $28 from "./routes/island_instance_nested/injected.tsx";
-import * as $29 from "./routes/island_instance_nested/partial.tsx";
-import * as $30 from "./routes/island_instance_nested/replace.tsx";
-import * as $31 from "./routes/island_props/index.tsx";
-import * as $32 from "./routes/island_props/injected.tsx";
-import * as $33 from "./routes/island_props/partial.tsx";
-import * as $34 from "./routes/island_props_signals/index.tsx";
-import * as $35 from "./routes/island_props_signals/injected.tsx";
-import * as $36 from "./routes/island_props_signals/partial.tsx";
-import * as $37 from "./routes/keys/index.tsx";
-import * as $38 from "./routes/keys/injected.tsx";
-import * as $39 from "./routes/keys/swap.tsx";
-import * as $40 from "./routes/keys_components/index.tsx";
-import * as $41 from "./routes/keys_components/injected.tsx";
-import * as $42 from "./routes/keys_components/swap.tsx";
-import * as $43 from "./routes/keys_dom/index.tsx";
-import * as $44 from "./routes/keys_dom/injected.tsx";
-import * as $45 from "./routes/keys_dom/swap.tsx";
-import * as $46 from "./routes/loading/index.tsx";
-import * as $47 from "./routes/loading/injected.tsx";
-import * as $48 from "./routes/loading/update.tsx";
-import * as $49 from "./routes/missing_partial/index.tsx";
-import * as $50 from "./routes/missing_partial/injected.tsx";
-import * as $51 from "./routes/missing_partial/update.tsx";
-import * as $52 from "./routes/mode/append.tsx";
-import * as $53 from "./routes/mode/index.tsx";
-import * as $54 from "./routes/mode/injected.tsx";
-import * as $55 from "./routes/mode/prepend.tsx";
-import * as $56 from "./routes/mode/replace.tsx";
-import * as $57 from "./routes/no_islands/index.tsx";
-import * as $58 from "./routes/no_islands/injected.tsx";
-import * as $59 from "./routes/no_islands/update.tsx";
-import * as $60 from "./routes/partial_slot_inside_island.tsx";
+import * as $1 from "./routes/active_nav/foo/bar.tsx";
+import * as $2 from "./routes/active_nav/foo/index.tsx";
+import * as $3 from "./routes/active_nav/index.tsx";
+import * as $4 from "./routes/active_nav/island.tsx";
+import * as $5 from "./routes/client_nav/_layout.tsx";
+import * as $6 from "./routes/client_nav/index.tsx";
+import * as $7 from "./routes/client_nav/injected.tsx";
+import * as $8 from "./routes/client_nav/page-a.tsx";
+import * as $9 from "./routes/client_nav/page-b.tsx";
+import * as $10 from "./routes/client_nav/page-c.tsx";
+import * as $11 from "./routes/client_nav_opt_out/_layout.tsx";
+import * as $12 from "./routes/client_nav_opt_out/index.tsx";
+import * as $13 from "./routes/client_nav_opt_out/injected.tsx";
+import * as $14 from "./routes/client_nav_opt_out/page-a.tsx";
+import * as $15 from "./routes/client_nav_opt_out/page-b.tsx";
+import * as $16 from "./routes/client_nav_opt_out/page-c.tsx";
+import * as $17 from "./routes/form/index.tsx";
+import * as $18 from "./routes/form/injected.tsx";
+import * as $19 from "./routes/form/update.tsx";
+import * as $20 from "./routes/fragment_nav.tsx";
+import * as $21 from "./routes/index.tsx";
+import * as $22 from "./routes/island_instance/index.tsx";
+import * as $23 from "./routes/island_instance/injected.tsx";
+import * as $24 from "./routes/island_instance/partial.tsx";
+import * as $25 from "./routes/island_instance/partial_remove.tsx";
+import * as $26 from "./routes/island_instance/partial_replace.tsx";
+import * as $27 from "./routes/island_instance_multiple/index.tsx";
+import * as $28 from "./routes/island_instance_multiple/injected.tsx";
+import * as $29 from "./routes/island_instance_multiple/partial.tsx";
+import * as $30 from "./routes/island_instance_multiple/partial_both.tsx";
+import * as $31 from "./routes/island_instance_nested/index.tsx";
+import * as $32 from "./routes/island_instance_nested/injected.tsx";
+import * as $33 from "./routes/island_instance_nested/partial.tsx";
+import * as $34 from "./routes/island_instance_nested/replace.tsx";
+import * as $35 from "./routes/island_props/index.tsx";
+import * as $36 from "./routes/island_props/injected.tsx";
+import * as $37 from "./routes/island_props/partial.tsx";
+import * as $38 from "./routes/island_props_signals/index.tsx";
+import * as $39 from "./routes/island_props_signals/injected.tsx";
+import * as $40 from "./routes/island_props_signals/partial.tsx";
+import * as $41 from "./routes/keys/index.tsx";
+import * as $42 from "./routes/keys/injected.tsx";
+import * as $43 from "./routes/keys/swap.tsx";
+import * as $44 from "./routes/keys_components/index.tsx";
+import * as $45 from "./routes/keys_components/injected.tsx";
+import * as $46 from "./routes/keys_components/swap.tsx";
+import * as $47 from "./routes/keys_dom/index.tsx";
+import * as $48 from "./routes/keys_dom/injected.tsx";
+import * as $49 from "./routes/keys_dom/swap.tsx";
+import * as $50 from "./routes/loading/index.tsx";
+import * as $51 from "./routes/loading/injected.tsx";
+import * as $52 from "./routes/loading/update.tsx";
+import * as $53 from "./routes/missing_partial/index.tsx";
+import * as $54 from "./routes/missing_partial/injected.tsx";
+import * as $55 from "./routes/missing_partial/update.tsx";
+import * as $56 from "./routes/mode/append.tsx";
+import * as $57 from "./routes/mode/index.tsx";
+import * as $58 from "./routes/mode/injected.tsx";
+import * as $59 from "./routes/mode/prepend.tsx";
+import * as $60 from "./routes/mode/replace.tsx";
+import * as $61 from "./routes/no_islands/index.tsx";
+import * as $62 from "./routes/no_islands/injected.tsx";
+import * as $63 from "./routes/no_islands/update.tsx";
+import * as $64 from "./routes/partial_slot_inside_island.tsx";
 import * as $$0 from "./islands/Counter.tsx";
 import * as $$1 from "./islands/CounterA.tsx";
 import * as $$2 from "./islands/CounterB.tsx";
 import * as $$3 from "./islands/Fader.tsx";
 import * as $$4 from "./islands/InvalidSlot.tsx";
-import * as $$5 from "./islands/Logger.tsx";
-import * as $$6 from "./islands/Other.tsx";
-import * as $$7 from "./islands/PartialTrigger.tsx";
-import * as $$8 from "./islands/PassThrough.tsx";
-import * as $$9 from "./islands/PropIsland.tsx";
-import * as $$10 from "./islands/SignalProp.tsx";
-import * as $$11 from "./islands/Spinner.tsx";
-import * as $$12 from "./islands/Stateful.tsx";
+import * as $$5 from "./islands/LazyLink.tsx";
+import * as $$6 from "./islands/Logger.tsx";
+import * as $$7 from "./islands/Other.tsx";
+import * as $$8 from "./islands/PartialTrigger.tsx";
+import * as $$9 from "./islands/PassThrough.tsx";
+import * as $$10 from "./islands/PropIsland.tsx";
+import * as $$11 from "./islands/SignalProp.tsx";
+import * as $$12 from "./islands/Spinner.tsx";
+import * as $$13 from "./islands/Stateful.tsx";
 
 const manifest = {
   routes: {
     "./routes/_app.tsx": $0,
-    "./routes/client_nav/_layout.tsx": $1,
-    "./routes/client_nav/index.tsx": $2,
-    "./routes/client_nav/injected.tsx": $3,
-    "./routes/client_nav/page-a.tsx": $4,
-    "./routes/client_nav/page-b.tsx": $5,
-    "./routes/client_nav/page-c.tsx": $6,
-    "./routes/client_nav_opt_out/_layout.tsx": $7,
-    "./routes/client_nav_opt_out/index.tsx": $8,
-    "./routes/client_nav_opt_out/injected.tsx": $9,
-    "./routes/client_nav_opt_out/page-a.tsx": $10,
-    "./routes/client_nav_opt_out/page-b.tsx": $11,
-    "./routes/client_nav_opt_out/page-c.tsx": $12,
-    "./routes/form/index.tsx": $13,
-    "./routes/form/injected.tsx": $14,
-    "./routes/form/update.tsx": $15,
-    "./routes/fragment_nav.tsx": $16,
-    "./routes/index.tsx": $17,
-    "./routes/island_instance/index.tsx": $18,
-    "./routes/island_instance/injected.tsx": $19,
-    "./routes/island_instance/partial.tsx": $20,
-    "./routes/island_instance/partial_remove.tsx": $21,
-    "./routes/island_instance/partial_replace.tsx": $22,
-    "./routes/island_instance_multiple/index.tsx": $23,
-    "./routes/island_instance_multiple/injected.tsx": $24,
-    "./routes/island_instance_multiple/partial.tsx": $25,
-    "./routes/island_instance_multiple/partial_both.tsx": $26,
-    "./routes/island_instance_nested/index.tsx": $27,
-    "./routes/island_instance_nested/injected.tsx": $28,
-    "./routes/island_instance_nested/partial.tsx": $29,
-    "./routes/island_instance_nested/replace.tsx": $30,
-    "./routes/island_props/index.tsx": $31,
-    "./routes/island_props/injected.tsx": $32,
-    "./routes/island_props/partial.tsx": $33,
-    "./routes/island_props_signals/index.tsx": $34,
-    "./routes/island_props_signals/injected.tsx": $35,
-    "./routes/island_props_signals/partial.tsx": $36,
-    "./routes/keys/index.tsx": $37,
-    "./routes/keys/injected.tsx": $38,
-    "./routes/keys/swap.tsx": $39,
-    "./routes/keys_components/index.tsx": $40,
-    "./routes/keys_components/injected.tsx": $41,
-    "./routes/keys_components/swap.tsx": $42,
-    "./routes/keys_dom/index.tsx": $43,
-    "./routes/keys_dom/injected.tsx": $44,
-    "./routes/keys_dom/swap.tsx": $45,
-    "./routes/loading/index.tsx": $46,
-    "./routes/loading/injected.tsx": $47,
-    "./routes/loading/update.tsx": $48,
-    "./routes/missing_partial/index.tsx": $49,
-    "./routes/missing_partial/injected.tsx": $50,
-    "./routes/missing_partial/update.tsx": $51,
-    "./routes/mode/append.tsx": $52,
-    "./routes/mode/index.tsx": $53,
-    "./routes/mode/injected.tsx": $54,
-    "./routes/mode/prepend.tsx": $55,
-    "./routes/mode/replace.tsx": $56,
-    "./routes/no_islands/index.tsx": $57,
-    "./routes/no_islands/injected.tsx": $58,
-    "./routes/no_islands/update.tsx": $59,
-    "./routes/partial_slot_inside_island.tsx": $60,
+    "./routes/active_nav/foo/bar.tsx": $1,
+    "./routes/active_nav/foo/index.tsx": $2,
+    "./routes/active_nav/index.tsx": $3,
+    "./routes/active_nav/island.tsx": $4,
+    "./routes/client_nav/_layout.tsx": $5,
+    "./routes/client_nav/index.tsx": $6,
+    "./routes/client_nav/injected.tsx": $7,
+    "./routes/client_nav/page-a.tsx": $8,
+    "./routes/client_nav/page-b.tsx": $9,
+    "./routes/client_nav/page-c.tsx": $10,
+    "./routes/client_nav_opt_out/_layout.tsx": $11,
+    "./routes/client_nav_opt_out/index.tsx": $12,
+    "./routes/client_nav_opt_out/injected.tsx": $13,
+    "./routes/client_nav_opt_out/page-a.tsx": $14,
+    "./routes/client_nav_opt_out/page-b.tsx": $15,
+    "./routes/client_nav_opt_out/page-c.tsx": $16,
+    "./routes/form/index.tsx": $17,
+    "./routes/form/injected.tsx": $18,
+    "./routes/form/update.tsx": $19,
+    "./routes/fragment_nav.tsx": $20,
+    "./routes/index.tsx": $21,
+    "./routes/island_instance/index.tsx": $22,
+    "./routes/island_instance/injected.tsx": $23,
+    "./routes/island_instance/partial.tsx": $24,
+    "./routes/island_instance/partial_remove.tsx": $25,
+    "./routes/island_instance/partial_replace.tsx": $26,
+    "./routes/island_instance_multiple/index.tsx": $27,
+    "./routes/island_instance_multiple/injected.tsx": $28,
+    "./routes/island_instance_multiple/partial.tsx": $29,
+    "./routes/island_instance_multiple/partial_both.tsx": $30,
+    "./routes/island_instance_nested/index.tsx": $31,
+    "./routes/island_instance_nested/injected.tsx": $32,
+    "./routes/island_instance_nested/partial.tsx": $33,
+    "./routes/island_instance_nested/replace.tsx": $34,
+    "./routes/island_props/index.tsx": $35,
+    "./routes/island_props/injected.tsx": $36,
+    "./routes/island_props/partial.tsx": $37,
+    "./routes/island_props_signals/index.tsx": $38,
+    "./routes/island_props_signals/injected.tsx": $39,
+    "./routes/island_props_signals/partial.tsx": $40,
+    "./routes/keys/index.tsx": $41,
+    "./routes/keys/injected.tsx": $42,
+    "./routes/keys/swap.tsx": $43,
+    "./routes/keys_components/index.tsx": $44,
+    "./routes/keys_components/injected.tsx": $45,
+    "./routes/keys_components/swap.tsx": $46,
+    "./routes/keys_dom/index.tsx": $47,
+    "./routes/keys_dom/injected.tsx": $48,
+    "./routes/keys_dom/swap.tsx": $49,
+    "./routes/loading/index.tsx": $50,
+    "./routes/loading/injected.tsx": $51,
+    "./routes/loading/update.tsx": $52,
+    "./routes/missing_partial/index.tsx": $53,
+    "./routes/missing_partial/injected.tsx": $54,
+    "./routes/missing_partial/update.tsx": $55,
+    "./routes/mode/append.tsx": $56,
+    "./routes/mode/index.tsx": $57,
+    "./routes/mode/injected.tsx": $58,
+    "./routes/mode/prepend.tsx": $59,
+    "./routes/mode/replace.tsx": $60,
+    "./routes/no_islands/index.tsx": $61,
+    "./routes/no_islands/injected.tsx": $62,
+    "./routes/no_islands/update.tsx": $63,
+    "./routes/partial_slot_inside_island.tsx": $64,
   },
   islands: {
     "./islands/Counter.tsx": $$0,
@@ -147,14 +156,15 @@ const manifest = {
     "./islands/CounterB.tsx": $$2,
     "./islands/Fader.tsx": $$3,
     "./islands/InvalidSlot.tsx": $$4,
-    "./islands/Logger.tsx": $$5,
-    "./islands/Other.tsx": $$6,
-    "./islands/PartialTrigger.tsx": $$7,
-    "./islands/PassThrough.tsx": $$8,
-    "./islands/PropIsland.tsx": $$9,
-    "./islands/SignalProp.tsx": $$10,
-    "./islands/Spinner.tsx": $$11,
-    "./islands/Stateful.tsx": $$12,
+    "./islands/LazyLink.tsx": $$5,
+    "./islands/Logger.tsx": $$6,
+    "./islands/Other.tsx": $$7,
+    "./islands/PartialTrigger.tsx": $$8,
+    "./islands/PassThrough.tsx": $$9,
+    "./islands/PropIsland.tsx": $$10,
+    "./islands/SignalProp.tsx": $$11,
+    "./islands/Spinner.tsx": $$12,
+    "./islands/Stateful.tsx": $$13,
   },
   baseUrl: import.meta.url,
 };

--- a/tests/fixture_partials/islands/LazyLink.tsx
+++ b/tests/fixture_partials/islands/LazyLink.tsx
@@ -1,0 +1,28 @@
+import { useSignal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+
+export default function LazyLink(props: { links: string[] }) {
+  const sig = useSignal(false);
+
+  useEffect(() => {
+    sig.value = true;
+  }, []);
+
+  return (
+    <div class="island">
+      {sig.value
+        ? (
+          <ul class="revived">
+            {props.links.map((link) => {
+              return (
+                <li key={link}>
+                  <a href={link}>{link}</a>
+                </li>
+              );
+            })}
+          </ul>
+        )
+        : null}
+    </div>
+  );
+}

--- a/tests/fixture_partials/routes/active_nav/foo/bar.tsx
+++ b/tests/fixture_partials/routes/active_nav/foo/bar.tsx
@@ -1,0 +1,19 @@
+export default function Page() {
+  return (
+    <div>
+      <h1>nav</h1>
+      <p>
+        <a href="/active_nav/foo/bar">/active_nav/foo/bar</a>
+      </p>
+      <p>
+        <a href="/active_nav/foo">/active_nav/foo</a>
+      </p>
+      <p>
+        <a href="/active_nav">/active_nav</a>
+      </p>
+      <p>
+        <a href="/">/</a>
+      </p>
+    </div>
+  );
+}

--- a/tests/fixture_partials/routes/active_nav/foo/index.tsx
+++ b/tests/fixture_partials/routes/active_nav/foo/index.tsx
@@ -1,0 +1,19 @@
+export default function Page() {
+  return (
+    <div>
+      <h1>nav</h1>
+      <p>
+        <a href="/active_nav/foo/bar">/active_nav/foo/bar</a>
+      </p>
+      <p>
+        <a href="/active_nav/foo">/active_nav/foo</a>
+      </p>
+      <p>
+        <a href="/active_nav">/active_nav</a>
+      </p>
+      <p>
+        <a href="/">/</a>
+      </p>
+    </div>
+  );
+}

--- a/tests/fixture_partials/routes/active_nav/index.tsx
+++ b/tests/fixture_partials/routes/active_nav/index.tsx
@@ -1,0 +1,19 @@
+export default function Page() {
+  return (
+    <div>
+      <h1>nav</h1>
+      <p>
+        <a href="/active_nav/foo/bar">/active_nav/foo/bar</a>
+      </p>
+      <p>
+        <a href="/active_nav/foo">/active_nav/foo</a>
+      </p>
+      <p>
+        <a href="/active_nav">/active_nav</a>
+      </p>
+      <p>
+        <a href="/">/</a>
+      </p>
+    </div>
+  );
+}

--- a/tests/fixture_partials/routes/active_nav/island.tsx
+++ b/tests/fixture_partials/routes/active_nav/island.tsx
@@ -1,0 +1,12 @@
+import LazyLink from "../../islands/LazyLink.tsx";
+
+export default function Page() {
+  return (
+    <div>
+      <h1>active nav island</h1>
+      <LazyLink
+        links={["/", "/active_nav", "/active_nav/foo", "/active_nav/island/"]}
+      />
+    </div>
+  );
+}

--- a/tests/partials_test.ts
+++ b/tests/partials_test.ts
@@ -891,7 +891,6 @@ Deno.test("fragment navigation should not cause loop", async () => {
   await withPageName(
     "./tests/fixture_partials/main.ts",
     async (page, address) => {
-      page.setDefaultTimeout(2000);
       const logs: string[] = [];
       page.on("console", (msg) => logs.push(msg.text()));
 
@@ -907,6 +906,28 @@ Deno.test("fragment navigation should not cause loop", async () => {
   );
 });
 
+Deno.test("active links without client nav", async () => {
+  await withFakeServe(
+    "./tests/fixture_partials/main.ts",
+    async (server) => {
+      let doc = await server.getHtml(`/active_nav`);
+      assertSelector(doc, "a[href='/'][data-ancestor]");
+
+      // Current
+      assertNotSelector(doc, "a[href='/active_nav'][data-ancestor]");
+      assertSelector(doc, "a[href='/active_nav'][data-current]");
+
+      // Unrelated links
+      assertNotSelector(doc, "a[href='/active_nav/foo'][data-ancestor]");
+      assertNotSelector(doc, "a[href='/active_nav/foo/bar'][data-ancestor]");
+
+      doc = await server.getHtml(`/active_nav/foo`);
+      assertSelector(doc, "a[href='/active_nav/foo'][data-current]");
+      assertSelector(doc, "a[href='/active_nav'][data-ancestor]");
+      assertSelector(doc, "a[href='/'][data-ancestor]");
+    },
+  );
+});
+
 // TODO Head merging
-// TODO Active links
 // TODO Children Keys


### PR DESCRIPTION
I've seen lots of code which manually passes around the current URL to set some sort of `active` class on the current URL. Fresh already knows about the current URL and when we render an `<a>`-tag, so this PR automatically adds `data-current` for links with an exact match or `data-ancestor` for links that partially match the current URL.

Note that the links are expected to be root relative and start with `/` instead of absolute URLs.