### PR TITLE
Switched to use Deno formatting rules

### DIFF
--- a/update.ts
+++ b/update.ts
@@ -56,7 +56,7 @@ if (!DENO_JSON_PATH) {
     `Neither deno.json nor deno.jsonc could be found in ${resolvedDirectory}`,
   );
 }
-let denoJsonText = await Deno.readTextFile(DENO_JSON_PATH);
+const denoJsonText = await Deno.readTextFile(DENO_JSON_PATH);
 const ext = extname(DENO_JSON_PATH);
 let denoJson;
 if (ext === ".json") {
@@ -139,8 +139,7 @@ freshImports(denoJson.imports);
 if (denoJson.imports["twind"]) {
   twindImports(denoJson.imports);
 }
-denoJsonText = stringifyFormattedJson(denoJson);
-await Deno.writeTextFile(DENO_JSON_PATH, denoJsonText);
+await writeFormattedJson(DENO_JSON_PATH, denoJson);
 
 // Code mod for classic JSX -> automatic JSX.
 const JSX_CODEMOD =
@@ -152,8 +151,7 @@ if (denoJson.compilerOptions?.jsx !== "react-jsx" && confirm(JSX_CODEMOD)) {
   denoJson.compilerOptions = denoJson.compilerOptions || {};
   denoJson.compilerOptions.jsx = "react-jsx";
   denoJson.compilerOptions.jsxImportSource = "preact";
-  denoJsonText = stringifyFormattedJson(denoJson);
-  await Deno.writeTextFile(DENO_JSON_PATH, denoJsonText);
+  await writeFormattedJson(DENO_JSON_PATH, denoJson);
 
   const project = new Project();
   const sfs = project.addSourceFilesAtPaths(
@@ -194,8 +192,7 @@ if (denoJson.imports["@twind"] && confirm(TWIND_CODEMOD)) {
   await Deno.remove(join(resolvedDirectory, denoJson.imports["@twind"]));
 
   delete denoJson.imports["@twind"];
-  denoJson = stringifyFormattedJson(denoJson);
-  await Deno.writeTextFile(DENO_JSON_PATH, denoJson);
+  await writeFormattedJson(DENO_JSON_PATH, denoJson);
 
   const MAIN_TS = `/// <reference no-default-lib="true" />
 /// <reference lib="dom" />
@@ -331,7 +328,18 @@ async function findSrcDirectory(
   return resolvedDirectory;
 }
 
-export function stringifyFormattedJson(data: unknown): string {
-  // Append newline to ensure formatting rules are met
-  return JSON.stringify(data, null, 2) + "\n";
+async function writeFormattedJson(
+  denoJsonPath: string,
+  // deno-lint-ignore no-explicit-any
+  denoJson: any,
+): Promise<void> {
+  const denoJsonText = JSON.stringify(denoJson);
+  await Deno.writeTextFile(denoJsonPath, denoJsonText);
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "fmt",
+      denoJsonPath,
+    ],
+  });
+  await command.output();
 }


### PR DESCRIPTION
Switched `update.ts` to use Deno fmt command on `deno.json` so it respects the `deno.json` `fmt` configuration.  Tested with 4 space indentation. 