### PR TITLE
fix: scoped `npm:` packages not working

### DIFF
--- a/src/build/deps.ts
+++ b/src/build/deps.ts
@@ -17,4 +17,4 @@ const esbuild: typeof esbuildWasm = Deno.run === undefined
 const esbuildWasmURL = new URL("./esbuild_v0.18.11.wasm", import.meta.url).href;
 export { esbuild, esbuildWasm as esbuildTypes, esbuildWasmURL };
 
-export { denoPlugins } from "https://deno.land/x/esbuild_deno_loader@0.8.1/mod.ts";
+export { denoPlugins } from "https://deno.land/x/esbuild_deno_loader@0.8.2/mod.ts";

--- a/src/build/deps.ts
+++ b/src/build/deps.ts
@@ -14,7 +14,7 @@ import * as esbuildNative from "https://deno.land/x/esbuild@v0.19.4/mod.js";
 const esbuild: typeof esbuildWasm = Deno.run === undefined
   ? esbuildWasm
   : esbuildNative;
-const esbuildWasmURL = new URL("./esbuild_v0.18.11.wasm", import.meta.url).href;
+const esbuildWasmURL = new URL("./esbuild_v0.19.4.wasm", import.meta.url).href;
 export { esbuild, esbuildWasm as esbuildTypes, esbuildWasmURL };
 
 export { denoPlugins } from "https://deno.land/x/esbuild_deno_loader@0.8.2/mod.ts";

--- a/src/build/deps.ts
+++ b/src/build/deps.ts
@@ -6,9 +6,9 @@ export {
 export { escape as regexpEscape } from "https://deno.land/std@0.193.0/regexp/escape.ts";
 
 // -- esbuild --
-// @deno-types="https://deno.land/x/esbuild@v0.18.11/mod.d.ts"
-import * as esbuildWasm from "https://deno.land/x/esbuild@v0.18.11/wasm.js";
-import * as esbuildNative from "https://deno.land/x/esbuild@v0.18.11/mod.js";
+// @deno-types="https://deno.land/x/esbuild@v0.19.4/mod.d.ts"
+import * as esbuildWasm from "https://deno.land/x/esbuild@v0.19.4/wasm.js";
+import * as esbuildNative from "https://deno.land/x/esbuild@v0.19.4/mod.js";
 // @ts-ignore trust me
 // deno-lint-ignore no-deprecated-deno-api
 const esbuild: typeof esbuildWasm = Deno.run === undefined

--- a/tests/islands_wasm_test.ts
+++ b/tests/islands_wasm_test.ts
@@ -1,4 +1,4 @@
-import { assert, delay, puppeteer } from "./deps.ts";
+import { assert, delay } from "./deps.ts";
 import { withPageName } from "./test_utils.ts";
 
 Deno.test({

--- a/tests/islands_wasm_test.ts
+++ b/tests/islands_wasm_test.ts
@@ -1,48 +1,35 @@
 import { assert, delay, puppeteer } from "./deps.ts";
-import { startFreshServer } from "./test_utils.ts";
+import { withPageName } from "./test_utils.ts";
 
 Deno.test({
   name: "wasm island tests",
   ignore: Deno.build.os === "windows",
   async fn(t) {
-    // Preparation
-    const { lines, serverProcess, address } = await startFreshServer({
-      args: ["run", "-A", "./tests/fixture/main_wasm.ts"],
-    });
+    await withPageName(
+      "./tests/fixture/main_wasm.ts",
+      async (page, address) => {
+        async function counterTest(counterId: string, originalValue: number) {
+          const pElem = await page.waitForSelector(`#${counterId} > p`);
+          let value = await pElem?.evaluate((el) => el.textContent);
+          assert(value === `${originalValue}`, `${counterId} first value`);
 
-    await delay(100);
+          const buttonPlus = await page.$(`#b-${counterId}`);
+          await buttonPlus?.click();
+          await delay(100);
+          value = await pElem?.evaluate((el) => el.textContent);
+          assert(value === `${originalValue + 1}`, `${counterId} click`);
+        }
 
-    const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
-    const page = await browser.newPage();
+        await page.goto(`${address}/islands`, {
+          waitUntil: "networkidle2",
+        });
 
-    async function counterTest(counterId: string, originalValue: number) {
-      const pElem = await page.waitForSelector(`#${counterId} > p`);
-      let value = await pElem?.evaluate((el) => el.textContent);
-      assert(value === `${originalValue}`, `${counterId} first value`);
-
-      const buttonPlus = await page.$(`#b-${counterId}`);
-      await buttonPlus?.click();
-      await delay(100);
-      value = await pElem?.evaluate((el) => el.textContent);
-      assert(value === `${originalValue + 1}`, `${counterId} click`);
-    }
-
-    await page.goto(`${address}/islands`, {
-      waitUntil: "networkidle2",
-    });
-
-    await t.step("Ensure 3 islands on 1 page are revived", async () => {
-      await counterTest("counter1", 3);
-      await counterTest("counter2", 10);
-      await counterTest("kebab-case-file-counter", 5);
-    });
-
-    await browser.close();
-
-    serverProcess.kill("SIGTERM");
-    await serverProcess.status;
-
-    // Drain the lines stream
-    for await (const _ of lines) { /* noop */ }
+        await t.step("Ensure 3 islands on 1 page are revived", async () => {
+          await counterTest("counter1", 3);
+          await counterTest("counter2", 10);
+          await counterTest("kebab-case-file-counter", 5);
+        });
+      },
+    );
   },
 });


### PR DESCRIPTION
Just cut a new release for the esbuild loader which fixes an issue with scoped packages and the `npm:` specifier. See https://github.com/lucacasonato/esbuild_deno_loader/releases/tag/0.8.2