### PR TITLE
Expose metafile.json

### DIFF
--- a/src/build/esbuild.ts
+++ b/src/build/esbuild.ts
@@ -89,6 +89,11 @@ export class EsbuildBuilder implements Builder {
         files.set(path, file.contents);
       }
 
+      files.set(
+        "metafile.json",
+        new TextEncoder().encode(JSON.stringify(bundle.metafile)),
+      );
+
       const metaOutputs = new Map(Object.entries(bundle.metafile.outputs));
 
       for (const [path, entry] of metaOutputs.entries()) {


### PR DESCRIPTION
This PR exposes ESbuild's metafile at `/_frsh/js/{build_id}/metafile.json` so we can use ESbuild's bundle analyzer https://esbuild.github.io/analyze/ to analyze our bundle sizes. 

A future work would be to merge and not use `snapshot.json` in favor `metafile.json` since the later contains the snapshot info. 