### PR TITLE
feat: middleware can call renderNotFound

### DIFF
--- a/src/server/compose.ts
+++ b/src/server/compose.ts
@@ -5,6 +5,7 @@ import {
   MiddlewareRoute,
   RouterState,
   ServeHandlerInfo,
+  UnknownRenderFunction,
 } from "./types.ts";
 
 export const ROOT_BASE_ROUTE = toBaseRoute("/");
@@ -59,6 +60,7 @@ export function composeMiddlewares(
     route: InternalRoute<RouterState> | undefined;
     params: Record<string, string>;
   },
+  renderNotFound: UnknownRenderFunction,
 ) {
   return (
     req: Request,
@@ -103,6 +105,9 @@ export function composeMiddlewares(
       },
       destination: "route",
       params: paramsAndRouteResult.params,
+      renderNotFound: async () => {
+        return await renderNotFound(req, paramsAndRouteResult.params, ctx);
+      },
     };
 
     for (const { module } of mws) {

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -16,6 +16,7 @@ import {
   RouterState,
   ServeHandlerInfo,
   UnknownPage,
+  UnknownRenderFunction,
 } from "./types.ts";
 import { render as internalRender } from "./render.ts";
 import {
@@ -130,12 +131,20 @@ export class ServerContext {
    * by Fresh, including static files.
    */
   handler(): (req: Request, connInfo?: ServeHandlerInfo) => Promise<Response> {
-    const handlers = this.#handlers();
+    const renderNotFound = createRenderNotFound(
+      this.#extractResult,
+      this.#dev,
+      this.#plugins,
+      this.#renderFn,
+      this.#maybeBuildSnapshot(),
+    );
+    const handlers = this.#handlers(renderNotFound);
     const inner = router.router<RouterState>(handlers);
     const withMiddlewares = composeMiddlewares(
       this.#extractResult.middlewares,
       handlers.errorHandler,
       router.getParamsAndRoute<RouterState>(handlers),
+      renderNotFound,
     );
     const trailingSlashEnabled = this.#state.config.router?.trailingSlash;
     const isDev = this.#dev;
@@ -224,7 +233,9 @@ export class ServerContext {
    * This function returns all routes required by Fresh as an extended
    * path-to-regex, to handler mapping.
    */
-  #handlers(): {
+  #handlers(
+    renderNotFound: UnknownRenderFunction,
+  ): {
     internalRoutes: router.Routes<RouterState>;
     staticRoutes: router.Routes<RouterState>;
     routes: router.Routes<RouterState>;
@@ -279,59 +290,6 @@ export class ServerContext {
     const dependenciesFn = (path: string) => {
       const snapshot = this.#maybeBuildSnapshot();
       return snapshot?.dependencies(path) ?? [];
-    };
-
-    const renderNotFound = async <Data = undefined>(
-      req: Request,
-      params: Record<string, string>,
-      // deno-lint-ignore no-explicit-any
-      ctx?: any,
-      data?: Data,
-      error?: unknown,
-    ) => {
-      const notFound = this.#extractResult.notFound;
-      if (!notFound.component) {
-        return sendResponse(["Not found.", undefined], {
-          status: Status.NotFound,
-          isDev: this.#dev,
-          statusText: undefined,
-          headers: undefined,
-        });
-      }
-
-      const layouts = selectSharedRoutes(
-        ROOT_BASE_ROUTE,
-        this.#extractResult.layouts,
-      );
-
-      const imports: string[] = [];
-      const resp = await internalRender({
-        request: req,
-        context: ctx,
-        route: notFound,
-        plugins: this.#plugins,
-        app: this.#extractResult.app,
-        layouts,
-        imports,
-        dependenciesFn,
-        renderFn: this.#renderFn,
-        url: new URL(req.url),
-        params,
-        data,
-        state: ctx?.state,
-        error,
-      });
-
-      if (resp instanceof Response) {
-        return resp;
-      }
-
-      return sendResponse(resp, {
-        status: Status.NotFound,
-        isDev: this.#dev,
-        statusText: undefined,
-        headers: undefined,
-      });
     };
 
     const genRender = <Data = undefined>(
@@ -555,6 +513,68 @@ export class ServerContext {
     };
   };
 }
+
+const createRenderNotFound = (
+  extractResult: FsExtractResult,
+  dev: boolean,
+  plugins: Plugin<Record<string, unknown>>[],
+  renderFunction: RenderFunction,
+  buildSnapshot: BuildSnapshot | null,
+) => {
+  const dependenciesFn = (path: string) => {
+    const snapshot = buildSnapshot;
+    return snapshot?.dependencies(path) ?? [];
+  };
+
+  return async (
+    ...args: Parameters<UnknownRenderFunction>
+  ) => {
+    const [req, params, ctx, data, error] = args;
+    const notFound = extractResult.notFound;
+    if (!notFound.component) {
+      return sendResponse(["Not found.", undefined], {
+        status: Status.NotFound,
+        isDev: dev,
+        statusText: undefined,
+        headers: undefined,
+      });
+    }
+
+    const layouts = selectSharedRoutes(
+      ROOT_BASE_ROUTE,
+      extractResult.layouts,
+    );
+
+    const imports: string[] = [];
+    const resp = await internalRender({
+      request: req,
+      context: ctx,
+      route: notFound,
+      plugins: plugins,
+      app: extractResult.app,
+      layouts,
+      imports,
+      dependenciesFn,
+      renderFn: renderFunction,
+      url: new URL(req.url),
+      params,
+      data,
+      state: ctx?.state,
+      error,
+    });
+
+    if (resp instanceof Response) {
+      return resp;
+    }
+
+    return sendResponse(resp, {
+      status: Status.NotFound,
+      isDev: dev,
+      statusText: undefined,
+      headers: undefined,
+    });
+  };
+};
 
 // Normalize a path for use in a URL. Returns null if the path is unparsable.
 export function normalizeURLPath(path: string): string | null {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -431,6 +431,15 @@ export interface UnknownPage {
   inheritLayouts: boolean;
 }
 
+export type UnknownRenderFunction = (
+  req: Request,
+  params: Record<string, string>,
+  // deno-lint-ignore no-explicit-any
+  ctx?: any,
+  data?: unknown,
+  error?: unknown,
+) => Promise<Response>;
+
 // --- ERROR PAGE ---
 
 export interface ErrorPageProps {
@@ -486,6 +495,7 @@ export interface ErrorPage {
 export interface MiddlewareHandlerContext<State = Record<string, unknown>>
   extends ServeHandlerInfo {
   next: () => Promise<Response>;
+  renderNotFound: (state?: State) => Response | Promise<Response>;
   state: State;
   destination: router.DestinationKind;
   params: Record<string, string>;

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -2,77 +2,79 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $0 from "./routes/[name].tsx";
-import * as $1 from "./routes/_404.tsx";
-import * as $2 from "./routes/_500.tsx";
-import * as $3 from "./routes/_app.tsx";
-import * as $4 from "./routes/_middleware.ts";
-import * as $5 from "./routes/admin/[site].tsx";
-import * as $6 from "./routes/api/get_only.ts";
-import * as $7 from "./routes/api/head_override.ts";
-import * as $8 from "./routes/assetsCaching/index.tsx";
-import * as $9 from "./routes/books/[id].tsx";
-import * as $10 from "./routes/connInfo.ts";
-import * as $11 from "./routes/error_boundary.tsx";
-import * as $12 from "./routes/event_handler_string.tsx";
-import * as $13 from "./routes/event_handler_string_island.tsx";
-import * as $14 from "./routes/evil.tsx";
-import * as $15 from "./routes/failure.ts";
-import * as $16 from "./routes/head_deduplicate.tsx";
-import * as $17 from "./routes/hooks-server/island.tsx";
-import * as $18 from "./routes/hooks-server/useReducer.tsx";
-import * as $19 from "./routes/hooks-server/useState.tsx";
-import * as $20 from "./routes/i18n/[[lang]]/lang.tsx";
-import * as $21 from "./routes/index.tsx";
-import * as $22 from "./routes/intercept.tsx";
-import * as $23 from "./routes/intercept_args.tsx";
-import * as $24 from "./routes/islands/index.tsx";
-import * as $25 from "./routes/islands/multiple_island_exports.tsx";
-import * as $26 from "./routes/islands/returning_null.tsx";
-import * as $27 from "./routes/islands/root_fragment.tsx";
-import * as $28 from "./routes/islands/root_fragment_conditional_first.tsx";
-import * as $29 from "./routes/layeredMdw/_middleware.ts";
-import * as $30 from "./routes/layeredMdw/layer2-no-mw/without_mw.ts";
-import * as $31 from "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts";
-import * as $32 from "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts";
-import * as $33 from "./routes/layeredMdw/layer2-with-params/_middleware.ts";
-import * as $34 from "./routes/layeredMdw/layer2/_middleware.ts";
-import * as $35 from "./routes/layeredMdw/layer2/abc.ts";
-import * as $36 from "./routes/layeredMdw/layer2/index.ts";
-import * as $37 from "./routes/layeredMdw/layer2/layer3/[id].ts";
-import * as $38 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
-import * as $39 from "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx";
-import * as $40 from "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts";
-import * as $41 from "./routes/layeredMdw/nesting/[tenant]/_middleware.ts";
-import * as $42 from "./routes/layeredMdw/nesting/_middleware.ts";
-import * as $43 from "./routes/middleware-error-handler/_middleware.ts";
-import * as $44 from "./routes/middleware-error-handler/index.tsx";
-import * as $45 from "./routes/middleware_root.ts";
-import * as $46 from "./routes/movies/[foo].json.ts";
-import * as $47 from "./routes/movies/[foo]@[bar].ts";
-import * as $48 from "./routes/nonce_inline.tsx";
-import * as $49 from "./routes/not_found.ts";
-import * as $50 from "./routes/params.tsx";
-import * as $51 from "./routes/preact/boolean_attrs.tsx";
-import * as $52 from "./routes/props/[id].tsx";
-import * as $53 from "./routes/route-groups-islands/index.tsx";
-import * as $54 from "./routes/route-groups/(bar)/(baz)/_layout.tsx";
-import * as $55 from "./routes/route-groups/(bar)/(baz)/baz.tsx";
-import * as $56 from "./routes/route-groups/(bar)/_layout.tsx";
-import * as $57 from "./routes/route-groups/(bar)/bar.tsx";
-import * as $58 from "./routes/route-groups/(bar)/boof/index.tsx";
-import * as $59 from "./routes/route-groups/(foo)/_layout.tsx";
-import * as $60 from "./routes/route-groups/(foo)/index.tsx";
-import * as $61 from "./routes/signal_shared.tsx";
-import * as $62 from "./routes/state-in-props/_middleware.ts";
-import * as $63 from "./routes/state-in-props/index.tsx";
-import * as $64 from "./routes/state-middleware/_middleware.ts";
-import * as $65 from "./routes/state-middleware/foo/_middleware.ts";
-import * as $66 from "./routes/state-middleware/foo/index.tsx";
-import * as $67 from "./routes/static.tsx";
-import * as $68 from "./routes/status_overwrite.tsx";
-import * as $69 from "./routes/umlaut-äöüß.tsx";
-import * as $70 from "./routes/wildcard.tsx";
+import * as $0 from "./routes/404-from-middleware/_middleware.ts";
+import * as $1 from "./routes/404-from-middleware/index.tsx";
+import * as $2 from "./routes/[name].tsx";
+import * as $3 from "./routes/_404.tsx";
+import * as $4 from "./routes/_500.tsx";
+import * as $5 from "./routes/_app.tsx";
+import * as $6 from "./routes/_middleware.ts";
+import * as $7 from "./routes/admin/[site].tsx";
+import * as $8 from "./routes/api/get_only.ts";
+import * as $9 from "./routes/api/head_override.ts";
+import * as $10 from "./routes/assetsCaching/index.tsx";
+import * as $11 from "./routes/books/[id].tsx";
+import * as $12 from "./routes/connInfo.ts";
+import * as $13 from "./routes/error_boundary.tsx";
+import * as $14 from "./routes/event_handler_string.tsx";
+import * as $15 from "./routes/event_handler_string_island.tsx";
+import * as $16 from "./routes/evil.tsx";
+import * as $17 from "./routes/failure.ts";
+import * as $18 from "./routes/head_deduplicate.tsx";
+import * as $19 from "./routes/hooks-server/island.tsx";
+import * as $20 from "./routes/hooks-server/useReducer.tsx";
+import * as $21 from "./routes/hooks-server/useState.tsx";
+import * as $22 from "./routes/i18n/[[lang]]/lang.tsx";
+import * as $23 from "./routes/index.tsx";
+import * as $24 from "./routes/intercept.tsx";
+import * as $25 from "./routes/intercept_args.tsx";
+import * as $26 from "./routes/islands/index.tsx";
+import * as $27 from "./routes/islands/multiple_island_exports.tsx";
+import * as $28 from "./routes/islands/returning_null.tsx";
+import * as $29 from "./routes/islands/root_fragment.tsx";
+import * as $30 from "./routes/islands/root_fragment_conditional_first.tsx";
+import * as $31 from "./routes/layeredMdw/_middleware.ts";
+import * as $32 from "./routes/layeredMdw/layer2-no-mw/without_mw.ts";
+import * as $33 from "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts";
+import * as $34 from "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts";
+import * as $35 from "./routes/layeredMdw/layer2-with-params/_middleware.ts";
+import * as $36 from "./routes/layeredMdw/layer2/_middleware.ts";
+import * as $37 from "./routes/layeredMdw/layer2/abc.ts";
+import * as $38 from "./routes/layeredMdw/layer2/index.ts";
+import * as $39 from "./routes/layeredMdw/layer2/layer3/[id].ts";
+import * as $40 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
+import * as $41 from "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx";
+import * as $42 from "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts";
+import * as $43 from "./routes/layeredMdw/nesting/[tenant]/_middleware.ts";
+import * as $44 from "./routes/layeredMdw/nesting/_middleware.ts";
+import * as $45 from "./routes/middleware-error-handler/_middleware.ts";
+import * as $46 from "./routes/middleware-error-handler/index.tsx";
+import * as $47 from "./routes/middleware_root.ts";
+import * as $48 from "./routes/movies/[foo].json.ts";
+import * as $49 from "./routes/movies/[foo]@[bar].ts";
+import * as $50 from "./routes/nonce_inline.tsx";
+import * as $51 from "./routes/not_found.ts";
+import * as $52 from "./routes/params.tsx";
+import * as $53 from "./routes/preact/boolean_attrs.tsx";
+import * as $54 from "./routes/props/[id].tsx";
+import * as $55 from "./routes/route-groups-islands/index.tsx";
+import * as $56 from "./routes/route-groups/(bar)/(baz)/_layout.tsx";
+import * as $57 from "./routes/route-groups/(bar)/(baz)/baz.tsx";
+import * as $58 from "./routes/route-groups/(bar)/_layout.tsx";
+import * as $59 from "./routes/route-groups/(bar)/bar.tsx";
+import * as $60 from "./routes/route-groups/(bar)/boof/index.tsx";
+import * as $61 from "./routes/route-groups/(foo)/_layout.tsx";
+import * as $62 from "./routes/route-groups/(foo)/index.tsx";
+import * as $63 from "./routes/signal_shared.tsx";
+import * as $64 from "./routes/state-in-props/_middleware.ts";
+import * as $65 from "./routes/state-in-props/index.tsx";
+import * as $66 from "./routes/state-middleware/_middleware.ts";
+import * as $67 from "./routes/state-middleware/foo/_middleware.ts";
+import * as $68 from "./routes/state-middleware/foo/index.tsx";
+import * as $69 from "./routes/static.tsx";
+import * as $70 from "./routes/status_overwrite.tsx";
+import * as $71 from "./routes/umlaut-äöüß.tsx";
+import * as $72 from "./routes/wildcard.tsx";
 import * as $$0 from "./islands/Counter.tsx";
 import * as $$1 from "./islands/FormIsland.tsx";
 import * as $$2 from "./islands/Greeter.tsx";
@@ -91,77 +93,79 @@ import * as $$14 from "./routes/route-groups-islands/(_islands)/invalid.tsx";
 
 const manifest = {
   routes: {
-    "./routes/[name].tsx": $0,
-    "./routes/_404.tsx": $1,
-    "./routes/_500.tsx": $2,
-    "./routes/_app.tsx": $3,
-    "./routes/_middleware.ts": $4,
-    "./routes/admin/[site].tsx": $5,
-    "./routes/api/get_only.ts": $6,
-    "./routes/api/head_override.ts": $7,
-    "./routes/assetsCaching/index.tsx": $8,
-    "./routes/books/[id].tsx": $9,
-    "./routes/connInfo.ts": $10,
-    "./routes/error_boundary.tsx": $11,
-    "./routes/event_handler_string.tsx": $12,
-    "./routes/event_handler_string_island.tsx": $13,
-    "./routes/evil.tsx": $14,
-    "./routes/failure.ts": $15,
-    "./routes/head_deduplicate.tsx": $16,
-    "./routes/hooks-server/island.tsx": $17,
-    "./routes/hooks-server/useReducer.tsx": $18,
-    "./routes/hooks-server/useState.tsx": $19,
-    "./routes/i18n/[[lang]]/lang.tsx": $20,
-    "./routes/index.tsx": $21,
-    "./routes/intercept.tsx": $22,
-    "./routes/intercept_args.tsx": $23,
-    "./routes/islands/index.tsx": $24,
-    "./routes/islands/multiple_island_exports.tsx": $25,
-    "./routes/islands/returning_null.tsx": $26,
-    "./routes/islands/root_fragment.tsx": $27,
-    "./routes/islands/root_fragment_conditional_first.tsx": $28,
-    "./routes/layeredMdw/_middleware.ts": $29,
-    "./routes/layeredMdw/layer2-no-mw/without_mw.ts": $30,
-    "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts": $31,
-    "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts": $32,
-    "./routes/layeredMdw/layer2-with-params/_middleware.ts": $33,
-    "./routes/layeredMdw/layer2/_middleware.ts": $34,
-    "./routes/layeredMdw/layer2/abc.ts": $35,
-    "./routes/layeredMdw/layer2/index.ts": $36,
-    "./routes/layeredMdw/layer2/layer3/[id].ts": $37,
-    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $38,
-    "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx": $39,
-    "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts": $40,
-    "./routes/layeredMdw/nesting/[tenant]/_middleware.ts": $41,
-    "./routes/layeredMdw/nesting/_middleware.ts": $42,
-    "./routes/middleware-error-handler/_middleware.ts": $43,
-    "./routes/middleware-error-handler/index.tsx": $44,
-    "./routes/middleware_root.ts": $45,
-    "./routes/movies/[foo].json.ts": $46,
-    "./routes/movies/[foo]@[bar].ts": $47,
-    "./routes/nonce_inline.tsx": $48,
-    "./routes/not_found.ts": $49,
-    "./routes/params.tsx": $50,
-    "./routes/preact/boolean_attrs.tsx": $51,
-    "./routes/props/[id].tsx": $52,
-    "./routes/route-groups-islands/index.tsx": $53,
-    "./routes/route-groups/(bar)/(baz)/_layout.tsx": $54,
-    "./routes/route-groups/(bar)/(baz)/baz.tsx": $55,
-    "./routes/route-groups/(bar)/_layout.tsx": $56,
-    "./routes/route-groups/(bar)/bar.tsx": $57,
-    "./routes/route-groups/(bar)/boof/index.tsx": $58,
-    "./routes/route-groups/(foo)/_layout.tsx": $59,
-    "./routes/route-groups/(foo)/index.tsx": $60,
-    "./routes/signal_shared.tsx": $61,
-    "./routes/state-in-props/_middleware.ts": $62,
-    "./routes/state-in-props/index.tsx": $63,
-    "./routes/state-middleware/_middleware.ts": $64,
-    "./routes/state-middleware/foo/_middleware.ts": $65,
-    "./routes/state-middleware/foo/index.tsx": $66,
-    "./routes/static.tsx": $67,
-    "./routes/status_overwrite.tsx": $68,
-    "./routes/umlaut-äöüß.tsx": $69,
-    "./routes/wildcard.tsx": $70,
+    "./routes/404-from-middleware/_middleware.ts": $0,
+    "./routes/404-from-middleware/index.tsx": $1,
+    "./routes/[name].tsx": $2,
+    "./routes/_404.tsx": $3,
+    "./routes/_500.tsx": $4,
+    "./routes/_app.tsx": $5,
+    "./routes/_middleware.ts": $6,
+    "./routes/admin/[site].tsx": $7,
+    "./routes/api/get_only.ts": $8,
+    "./routes/api/head_override.ts": $9,
+    "./routes/assetsCaching/index.tsx": $10,
+    "./routes/books/[id].tsx": $11,
+    "./routes/connInfo.ts": $12,
+    "./routes/error_boundary.tsx": $13,
+    "./routes/event_handler_string.tsx": $14,
+    "./routes/event_handler_string_island.tsx": $15,
+    "./routes/evil.tsx": $16,
+    "./routes/failure.ts": $17,
+    "./routes/head_deduplicate.tsx": $18,
+    "./routes/hooks-server/island.tsx": $19,
+    "./routes/hooks-server/useReducer.tsx": $20,
+    "./routes/hooks-server/useState.tsx": $21,
+    "./routes/i18n/[[lang]]/lang.tsx": $22,
+    "./routes/index.tsx": $23,
+    "./routes/intercept.tsx": $24,
+    "./routes/intercept_args.tsx": $25,
+    "./routes/islands/index.tsx": $26,
+    "./routes/islands/multiple_island_exports.tsx": $27,
+    "./routes/islands/returning_null.tsx": $28,
+    "./routes/islands/root_fragment.tsx": $29,
+    "./routes/islands/root_fragment_conditional_first.tsx": $30,
+    "./routes/layeredMdw/_middleware.ts": $31,
+    "./routes/layeredMdw/layer2-no-mw/without_mw.ts": $32,
+    "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts": $33,
+    "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts": $34,
+    "./routes/layeredMdw/layer2-with-params/_middleware.ts": $35,
+    "./routes/layeredMdw/layer2/_middleware.ts": $36,
+    "./routes/layeredMdw/layer2/abc.ts": $37,
+    "./routes/layeredMdw/layer2/index.ts": $38,
+    "./routes/layeredMdw/layer2/layer3/[id].ts": $39,
+    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $40,
+    "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx": $41,
+    "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts": $42,
+    "./routes/layeredMdw/nesting/[tenant]/_middleware.ts": $43,
+    "./routes/layeredMdw/nesting/_middleware.ts": $44,
+    "./routes/middleware-error-handler/_middleware.ts": $45,
+    "./routes/middleware-error-handler/index.tsx": $46,
+    "./routes/middleware_root.ts": $47,
+    "./routes/movies/[foo].json.ts": $48,
+    "./routes/movies/[foo]@[bar].ts": $49,
+    "./routes/nonce_inline.tsx": $50,
+    "./routes/not_found.ts": $51,
+    "./routes/params.tsx": $52,
+    "./routes/preact/boolean_attrs.tsx": $53,
+    "./routes/props/[id].tsx": $54,
+    "./routes/route-groups-islands/index.tsx": $55,
+    "./routes/route-groups/(bar)/(baz)/_layout.tsx": $56,
+    "./routes/route-groups/(bar)/(baz)/baz.tsx": $57,
+    "./routes/route-groups/(bar)/_layout.tsx": $58,
+    "./routes/route-groups/(bar)/bar.tsx": $59,
+    "./routes/route-groups/(bar)/boof/index.tsx": $60,
+    "./routes/route-groups/(foo)/_layout.tsx": $61,
+    "./routes/route-groups/(foo)/index.tsx": $62,
+    "./routes/signal_shared.tsx": $63,
+    "./routes/state-in-props/_middleware.ts": $64,
+    "./routes/state-in-props/index.tsx": $65,
+    "./routes/state-middleware/_middleware.ts": $66,
+    "./routes/state-middleware/foo/_middleware.ts": $67,
+    "./routes/state-middleware/foo/index.tsx": $68,
+    "./routes/static.tsx": $69,
+    "./routes/status_overwrite.tsx": $70,
+    "./routes/umlaut-äöüß.tsx": $71,
+    "./routes/wildcard.tsx": $72,
   },
   islands: {
     "./islands/Counter.tsx": $$0,

--- a/tests/fixture/routes/404-from-middleware/_middleware.ts
+++ b/tests/fixture/routes/404-from-middleware/_middleware.ts
@@ -1,0 +1,8 @@
+import { MiddlewareHandlerContext } from "$fresh/server.ts";
+
+export async function handler(
+  _req: Request,
+  ctx: MiddlewareHandlerContext,
+) {
+  return await ctx.renderNotFound();
+}

--- a/tests/fixture/routes/404-from-middleware/index.tsx
+++ b/tests/fixture/routes/404-from-middleware/index.tsx
@@ -1,0 +1,5 @@
+import { defineRoute } from "$fresh/server.ts";
+
+export default defineRoute((req, ctx) => {
+  return "This never gets shown, because the middleware calls ctx.renderNotFound.";
+});

--- a/tests/fixture_plugin/utils/second-middleware-plugin.ts
+++ b/tests/fixture_plugin/utils/second-middleware-plugin.ts
@@ -8,7 +8,10 @@ export default function secondMiddlewarePlugin(): Plugin<
     name: "secondMiddlewarePlugin",
     middlewares: [{
       middleware: {
-        handler: async (_req: Request, ctx: MiddlewareHandlerContext) => {
+        handler: async (
+          _req: Request,
+          ctx: MiddlewareHandlerContext<PluginMiddlewareState>,
+        ) => {
           return await ctx.next();
         },
       },
@@ -26,7 +29,10 @@ export default function secondMiddlewarePlugin(): Plugin<
       path: "lots-of-middleware/",
     }, {
       middleware: {
-        handler: async (_req: Request, ctx: MiddlewareHandlerContext) => {
+        handler: async (
+          _req: Request,
+          ctx: MiddlewareHandlerContext<PluginMiddlewareState>,
+        ) => {
           return await ctx.next();
         },
       },

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -715,6 +715,24 @@ Deno.test({
   },
 });
 
+Deno.test({
+  name: "404 from middleware",
+  fn: async () => {
+    const resp = await handler(
+      new Request(
+        "https://fresh.deno.dev/404-from-middleware",
+      ),
+    );
+    assert(resp);
+    assertEquals(resp.status, Status.NotFound);
+    const body = await resp.text();
+    assertStringIncludes(
+      body,
+      "404 not found: /404-from-middleware",
+    );
+  },
+});
+
 Deno.test("jsx pragma works", async (t) => {
   // Preparation
   const { serverProcess, lines, address } = await startFreshServer({


### PR DESCRIPTION
closes https://github.com/denoland/fresh/issues/1628

I now create the `renderNotFound` function outside of `#handlers`. This allows me to pass it to both `#handlers` and `composeMiddlewares`, so that it can get added to `MiddlewareHandlerContext`.

This also makes it trivial to do https://github.com/denoland/fresh/issues/1759. Please reassign that to me, because I can complete it as soon as this is merged.