### PR TITLE
feat: Nested partials support

### DIFF
--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -111,8 +111,7 @@ export function revive(
       );
 
       if (marker.kind === MarkerKind.Partial) {
-        // deno-lint-ignore no-explicit-any
-        partials.set(marker.text, (vnode as any).__c);
+        partials.set(marker.text, vnode as VNode<PartialComp>);
       }
     };
 
@@ -176,7 +175,7 @@ export interface RenderRequest {
 // Useful for debugging
 const SHOW_MARKERS = false;
 
-const partials = new Map<string, PartialComp>();
+const partials = new Map<string, VNode<PartialComp>>();
 
 /**
  * Replace comment markers with empty text nodes to hide them
@@ -433,8 +432,7 @@ function _walkInner(
             addPropsChild(parent, vnode);
 
             if (marker.kind === MarkerKind.Partial) {
-              // deno-lint-ignore no-explicit-any
-              partials.set(marker.text, (vnode as any).__c);
+              partials.set(marker.text, vnode as VNode<PartialComp>);
             }
 
             sib = marker.endNode.nextSibling;
@@ -786,7 +784,8 @@ export async function applyPartials(res: Response): Promise<void> {
   // Update all encountered partials
   for (let i = 0; i < encounteredPartials.length; i++) {
     const { vnode, marker } = encounteredPartials[i];
-    const instance = partials.get(marker.text);
+    // deno-lint-ignore no-explicit-any
+    const instance = (partials.get(marker.text) as any)?.__c;
 
     if (!instance) {
       console.warn(`Partial "${marker.text}" not found. Skipping...`);

--- a/tests/fixture_partials/fresh.gen.ts
+++ b/tests/fixture_partials/fresh.gen.ts
@@ -90,17 +90,20 @@ import * as $84 from "./routes/mode/index.tsx";
 import * as $85 from "./routes/mode/injected.tsx";
 import * as $86 from "./routes/mode/prepend.tsx";
 import * as $87 from "./routes/mode/replace.tsx";
-import * as $88 from "./routes/no_islands/index.tsx";
-import * as $89 from "./routes/no_islands/injected.tsx";
-import * as $90 from "./routes/no_islands/update.tsx";
-import * as $91 from "./routes/no_partial_response/index.tsx";
-import * as $92 from "./routes/no_partial_response/injected.tsx";
-import * as $93 from "./routes/no_partial_response/update.tsx";
-import * as $94 from "./routes/partial_slot_inside_island.tsx";
-import * as $95 from "./routes/relative_link/index.tsx";
-import * as $96 from "./routes/scroll_restoration/index.tsx";
-import * as $97 from "./routes/scroll_restoration/injected.tsx";
-import * as $98 from "./routes/scroll_restoration/update.tsx";
+import * as $88 from "./routes/nested/index.tsx";
+import * as $89 from "./routes/nested/inner.tsx";
+import * as $90 from "./routes/nested/outer.tsx";
+import * as $91 from "./routes/no_islands/index.tsx";
+import * as $92 from "./routes/no_islands/injected.tsx";
+import * as $93 from "./routes/no_islands/update.tsx";
+import * as $94 from "./routes/no_partial_response/index.tsx";
+import * as $95 from "./routes/no_partial_response/injected.tsx";
+import * as $96 from "./routes/no_partial_response/update.tsx";
+import * as $97 from "./routes/partial_slot_inside_island.tsx";
+import * as $98 from "./routes/relative_link/index.tsx";
+import * as $99 from "./routes/scroll_restoration/index.tsx";
+import * as $100 from "./routes/scroll_restoration/injected.tsx";
+import * as $101 from "./routes/scroll_restoration/update.tsx";
 import * as $$0 from "./islands/Counter.tsx";
 import * as $$1 from "./islands/CounterA.tsx";
 import * as $$2 from "./islands/CounterB.tsx";
@@ -207,17 +210,20 @@ const manifest = {
     "./routes/mode/injected.tsx": $85,
     "./routes/mode/prepend.tsx": $86,
     "./routes/mode/replace.tsx": $87,
-    "./routes/no_islands/index.tsx": $88,
-    "./routes/no_islands/injected.tsx": $89,
-    "./routes/no_islands/update.tsx": $90,
-    "./routes/no_partial_response/index.tsx": $91,
-    "./routes/no_partial_response/injected.tsx": $92,
-    "./routes/no_partial_response/update.tsx": $93,
-    "./routes/partial_slot_inside_island.tsx": $94,
-    "./routes/relative_link/index.tsx": $95,
-    "./routes/scroll_restoration/index.tsx": $96,
-    "./routes/scroll_restoration/injected.tsx": $97,
-    "./routes/scroll_restoration/update.tsx": $98,
+    "./routes/nested/index.tsx": $88,
+    "./routes/nested/inner.tsx": $89,
+    "./routes/nested/outer.tsx": $90,
+    "./routes/no_islands/index.tsx": $91,
+    "./routes/no_islands/injected.tsx": $92,
+    "./routes/no_islands/update.tsx": $93,
+    "./routes/no_partial_response/index.tsx": $94,
+    "./routes/no_partial_response/injected.tsx": $95,
+    "./routes/no_partial_response/update.tsx": $96,
+    "./routes/partial_slot_inside_island.tsx": $97,
+    "./routes/relative_link/index.tsx": $98,
+    "./routes/scroll_restoration/index.tsx": $99,
+    "./routes/scroll_restoration/injected.tsx": $100,
+    "./routes/scroll_restoration/update.tsx": $101,
   },
   islands: {
     "./islands/Counter.tsx": $$0,

--- a/tests/fixture_partials/routes/nested/index.tsx
+++ b/tests/fixture_partials/routes/nested/index.tsx
@@ -1,0 +1,55 @@
+import { Partial } from "$fresh/runtime.ts";
+import { ComponentChildren } from "preact";
+import { Fader } from "../../islands/Fader.tsx";
+import { Logger } from "../../islands/Logger.tsx";
+
+export function Inner() {
+  return (
+    <Partial name="inner">
+      <Logger name="inner">
+        <Fader>
+          <p class="status-inner">inner</p>
+        </Fader>
+      </Logger>
+    </Partial>
+  );
+}
+
+function Outer({ children }: { children: ComponentChildren }) {
+  return (
+    <Partial name="outer">
+      <Logger name="outer">
+        <Fader>
+          <p class="status-outer">outer</p>
+
+          {children}
+        </Fader>
+      </Logger>
+    </Partial>
+  );
+}
+
+export default function SlotDemo() {
+  return (
+    <div>
+      <Outer>
+        <Inner />
+      </Outer>
+      <p>
+        <button
+          class="update-outer"
+          f-partial="/nested/outer"
+        >
+          update outer component
+        </button>
+        <button
+          class="update-inner"
+          f-partial="/nested/inner"
+        >
+          update inner component
+        </button>
+      </p>
+      <pre id="logs" />
+    </div>
+  );
+}

--- a/tests/fixture_partials/routes/nested/inner.tsx
+++ b/tests/fixture_partials/routes/nested/inner.tsx
@@ -1,0 +1,24 @@
+import { defineRoute } from "$fresh/src/server/defines.ts";
+import { RouteConfig } from "$fresh/server.ts";
+import { Partial } from "$fresh/runtime.ts";
+import { Fader } from "../../islands/Fader.tsx";
+import { Logger } from "../../islands/Logger.tsx";
+
+export const config: RouteConfig = {
+  skipAppWrapper: true,
+  skipInheritedLayouts: true,
+};
+
+export default defineRoute(() => (
+  <div>
+    <div>
+      <Partial name="inner">
+        <Logger name="inner">
+          <Fader>
+            <p class="status-inner">updated inner</p>
+          </Fader>
+        </Logger>
+      </Partial>
+    </div>
+  </div>
+));

--- a/tests/fixture_partials/routes/nested/outer.tsx
+++ b/tests/fixture_partials/routes/nested/outer.tsx
@@ -1,0 +1,27 @@
+import { defineRoute } from "$fresh/src/server/defines.ts";
+import { RouteConfig } from "$fresh/server.ts";
+import { Partial } from "$fresh/runtime.ts";
+import { Inner } from "./index.tsx";
+import { Fader } from "../../islands/Fader.tsx";
+import { Logger } from "../../islands/Logger.tsx";
+
+export const config: RouteConfig = {
+  skipAppWrapper: true,
+  skipInheritedLayouts: true,
+};
+
+export default defineRoute(() => (
+  <div>
+    <div>
+      <Partial name="outer">
+        <Logger name="outer">
+          <Fader>
+            <p class="status-outer">updated outer</p>
+
+            <Inner />
+          </Fader>
+        </Logger>
+      </Partial>
+    </div>
+  </div>
+));

--- a/tests/partials_test.ts
+++ b/tests/partials_test.ts
@@ -1382,3 +1382,26 @@ Deno.test("supports relative links", async () => {
     },
   );
 });
+
+Deno.test("nested partials are able to be updated", async () => {
+  await withPageName(
+    "./tests/fixture_partials/main.ts",
+    async (page, address) => {
+      await page.goto(`${address}/nested`);
+      await page.waitForSelector(".status-outer");
+      await page.waitForSelector(".status-inner");
+
+      await page.click(".update-outer");
+      await waitForText(page, ".status-outer", "updated outer");
+      await waitForText(page, ".status-inner", "inner");
+
+      await page.click(".update-inner");
+      await waitForText(page, ".status-outer", "updated outer");
+      await waitForText(page, ".status-inner", "updated inner");
+
+      await page.click(".update-outer");
+      await waitForText(page, ".status-outer", "updated outer");
+      await waitForText(page, ".status-inner", "inner");
+    },
+  );
+});


### PR DESCRIPTION
This PR adds initial support for nested Partials.

# How it works?
Suppose you have a scenario where you don't really have control over where/how your component is rendered, but you still want to be able to partially update/render this component:
```tsx
// Comp1.tsx
function Comp1({ children }) {
  return (
    <Partial name="comp-1">
      {children}
    </Partial>
  );
}

// Comp2.tsx
function Comp2() {
  return (
    <Partial name="comp-2">
      {/* component layout */}
    </Partial>
  );
}

defineRoute(() => {
  return (
    <>
      <Comp1>
        <Comp2 />
      </Comp1>
      <button f-partial="/update-comp1">Update 1</button>
      <button f-partial="/update-comp2">Update 2</button>
    </>
  );
});
```

With the current Fresh implementation, If you hit `Update 1`, everything works fine. However, if you press `Update 2`, an error is logged. This PR makes pressing `Update 2` to work.

# Limitations
Once `Update 2` is clicked, `<Comp2/>` is updated. However, If you then click on `Update 1`, both `<Comp1/>` and `<Comp2/>` will be updated. This behavior can be seen on the added tests.



