### PR TITLE
fix: add error-handler type to manifest

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,8 @@
     "www": "deno task --cwd=www start",
     "screenshot": "deno run -A www/utils/screenshot.ts",
     "check:types": "deno check **/*.ts && deno check **/*.tsx",
-    "ok": "deno fmt --check && deno lint && deno task check:types && deno task test"
+    "ok": "deno fmt --check && deno lint && deno task check:types && deno task test",
+    "install-puppeteer": "PUPPETEER_PRODUCT=chrome deno run -A --unstable https://deno.land/x/puppeteer@16.2.0/install.ts && PUPPETEER_PRODUCT=firefox deno run -A --unstable https://deno.land/x/puppeteer@16.2.0/install.ts"
   },
   "exclude": [
     "**/_fresh/*",

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -172,7 +172,7 @@ export async function getServerContext(opts: InternalFreshConfig) {
     if (!url.startsWith(baseUrl + "routes")) {
       throw new TypeError("Page is not a child of the basepath.");
     }
-    const path = url.substring(baseUrl.length).substring("routes".length);
+    const path = url.substring(baseUrl.length + "routes".length);
     const baseRoute = path.substring(1, path.length - extname(path).length);
     const name = baseRoute.replace("/", "-");
     const isLayout = path.endsWith("/_layout.tsx") ||

--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -74,9 +74,14 @@ export interface Manifest {
         ctx: any,
         // deno-lint-ignore no-explicit-any
       ) => Promise<any | Response> | any;
-      // deno-lint-ignore no-explicit-any
-      handler?: Handler<any, any> | Handlers<any, any> | UnknownHandler;
-      config?: RouteConfig | LayoutConfig | ErrorHandler;
+      handler?:
+        // deno-lint-ignore no-explicit-any
+        | Handler<any, any>
+        // deno-lint-ignore no-explicit-any
+        | Handlers<any, any>
+        | UnknownHandler
+        | ErrorHandler;
+      config?: RouteConfig | LayoutConfig;
     } | MiddlewareModule
   >;
   islands: Record<string, IslandModule>;

--- a/tests/fixture_custom_500/routes/_500.tsx
+++ b/tests/fixture_custom_500/routes/_500.tsx
@@ -1,4 +1,8 @@
-import { ErrorPageProps } from "../../../server.ts";
+import { ErrorHandler, ErrorPageProps } from "../../../server.ts";
+
+export const handler: ErrorHandler = (_req, ctx) => {
+  return ctx.render();
+};
 
 export default function Error500Page({ error }: ErrorPageProps) {
   return <p class="custom-500">Custom 500: {(error as Error).message}</p>;


### PR DESCRIPTION
Adds the type `ErrorHandler` as possible value for each `handler` export for modules in `Manifest`. Also removes `ErrorHandler` from `config`, as it looks like the type existed there by mistake. I ran the `ok` task, but everything passed anyway.

The updated fixture works as a test that the `Manifest` type is correct. Though I don't think there are any unit tests that uses `_500.tsx` with a handler though, so let me know if you want me to add that before merging this.

I can remove the `install-puppeteer` Deno task if it's something you don't want. The [contribution docs](https://deno.com/manual/references/contributing#submitting-a-pr-to-fresh) linked to this install script, but as a windows user I found it easiest to run the command with environment variables by using it from a Deno task.

Fixes #1753