### PR TITLE
Allow plugin render hooks to add link tags to the page

### DIFF
--- a/docs/canary/concepts/plugins.md
+++ b/docs/canary/concepts/plugins.md
@@ -80,14 +80,14 @@ client.
 The `render` hook needs to synchronously return a
 [`PluginRenderResult`](https://deno.land/x/fresh/server.ts?s=PluginRenderResult)
 object. Additional CSS and JS modules can be added to be injected into the page
-by adding them to `styles`, `cssLinks` and `scripts` arrays in this object.
+by adding them to `styles`, `links` and `scripts` arrays in this object.
 
 `styles` are injected into the `<head>` of the page as inline CSS. Each entry
 can define the CSS text to inject, as well as an optional `id` for the style
 tag, and an optional `media` attribute for the style tag.
 
-`cssLinks` are injected into the `<head>` of the page as link tags. Each entry
-can define the url to a CSS file, and an optional `media` attribute.
+`links` are injected into the `<head>` of the page as `<link>` tags. A link tag
+is created for each entry, with attributes from the entry's properties.
 
 `scripts` define JavaScript/TypeScript modules to be injected into the page. The
 possibly loaded modules need to be defined up front in the `Plugin#entrypoints`

--- a/docs/canary/concepts/plugins.md
+++ b/docs/canary/concepts/plugins.md
@@ -80,11 +80,14 @@ client.
 The `render` hook needs to synchronously return a
 [`PluginRenderResult`](https://deno.land/x/fresh/server.ts?s=PluginRenderResult)
 object. Additional CSS and JS modules can be added to be injected into the page
-by adding them to `styles` and `scripts` arrays in this object.
+by adding them to `styles`, `cssLinks` and `scripts` arrays in this object.
 
 `styles` are injected into the `<head>` of the page as inline CSS. Each entry
 can define the CSS text to inject, as well as an optional `id` for the style
 tag, and an optional `media` attribute for the style tag.
+
+`cssLinks` are injected into the `<head>` of the page as link tags. Each entry
+can define the url to a CSS file, and an optional `media` attribute.
 
 `scripts` define JavaScript/TypeScript modules to be injected into the page. The
 possibly loaded modules need to be defined up front in the `Plugin#entrypoints`

--- a/docs/latest/concepts/plugins.md
+++ b/docs/latest/concepts/plugins.md
@@ -80,11 +80,14 @@ client.
 The `render` hook needs to synchronously return a
 [`PluginRenderResult`](https://deno.land/x/fresh/server.ts?s=PluginRenderResult)
 object. Additional CSS and JS modules can be added to be injected into the page
-by adding them to `styles` and `scripts` arrays in this object.
+by adding them to `styles`, `cssLinks` and `scripts` arrays in this object.
 
 `styles` are injected into the `<head>` of the page as inline CSS. Each entry
 can define the CSS text to inject, as well as an optional `id` for the style
 tag, and an optional `media` attribute for the style tag.
+
+`cssLinks` are injected into the `<head>` of the page as link tags. Each entry
+can define the url to a CSS file, and an optional `media` attribute.
 
 `scripts` define JavaScript/TypeScript modules to be injected into the page. The
 possibly loaded modules need to be defined up front in the `Plugin#entrypoints`

--- a/docs/latest/concepts/plugins.md
+++ b/docs/latest/concepts/plugins.md
@@ -80,14 +80,11 @@ client.
 The `render` hook needs to synchronously return a
 [`PluginRenderResult`](https://deno.land/x/fresh/server.ts?s=PluginRenderResult)
 object. Additional CSS and JS modules can be added to be injected into the page
-by adding them to `styles`, `cssLinks` and `scripts` arrays in this object.
+by adding them to `styles` and `scripts` arrays in this object.
 
 `styles` are injected into the `<head>` of the page as inline CSS. Each entry
 can define the CSS text to inject, as well as an optional `id` for the style
 tag, and an optional `media` attribute for the style tag.
-
-`cssLinks` are injected into the `<head>` of the page as link tags. Each entry
-can define the url to a CSS file, and an optional `media` attribute.
 
 `scripts` define JavaScript/TypeScript modules to be injected into the page. The
 possibly loaded modules need to be defined up front in the `Plugin#entrypoints`

--- a/src/server/rendering/fresh_tags.tsx
+++ b/src/server/rendering/fresh_tags.tsx
@@ -2,7 +2,12 @@ import { bundleAssetUrl } from "../constants.ts";
 import { RenderState } from "./state.ts";
 import { htmlEscapeJsonString } from "../htmlescape.ts";
 import { serialize } from "../serializer.ts";
-import { Plugin, PluginRenderResult, PluginRenderStyleTag } from "../types.ts";
+import {
+  Plugin,
+  PluginRenderCssLink,
+  PluginRenderResult,
+  PluginRenderStyleTag,
+} from "../types.ts";
 import { ContentSecurityPolicy, nonce } from "../../runtime/csp.ts";
 import { h } from "preact";
 
@@ -52,6 +57,7 @@ export function renderFreshTags(
     [],
   ];
   const styleTags: PluginRenderStyleTag[] = [];
+  const cssLinks: PluginRenderCssLink[] = [];
   const pluginScripts: [string, string, number][] = [];
 
   for (const [plugin, res] of opts.pluginRenderResults) {
@@ -60,6 +66,7 @@ export function renderFreshTags(
       pluginScripts.push([plugin.name, hydrate.entrypoint, i]);
     }
     styleTags.splice(styleTags.length, 0, ...res.styles ?? []);
+    cssLinks.splice(cssLinks.length, 0, ...res.cssLinks ?? []);
   }
 
   // The inline script that will hydrate the page.
@@ -176,6 +183,15 @@ export function renderFreshTags(
       id: style.id,
       media: style.media,
       dangerouslySetInnerHTML: { __html: style.cssText },
+    });
+    renderState.headVNodes.splice(0, 0, node);
+  }
+
+  for (const link of cssLinks) {
+    const node = h("link", {
+      rel: "stylesheet",
+      media: link.media,
+      href: link.url,
     });
     renderState.headVNodes.splice(0, 0, node);
   }

--- a/src/server/rendering/fresh_tags.tsx
+++ b/src/server/rendering/fresh_tags.tsx
@@ -4,7 +4,7 @@ import { htmlEscapeJsonString } from "../htmlescape.ts";
 import { serialize } from "../serializer.ts";
 import {
   Plugin,
-  PluginRenderCssLink,
+  PluginRenderLink,
   PluginRenderResult,
   PluginRenderStyleTag,
 } from "../types.ts";
@@ -57,7 +57,7 @@ export function renderFreshTags(
     [],
   ];
   const styleTags: PluginRenderStyleTag[] = [];
-  const cssLinks: PluginRenderCssLink[] = [];
+  const linkTags: PluginRenderLink[] = [];
   const pluginScripts: [string, string, number][] = [];
 
   for (const [plugin, res] of opts.pluginRenderResults) {
@@ -66,7 +66,7 @@ export function renderFreshTags(
       pluginScripts.push([plugin.name, hydrate.entrypoint, i]);
     }
     styleTags.splice(styleTags.length, 0, ...res.styles ?? []);
-    cssLinks.splice(cssLinks.length, 0, ...res.cssLinks ?? []);
+    linkTags.splice(linkTags.length, 0, ...res.links ?? []);
   }
 
   // The inline script that will hydrate the page.
@@ -187,12 +187,8 @@ export function renderFreshTags(
     renderState.headVNodes.splice(0, 0, node);
   }
 
-  for (const link of cssLinks) {
-    const node = h("link", {
-      rel: "stylesheet",
-      media: link.media,
-      href: link.url,
-    });
+  for (const link of linkTags) {
+    const node = h("link", link);
     renderState.headVNodes.splice(0, 0, node);
   }
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -599,8 +599,8 @@ export interface PluginRenderResult {
   styles?: PluginRenderStyleTag[];
   /** JS scripts to ship to the client. */
   scripts?: PluginRenderScripts[];
-  /** CSS URLS to link to in the page */
-  cssLinks?: PluginRenderCssLink[];
+  /** Link tags for the page */
+  links?: PluginRenderLink[];
 }
 
 export interface PluginRenderStyleTag {
@@ -609,10 +609,16 @@ export interface PluginRenderStyleTag {
   id?: string;
 }
 
-export interface PluginRenderCssLink {
-  url: string;
+export type PluginRenderLink = {
+  crossOrigin?: string;
+  href?: string;
+  hreflang?: string;
   media?: string;
-}
+  referrerPolicy?: string;
+  rel?: string;
+  title?: string;
+  type?: string;
+};
 
 export interface PluginRenderScripts {
   /** The "key" of the entrypoint (as specified in `Plugin.entrypoints`) for the

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -599,12 +599,19 @@ export interface PluginRenderResult {
   styles?: PluginRenderStyleTag[];
   /** JS scripts to ship to the client. */
   scripts?: PluginRenderScripts[];
+  /** CSS URLS to link to in the page */
+  cssLinks?: PluginRenderCssLink[];
 }
 
 export interface PluginRenderStyleTag {
   cssText: string;
   media?: string;
   id?: string;
+}
+
+export interface PluginRenderCssLink {
+  url: string;
+  media?: string;
 }
 
 export interface PluginRenderScripts {

--- a/tests/fixture_plugin/fresh.config.ts
+++ b/tests/fixture_plugin/fresh.config.ts
@@ -2,6 +2,7 @@ import { FreshConfig } from "$fresh/server.ts";
 import cssInjectPlugin from "./utils/css-inject-plugin.ts";
 import jsInjectPlugin from "./utils/js-inject-plugin.ts";
 import cssInjectPluginAsync from "./utils/css-inject-plugin-async.ts";
+import linkInjectPlugin from "./utils/link-inject-plugin.ts";
 import routePlugin from "./utils/route-plugin.ts";
 import secondMiddlewarePlugin from "$fresh/tests/fixture_plugin/utils/second-middleware-plugin.ts";
 
@@ -10,6 +11,7 @@ export default {
     cssInjectPlugin,
     jsInjectPlugin,
     cssInjectPluginAsync,
+    linkInjectPlugin,
     routePlugin({ title: "Title Set From Plugin Config" }),
     secondMiddlewarePlugin(),
   ],

--- a/tests/fixture_plugin/utils/link-inject-plugin.ts
+++ b/tests/fixture_plugin/utils/link-inject-plugin.ts
@@ -1,0 +1,11 @@
+import { Plugin } from "$fresh/server.ts";
+
+export default {
+  name: "link-inject",
+  render(ctx) {
+    ctx.render();
+    return {
+      cssLinks: [{ url: "styles.css" }, { url: "print.css", media: "print" }],
+    };
+  },
+} as Plugin;

--- a/tests/fixture_plugin/utils/link-inject-plugin.ts
+++ b/tests/fixture_plugin/utils/link-inject-plugin.ts
@@ -5,7 +5,11 @@ export default {
   render(ctx) {
     ctx.render();
     return {
-      cssLinks: [{ url: "styles.css" }, { url: "print.css", media: "print" }],
+      links: [{ rel: "stylesheet", href: "styles.css" }, {
+        rel: "stylesheet",
+        href: "print.css",
+        media: "print",
+      }],
     };
   },
 } as Plugin;

--- a/tests/plugin_test.ts
+++ b/tests/plugin_test.ts
@@ -41,6 +41,11 @@ Deno.test("/static page prerender", async () => {
     body,
     '<style id="def">h1 { text-decoration: underline; }</style>',
   );
+  assertStringIncludes(body, '<link rel="stylesheet" href="styles.css"/>');
+  assertStringIncludes(
+    body,
+    '<link rel="stylesheet" media="print" href="print.css"/>',
+  );
 });
 
 Deno.test("/with-island prerender", async () => {

--- a/tests/plugin_test.ts
+++ b/tests/plugin_test.ts
@@ -44,7 +44,7 @@ Deno.test("/static page prerender", async () => {
   assertStringIncludes(body, '<link rel="stylesheet" href="styles.css"/>');
   assertStringIncludes(
     body,
-    '<link rel="stylesheet" media="print" href="print.css"/>',
+    '<link rel="stylesheet" href="print.css" media="print"/>',
   );
 });
 


### PR DESCRIPTION
Adds an extra optional property to plugin render results to allow plugins to add `<link>` tags to the page.