### PR TITLE
feat: Use href instead of origin on Partial 

### DIFF
--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -948,7 +948,7 @@ document.addEventListener("click", async (e) => {
 
         const partialUrl = new URL(
           partial ? partial : nextUrl.href,
-          location.origin,
+          location.href,
         );
         await fetchPartials(partialUrl);
         updateLinks(nextUrl);
@@ -979,7 +979,7 @@ document.addEventListener("click", async (e) => {
 
         const partialUrl = new URL(
           partial,
-          location.origin,
+          location.href,
         );
         await fetchPartials(partialUrl);
       }
@@ -1042,7 +1042,7 @@ document.addEventListener("submit", async (e) => {
     if (partial !== null) {
       e.preventDefault();
 
-      const url = new URL(partial, location.origin);
+      const url = new URL(partial, location.href);
       await fetchPartials(url);
     }
   }

--- a/tests/fixture_partials/fresh.gen.ts
+++ b/tests/fixture_partials/fresh.gen.ts
@@ -85,7 +85,7 @@ import * as $79 from "./routes/no_partial_response/index.tsx";
 import * as $80 from "./routes/no_partial_response/injected.tsx";
 import * as $81 from "./routes/no_partial_response/update.tsx";
 import * as $82 from "./routes/partial_slot_inside_island.tsx";
-import * as $83 from "./routes/refresh/index.tsx";
+import * as $83 from "./routes/relative_link/index.tsx";
 import * as $84 from "./routes/scroll_restoration/index.tsx";
 import * as $85 from "./routes/scroll_restoration/injected.tsx";
 import * as $86 from "./routes/scroll_restoration/update.tsx";
@@ -189,7 +189,7 @@ const manifest = {
     "./routes/no_partial_response/injected.tsx": $80,
     "./routes/no_partial_response/update.tsx": $81,
     "./routes/partial_slot_inside_island.tsx": $82,
-    "./routes/refresh/index.tsx": $83,
+    "./routes/relative_link/index.tsx": $83,
     "./routes/scroll_restoration/index.tsx": $84,
     "./routes/scroll_restoration/injected.tsx": $85,
     "./routes/scroll_restoration/update.tsx": $86,

--- a/tests/fixture_partials/fresh.gen.ts
+++ b/tests/fixture_partials/fresh.gen.ts
@@ -85,9 +85,10 @@ import * as $79 from "./routes/no_partial_response/index.tsx";
 import * as $80 from "./routes/no_partial_response/injected.tsx";
 import * as $81 from "./routes/no_partial_response/update.tsx";
 import * as $82 from "./routes/partial_slot_inside_island.tsx";
-import * as $83 from "./routes/scroll_restoration/index.tsx";
-import * as $84 from "./routes/scroll_restoration/injected.tsx";
-import * as $85 from "./routes/scroll_restoration/update.tsx";
+import * as $83 from "./routes/refresh/index.tsx";
+import * as $84 from "./routes/scroll_restoration/index.tsx";
+import * as $85 from "./routes/scroll_restoration/injected.tsx";
+import * as $86 from "./routes/scroll_restoration/update.tsx";
 import * as $$0 from "./islands/Counter.tsx";
 import * as $$1 from "./islands/CounterA.tsx";
 import * as $$2 from "./islands/CounterB.tsx";
@@ -188,9 +189,10 @@ const manifest = {
     "./routes/no_partial_response/injected.tsx": $80,
     "./routes/no_partial_response/update.tsx": $81,
     "./routes/partial_slot_inside_island.tsx": $82,
-    "./routes/scroll_restoration/index.tsx": $83,
-    "./routes/scroll_restoration/injected.tsx": $84,
-    "./routes/scroll_restoration/update.tsx": $85,
+    "./routes/refresh/index.tsx": $83,
+    "./routes/scroll_restoration/index.tsx": $84,
+    "./routes/scroll_restoration/injected.tsx": $85,
+    "./routes/scroll_restoration/update.tsx": $86,
   },
   islands: {
     "./islands/Counter.tsx": $$0,

--- a/tests/fixture_partials/routes/refresh/index.tsx
+++ b/tests/fixture_partials/routes/refresh/index.tsx
@@ -1,0 +1,30 @@
+import { Partial } from "$fresh/runtime.ts";
+import { defineRoute } from "$fresh/src/server/defines.ts";
+import { Fader } from "../../islands/Fader.tsx";
+
+export default defineRoute((req) => {
+  const url = new URL(req.url);
+
+  return (
+    <div f-client-nav>
+      <Partial name="body">
+        <Fader>
+          <p
+            class={url.searchParams.has("refresh")
+              ? "status-refreshed"
+              : "status-initial"}
+          >
+            {url.searchParams.has("refresh")
+              ? "Refreshed content"
+              : "Initial content"}
+          </p>
+        </Fader>
+      </Partial>
+      <p>
+        <button f-partial="?refresh">
+          update
+        </button>
+      </p>
+    </div>
+  );
+});

--- a/tests/fixture_partials/routes/relative_link/index.tsx
+++ b/tests/fixture_partials/routes/relative_link/index.tsx
@@ -22,7 +22,7 @@ export default defineRoute((req) => {
       </Partial>
       <p>
         <button f-partial="?refresh">
-          update
+          refresh
         </button>
       </p>
     </div>

--- a/tests/partials_test.ts
+++ b/tests/partials_test.ts
@@ -1,4 +1,9 @@
-import { assert, assertEquals, assertMatch } from "$std/testing/asserts.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertMatch,
+} from "$std/testing/asserts.ts";
 import { Page } from "./deps.ts";
 import {
   assertMetaContent,
@@ -1098,6 +1103,19 @@ Deno.test("applies f-partial on <button>", async () => {
 
       await page.click("button");
       await page.waitForSelector(".status-updated");
+    },
+  );
+});
+
+Deno.test("supports relative links", async () => {
+  await withPageName(
+    "./tests/fixture_partials/main.ts",
+    async (page, address) => {
+      await page.goto(`${address}/refresh`);
+      await page.waitForSelector(".status-initial");
+
+      await page.click("button");
+      await page.waitForSelector(".status-refreshed");
     },
   );
 });

--- a/tests/partials_test.ts
+++ b/tests/partials_test.ts
@@ -1,9 +1,4 @@
-import {
-  assert,
-  assertEquals,
-  assertExists,
-  assertMatch,
-} from "$std/testing/asserts.ts";
+import { assert, assertEquals, assertMatch } from "$std/testing/asserts.ts";
 import { Page } from "./deps.ts";
 import {
   assertMetaContent,

--- a/tests/partials_test.ts
+++ b/tests/partials_test.ts
@@ -1111,7 +1111,7 @@ Deno.test("supports relative links", async () => {
   await withPageName(
     "./tests/fixture_partials/main.ts",
     async (page, address) => {
-      await page.goto(`${address}/refresh`);
+      await page.goto(`${address}/relative_link`);
       await page.waitForSelector(".status-initial");
 
       await page.click("button");


### PR DESCRIPTION
Use `location.href` on partials so we can create refresh buttons without relying on islands or on the request

The idea is to be able to write code like this:
```tsx
const Refresh () => {
   return <button f-partial="?refresh">Refresh Page</button>
}
```

instead of this
```tsx
const Refresh ({href}: {href: string}) => {
   const url = new URL(href)
   
   url.searchParams.set('refresh', "true")
   
   return <button f-partial=`${url.href}`>Refresh Page</button>
}
```