### PR TITLE
fix: flaky `doesn't leak data across renderers` test

### DIFF
--- a/tests/render_test.ts
+++ b/tests/render_test.ts
@@ -1,28 +1,28 @@
-import {
-  assertSelector,
-  fetchHtml,
-  withFresh,
-} from "$fresh/tests/test_utils.ts";
+import { assertSelector, parseHtml } from "$fresh/tests/test_utils.ts";
 import { assertEquals } from "$std/testing/asserts.ts";
+import { createHandler } from "$fresh/server.ts";
+import manifest from "./fixture/fresh.gen.ts";
+import options from "./fixture/options.ts";
 
+const handler = await createHandler(manifest, options);
+
+// Issue: https://github.com/denoland/fresh/issues/1636
 Deno.test("doesn't leak data across renderers", async () => {
-  // Issue: https://github.com/denoland/fresh/issues/1636
-  await withFresh("./tests/fixture/main.ts", async (address) => {
-    function load(name: string) {
-      return fetchHtml(`${address}/admin/${name}`).then((doc) => {
-        assertSelector(doc, "#__FRSH_STATE");
-        const text = doc.querySelector("#__FRSH_STATE")?.textContent!;
-        const json = JSON.parse(text);
-        assertEquals(json, { "v": [[{ "site": name }], []] });
-      });
-    }
+  async function load(name: string) {
+    const req = new Request(`http://localhost/admin/${name}`);
+    const resp = await handler(req);
+    const doc = parseHtml(await resp.text());
 
-    const promises: Promise<void>[] = [];
-    for (let i = 0; i < 100; i++) {
-      promises.push(load("foo"));
-      promises.push(load("bar"));
-    }
+    assertSelector(doc, "#__FRSH_STATE");
+    const text = doc.querySelector("#__FRSH_STATE")?.textContent!;
+    const json = JSON.parse(text);
+    assertEquals(json, { "v": [[{ "site": name }], []] });
+  }
 
-    await Promise.all(promises);
-  });
+  const promises = [];
+  for (let i = 0; i < 100; i++) {
+    promises.push(load("foo"));
+    promises.push(load("bar"));
+  }
+  await Promise.all(promises);
 });


### PR DESCRIPTION
Using `createHandler()` is simpler than starting a server and fetching a page. `createHandler()` avoids unnecessary network requests, which can be flaky when you only need to analyse parts of the returned request. I think we should push for more use of  `createHandler()` and only start a server as a last resort.

This closes #1896, or rather the particular test mentioned there, but other tests involving TCP connections can still occur. Again, their remedy is to use `createHandler()` instead of starting a server.