### PR TITLE
fix: use consistent partial attribute naming

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 export const PARTIAL_SEARCH_PARAM = "fresh-partial";
-export const PARTIAL_ATTR = "fh-partial";
-export const LOADING_ATTR = "fh-loading";
+export const PARTIAL_ATTR = "f-partial";
+export const LOADING_ATTR = "f-loading";
+export const CLIENT_NAV_ATTR = "f-client-nav";
 export const DATA_KEY_ATTR = "data-fresh-key";
 
 export const enum PartialMode {

--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -13,6 +13,7 @@ import { assetHashingHook } from "../utils.ts";
 import { type SerializedState } from "../../server/rendering/fresh_tags.tsx";
 import type { Signal } from "@preact/signals";
 import {
+  CLIENT_NAV_ATTR,
   DATA_KEY_ATTR,
   LOADING_ATTR,
   PARTIAL_ATTR,
@@ -748,11 +749,11 @@ document.addEventListener("click", async (e) => {
       // There are two cases to account for:
       //  1. Partial request
       //  2. Normal request (turbolink-style)
-      const settingEl = el.closest("[fresh-client-nav]");
+      const settingEl = el.closest(`[${CLIENT_NAV_ATTR}]`);
       if (
         partial === null && (
           settingEl === null ||
-          settingEl.getAttribute("fresh-client-nav") !== "true"
+          settingEl.getAttribute(CLIENT_NAV_ATTR) !== "true"
         )
       ) {
         return;

--- a/tests/fixture_partials/islands/PartialTrigger.tsx
+++ b/tests/fixture_partials/islands/PartialTrigger.tsx
@@ -14,8 +14,8 @@ export default function PartialTrigger(
     <a
       class={props.class}
       href={props.href}
-      fh-partial={props.partial}
-      fh-loading={props.loading}
+      f-partial={props.partial}
+      f-loading={props.loading}
     >
       {props.children}
     </a>

--- a/tests/fixture_partials/routes/client_nav/_layout.tsx
+++ b/tests/fixture_partials/routes/client_nav/_layout.tsx
@@ -10,7 +10,7 @@ export default function AppLayout({ Component }: AppProps) {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>fresh title</title>
       </head>
-      <body fresh-client-nav="true">
+      <body f-client-nav="true">
         <Partial name="body">
           <Fader>
             <Component />

--- a/tests/fixture_partials/routes/client_nav_opt_out/_layout.tsx
+++ b/tests/fixture_partials/routes/client_nav_opt_out/_layout.tsx
@@ -10,7 +10,7 @@ export default function AppLayout({ Component }: AppProps) {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>fresh title</title>
       </head>
-      <body fresh-client-nav="false">
+      <body f-client-nav="false">
         <Partial name="body">
           <Fader>
             <Component />

--- a/tests/fixture_partials/routes/form/index.tsx
+++ b/tests/fixture_partials/routes/form/index.tsx
@@ -3,7 +3,7 @@ import { Partial } from "$fresh/runtime.ts";
 export default function SlotDemo() {
   return (
     <div>
-      <form fh-partial="/form/update">
+      <form f-partial="/form/update">
         <Partial name="slot-1">
           <p class="status">Default content</p>
           <p>

--- a/tests/fixture_partials/routes/island_instance/index.tsx
+++ b/tests/fixture_partials/routes/island_instance/index.tsx
@@ -15,7 +15,7 @@ export default function SlotDemo() {
         <a
           class="update-link"
           href="/island_instance/injected"
-          fh-partial="/island_instance/partial"
+          f-partial="/island_instance/partial"
         >
           Update
         </a>
@@ -24,7 +24,7 @@ export default function SlotDemo() {
         <a
           class="remove-link"
           href="/island_instance/injected"
-          fh-partial="/island_instance/partial_remove"
+          f-partial="/island_instance/partial_remove"
         >
           Remove
         </a>
@@ -33,7 +33,7 @@ export default function SlotDemo() {
         <a
           class="replace-link"
           href="/island_instance/injected"
-          fh-partial="/island_instance/partial_replace"
+          f-partial="/island_instance/partial_replace"
         >
           Replace
         </a>

--- a/tests/fixture_partials/routes/island_instance_multiple/index.tsx
+++ b/tests/fixture_partials/routes/island_instance_multiple/index.tsx
@@ -26,7 +26,7 @@ export default function SlotDemo() {
         <a
           class="update-second-link"
           href="/island_instance_multiple/injected"
-          fh-partial="/island_instance_multiple/partial"
+          f-partial="/island_instance_multiple/partial"
         >
           update second
         </a>
@@ -35,7 +35,7 @@ export default function SlotDemo() {
         <a
           class="update-both-link"
           href="/island_instance_multiple/injected"
-          fh-partial="/island_instance_multiple/partial_both"
+          f-partial="/island_instance_multiple/partial_both"
         >
           update both
         </a>

--- a/tests/fixture_partials/routes/island_instance_nested/index.tsx
+++ b/tests/fixture_partials/routes/island_instance_nested/index.tsx
@@ -24,7 +24,7 @@ export default function SlotDemo() {
         <a
           class="update-link"
           href="/island_instance_nested/injected"
-          fh-partial="/island_instance_nested/partial"
+          f-partial="/island_instance_nested/partial"
         >
           update
         </a>
@@ -33,7 +33,7 @@ export default function SlotDemo() {
         <a
           class="replace-link"
           href="/island_instance_nested/injected"
-          fh-partial="/island_instance_nested/replace"
+          f-partial="/island_instance_nested/replace"
         >
           replace
         </a>

--- a/tests/fixture_partials/routes/island_props/index.tsx
+++ b/tests/fixture_partials/routes/island_props/index.tsx
@@ -21,7 +21,7 @@ export default function PropsDemo() {
         <a
           class="update-link"
           href="/island_props/injected"
-          fh-partial="/island_props/partial"
+          f-partial="/island_props/partial"
         >
           Update
         </a>

--- a/tests/fixture_partials/routes/island_props_signals/index.tsx
+++ b/tests/fixture_partials/routes/island_props_signals/index.tsx
@@ -20,7 +20,7 @@ export default function PropsDemo() {
         <a
           class="update-link"
           href="/island_props_signals/injected"
-          fh-partial="/island_props_signals/partial"
+          f-partial="/island_props_signals/partial"
         >
           Update
         </a>

--- a/tests/fixture_partials/routes/keys/index.tsx
+++ b/tests/fixture_partials/routes/keys/index.tsx
@@ -19,7 +19,7 @@ export default function SlotDemo() {
         <a
           class="swap-link"
           href="/keys/injected"
-          fh-partial="/keys/swap"
+          f-partial="/keys/swap"
         >
           swap
         </a>

--- a/tests/fixture_partials/routes/keys_components/index.tsx
+++ b/tests/fixture_partials/routes/keys_components/index.tsx
@@ -26,7 +26,7 @@ export default function SlotDemo() {
         <a
           class="swap-link"
           href="/keys_components/injected"
-          fh-partial="/keys_components/swap"
+          f-partial="/keys_components/swap"
         >
           swap
         </a>

--- a/tests/fixture_partials/routes/keys_dom/index.tsx
+++ b/tests/fixture_partials/routes/keys_dom/index.tsx
@@ -27,7 +27,7 @@ export default function SlotDemo() {
         <a
           class="swap-link"
           href="/keys_dom/injected"
-          fh-partial="/keys_dom/swap"
+          f-partial="/keys_dom/swap"
         >
           swap
         </a>

--- a/tests/fixture_partials/routes/loading/index.tsx
+++ b/tests/fixture_partials/routes/loading/index.tsx
@@ -17,8 +17,8 @@ export default function SlotDemo() {
       <a
         class="update-link"
         href="/loading/injected"
-        fh-partial="/loading/update"
-        fh-loading={sig}
+        f-partial="/loading/update"
+        f-loading={sig}
       >
         update
       </a>

--- a/tests/fixture_partials/routes/missing_partial/index.tsx
+++ b/tests/fixture_partials/routes/missing_partial/index.tsx
@@ -15,7 +15,7 @@ export default function WarnDemo() {
         <a
           class="update-link"
           href="/missing_partial/injected"
-          fh-partial="/missing_partial/update"
+          f-partial="/missing_partial/update"
         >
           update
         </a>

--- a/tests/fixture_partials/routes/mode/index.tsx
+++ b/tests/fixture_partials/routes/mode/index.tsx
@@ -15,7 +15,7 @@ export default function ModeDemo() {
         <a
           class="replace-link"
           href="/mode/injected"
-          fh-partial="/mode/replace"
+          f-partial="/mode/replace"
         >
           replace
         </a>
@@ -24,7 +24,7 @@ export default function ModeDemo() {
         <a
           class="append-link"
           href="/mode/injected"
-          fh-partial="/mode/append"
+          f-partial="/mode/append"
         >
           append
         </a>
@@ -33,7 +33,7 @@ export default function ModeDemo() {
         <a
           class="prepend-link"
           href="/mode/injected"
-          fh-partial="/mode/prepend"
+          f-partial="/mode/prepend"
         >
           prepend
         </a>

--- a/tests/fixture_partials/routes/no_islands/index.tsx
+++ b/tests/fixture_partials/routes/no_islands/index.tsx
@@ -11,7 +11,7 @@ export default function SlotDemo() {
       <a
         class="update-link"
         href="/no_islands/injected"
-        fh-partial="/no_islands/update"
+        f-partial="/no_islands/update"
       >
         update
       </a>


### PR DESCRIPTION
Result of an internal discussion in the team. Every fresh specific attribute starts with `f-*`