### PR TITLE
chore: synchronize CI and local tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,4 @@ jobs:
         run: deno task check:types
 
       - name: Run tests
-        run: deno test -A --parallel --trace-ops --unstable
+        run: deno task test

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": false,
   "tasks": {
-    "test": "deno test -A --parallel --unstable",
+    "test": "deno test -A --parallel --trace-ops --unstable",
     "fixture": "deno run -A --watch=static/,routes/ tests/fixture/dev.ts",
     "www": "deno task --cwd=www start",
     "screenshot": "deno run -A www/utils/screenshot.ts",


### PR DESCRIPTION
These should be kept the same in the future so tests are run identically locally and in CI.