### PR TITLE
chore: remove console.log

### DIFF
--- a/www/utils/markdown.ts
+++ b/www/utils/markdown.ts
@@ -102,7 +102,6 @@ class DefaultRenderer extends Marked.Renderer {
 
   blockquote(quote: string): string {
     const match = quote.match(ADMISSION_REG);
-    console.log(match, quote);
     if (match) {
       const label: Record<string, string> = {
         tip: "Tip",


### PR DESCRIPTION
Here is hope that our linter will get a `no-console` rule someday...