### PR TITLE
fix: Partial state deserialization on simple islands

### DIFF
--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -698,8 +698,10 @@ export async function applyPartials(res: Response): Promise<void> {
 
   await Promise.all(promises);
 
-  if (deserialize) {
-    state = deserialize(stateDom!, signal) as SerializedState;
+  if (stateDom) {
+    state = deserialize
+      ? deserialize(stateDom, signal) as SerializedState
+      : JSON.parse(stateDom)?.v;
   }
 
   // Collect all partials and build up the vnode tree

--- a/tests/fixture_partials/routes/island_props/index.tsx
+++ b/tests/fixture_partials/routes/island_props/index.tsx
@@ -1,21 +1,19 @@
 import { Partial } from "$fresh/runtime.ts";
-import { Fader } from "../../islands/Fader.tsx";
+// import { Fader } from "../../islands/Fader.tsx";
 import PropIsland from "../../islands/PropIsland.tsx";
 
 export default function PropsDemo() {
   return (
     <div>
       <Partial name="slot-1">
-        <Fader>
-          <p class="status-initial">initial</p>
-          <PropIsland
-            boolean={true}
-            number={1}
-            obj={{ foo: 123 }}
-            strArr={["foo"]}
-            string="foo"
-          />
-        </Fader>
+        <p class="status-initial">initial</p>
+        <PropIsland
+          boolean={true}
+          number={1}
+          obj={{ foo: 123 }}
+          strArr={["foo"]}
+          string="foo"
+        />
       </Partial>
       <p>
         <a

--- a/tests/fixture_partials/routes/island_props/index.tsx
+++ b/tests/fixture_partials/routes/island_props/index.tsx
@@ -1,5 +1,4 @@
 import { Partial } from "$fresh/runtime.ts";
-// import { Fader } from "../../islands/Fader.tsx";
 import PropIsland from "../../islands/PropIsland.tsx";
 
 export default function PropsDemo() {

--- a/tests/fixture_partials/routes/island_props/partial.tsx
+++ b/tests/fixture_partials/routes/island_props/partial.tsx
@@ -12,16 +12,14 @@ export const config: RouteConfig = {
 export default defineRoute((req, ctx) => {
   return (
     <Partial name="slot-1">
-      <Fader>
-        <p class="status-updated">updated</p>
-        <PropIsland
-          boolean={false}
-          number={42}
-          obj={{ foo: 123456 }}
-          strArr={["foo", "bar"]}
-          string="foobar"
-        />
-      </Fader>
+      <p class="status-updated">updated</p>
+      <PropIsland
+        boolean={false}
+        number={42}
+        obj={{ foo: 123456 }}
+        strArr={["foo", "bar"]}
+        string="foobar"
+      />
     </Partial>
   );
 });


### PR DESCRIPTION
This PR fixes an issue with deserialization of Fresh Partial.

When no special type is used on __FRESH_STATE, the requiresSerialization variable is false, which causes the`deserialize` function to be null, thus making a void state, thus not hydrating correctly the islands inside the fresh state. 

This PR addresses this issue by using the good&old JSON.parse in these cases.