### PR TITLE
fix: don't store codeframe on error object

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -792,6 +792,7 @@ export class ServerContext {
         // deno-lint-ignore no-explicit-any
         ctx?: any,
         error?: unknown,
+        codeFrame?: string,
       ) => {
         return async (data?: Data, options?: RenderOptions) => {
           if (route.component === undefined) {
@@ -819,6 +820,7 @@ export class ServerContext {
             data,
             state: ctx?.state,
             error,
+            codeFrame,
           });
 
           if (resp instanceof Response) {
@@ -905,14 +907,13 @@ export class ServerContext {
         "%cAn error occurred during route handling or page rendering.",
         "color:red",
       );
+      let codeFrame: string | undefined;
       if (this.#dev && error instanceof Error) {
-        const codeFrame = await getCodeFrame(error);
+        codeFrame = await getCodeFrame(error);
 
         if (codeFrame) {
           console.error();
           console.error(codeFrame);
-          // deno-lint-ignore no-explicit-any
-          (error as any).codeFrame = codeFrame;
         }
       }
       console.error(error);
@@ -922,7 +923,7 @@ export class ServerContext {
         {
           ...ctx,
           error,
-          render: errorHandlerRender(req, {}, ctx, error),
+          render: errorHandlerRender(req, {}, ctx, error, codeFrame),
         },
       );
     };

--- a/src/server/default_error_page.tsx
+++ b/src/server/default_error_page.tsx
@@ -90,8 +90,7 @@ export default function DefaultErrorPage(
   if (DEBUG) {
     if (error instanceof Error) {
       title = error.message;
-      // deno-lint-ignore no-explicit-any
-      codeFrame = (error as any).codeFrame;
+      codeFrame = props.codeFrame;
       stack = error.stack ?? "";
     } else {
       title = String(error);

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -39,6 +39,7 @@ export interface RenderOptions<Data> {
   data?: Data;
   state?: Record<string, unknown>;
   error?: unknown;
+  codeFrame?: string;
   lang?: string;
 }
 
@@ -152,6 +153,9 @@ export async function render<Data>(
   };
   if (opts.error) {
     props.error = opts.error;
+  }
+  if (opts.codeFrame) {
+    props.codeFrame = opts.codeFrame;
   }
 
   const csp: ContentSecurityPolicy | undefined = opts.route.csp

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -418,6 +418,9 @@ export interface ErrorPageProps {
 
   /** The error that caused the error page to be loaded. */
   error: unknown;
+
+  /** Sringified code frame (only in development mode) */
+  codeFrame?: string;
 }
 
 export interface ErrorHandlerContext<State = Record<string, unknown>>


### PR DESCRIPTION
This makes the output a little cleaner.