### PR TITLE
refactor: use `manifest` variable name

### DIFF
--- a/docs/latest/concepts/server-configuration.md
+++ b/docs/latest/concepts/server-configuration.md
@@ -8,7 +8,7 @@ In this page we discuss how the server can be configured during startup.
 The signature of the primary method looks like this:
 
 ```ts main.ts
-export async function start(routes: Manifest, opts: StartOptions = {});
+export async function start(manifest: Manifest, opts: StartOptions = {});
 ```
 
 ## Options

--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -85,17 +85,17 @@ export interface Manifest {
 export { ServerContext };
 
 export async function createHandler(
-  routes: Manifest,
+  manifest: Manifest,
   opts: StartOptions = {},
 ): Promise<
   (req: Request, connInfo?: ServeHandlerInfo) => Promise<Response>
 > {
-  const ctx = await ServerContext.fromManifest(routes, opts);
+  const ctx = await ServerContext.fromManifest(manifest, opts);
   return ctx.handler();
 }
 
-export async function start(routes: Manifest, opts: StartOptions = {}) {
-  const ctx = await ServerContext.fromManifest(routes, {
+export async function start(manifest: Manifest, opts: StartOptions = {}) {
+  const ctx = await ServerContext.fromManifest(manifest, {
     ...opts,
     skipSnapshot: false,
     dev: false,

--- a/tests/fixture/main.ts
+++ b/tests/fixture/main.ts
@@ -5,7 +5,7 @@
 /// <reference lib="deno.ns" />
 
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 import options from "./options.ts";
 
-await start(routes, options);
+await start(manifest, options);

--- a/tests/fixture/main_tls.ts
+++ b/tests/fixture/main_tls.ts
@@ -5,8 +5,8 @@
 /// <reference lib="deno.ns" />
 
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 import options from "./options.ts";
 
 // this just exists to function as a type check to assert that we can actually pass a key and cert in
-await start(routes, { ...options, key: "test", cert: "test" });
+await start(manifest, { ...options, key: "test", cert: "test" });

--- a/tests/fixture/main_wasm.ts
+++ b/tests/fixture/main_wasm.ts
@@ -8,7 +8,7 @@
 
 import "./polyfill_deno_deploy.ts";
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 import options from "./options.ts";
 
-await start(routes, options);
+await start(manifest, options);

--- a/tests/fixture_build/main.ts
+++ b/tests/fixture_build/main.ts
@@ -5,6 +5,6 @@
 /// <reference lib="deno.ns" />
 
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 
-await start(routes);
+await start(manifest);

--- a/tests/fixture_build_out_dir/main.ts
+++ b/tests/fixture_build_out_dir/main.ts
@@ -5,6 +5,6 @@
 /// <reference lib="deno.ns" />
 
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 
-await start(routes);
+await start(manifest);

--- a/tests/fixture_build_out_dir_sub/src/main.ts
+++ b/tests/fixture_build_out_dir_sub/src/main.ts
@@ -5,6 +5,6 @@
 /// <reference lib="deno.ns" />
 
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 
-await start(routes);
+await start(manifest);

--- a/tests/fixture_build_out_dir_sub2/src/main.ts
+++ b/tests/fixture_build_out_dir_sub2/src/main.ts
@@ -5,6 +5,6 @@
 /// <reference lib="deno.ns" />
 
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 
-await start(routes);
+await start(manifest);

--- a/tests/fixture_build_sub_dir/src/main.ts
+++ b/tests/fixture_build_sub_dir/src/main.ts
@@ -5,6 +5,6 @@
 /// <reference lib="deno.ns" />
 
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 
-await start(routes);
+await start(manifest);

--- a/tests/fixture_build_target/main.ts
+++ b/tests/fixture_build_target/main.ts
@@ -5,6 +5,6 @@
 /// <reference lib="deno.ns" />
 
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 
-await start(routes);
+await start(manifest);

--- a/tests/fixture_config/main.ts
+++ b/tests/fixture_config/main.ts
@@ -5,7 +5,7 @@
 /// <reference lib="deno.ns" />
 
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 
 const TEST_CONFIG_SERVER = Deno.env.get("TEST_CONFIG_SERVER") === "true";
 const onListen = (params: { hostname: string; port: number }) => {
@@ -17,7 +17,7 @@ const onListen2 = (params: { hostname: string; port: number }) => {
   console.log(`http://localhost:${params.port}`);
 };
 
-await start(routes, {
+await start(manifest, {
   server: {
     onListen: TEST_CONFIG_SERVER ? onListen2 : undefined,
   },

--- a/tests/fixture_island_nesting/main.ts
+++ b/tests/fixture_island_nesting/main.ts
@@ -5,6 +5,6 @@
 /// <reference lib="deno.ns" />
 
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 
-await start(routes);
+await start(manifest);

--- a/tests/fixture_island_nesting/main_wasm.ts
+++ b/tests/fixture_island_nesting/main_wasm.ts
@@ -8,6 +8,6 @@
 
 import "./polyfill_deno_deploy.ts";
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 
-await start(routes);
+await start(manifest);

--- a/tests/fixture_npm/main.ts
+++ b/tests/fixture_npm/main.ts
@@ -5,6 +5,6 @@
 /// <reference lib="deno.ns" />
 
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 
-await start(routes);
+await start(manifest);

--- a/tests/fixture_preact_rts_v5/main.ts
+++ b/tests/fixture_preact_rts_v5/main.ts
@@ -5,7 +5,7 @@
 /// <reference lib="deno.ns" />
 
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 import options from "./options.ts";
 
-await start(routes, options);
+await start(manifest, options);

--- a/tests/fixture_preact_rts_v5/main_wasm.ts
+++ b/tests/fixture_preact_rts_v5/main_wasm.ts
@@ -8,7 +8,7 @@
 
 import "./polyfill_deno_deploy.ts";
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 import options from "./options.ts";
 
-await start(routes, options);
+await start(manifest, options);

--- a/tests/fixture_router_ignore_files/main.ts
+++ b/tests/fixture_router_ignore_files/main.ts
@@ -5,7 +5,7 @@
 /// <reference lib="deno.ns" />
 
 import { start } from "$fresh/server.ts";
-import routes from "./fresh.gen.ts";
+import manifest from "./fresh.gen.ts";
 import options from "./options.ts";
 
-await start(routes, options);
+await start(manifest, options);


### PR DESCRIPTION
Previously, the `routes` variable name was used. This change makes more sense as the variable has the `Manifest` type.