### PR TITLE
feat: speed up route matching

### DIFF
--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -271,7 +271,7 @@ export function getParamsAndRoute<T>(
 
   return (url: string) => {
     const urlObject = new URL(url);
-    const isPartial = urlObject.searchParams.has("fresh-partial");
+    const isPartial = urlObject.searchParams.has(PARTIAL_SEARCH_PARAM);
     const pathname = urlObject.pathname;
 
     const cached = statics.get(pathname);

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -271,9 +271,12 @@ export function getParamsAndRoute<T>(
 
   return (url: string) => {
     const urlObject = new URL(url);
+    const isPartial = urlObject.searchParams.has("fresh-partial");
     const pathname = urlObject.pathname;
+
     const cached = statics.get(pathname);
     if (cached !== undefined) {
+      cached.isPartial = isPartial;
       return cached;
     }
 
@@ -287,7 +290,7 @@ export function getParamsAndRoute<T>(
       if (typeof route.pattern === "string") {
         if (route.pattern === pathname) {
           processedRoutes[i] = null;
-          const res = { route: route, params: {}, isPartial: false };
+          const res = { route: route, params: {}, isPartial };
           statics.set(route.pattern, res);
           return res;
         }
@@ -295,7 +298,7 @@ export function getParamsAndRoute<T>(
         continue;
       }
 
-      const res = route.pattern.exec(urlObject.pathname);
+      const res = route.pattern.exec(pathname);
 
       if (res !== null) {
         const groups: Record<string, string> = {};
@@ -311,14 +314,14 @@ export function getParamsAndRoute<T>(
         return {
           route: route,
           params: groups,
-          isPartial: urlObject.searchParams.has(PARTIAL_SEARCH_PARAM),
+          isPartial,
         };
       }
     }
     return {
       route: undefined,
       params: {},
-      isPartial: false,
+      isPartial,
     };
   };
 }

--- a/src/server/router_test.ts
+++ b/src/server/router_test.ts
@@ -1,0 +1,39 @@
+import { assertEquals } from "$std/testing/asserts.ts";
+import { IS_PATTERN, patternToRegExp } from "./router.ts";
+
+function testPattern(input: string, test: string) {
+  const regex = patternToRegExp(input);
+  const match = test.match(regex);
+  return (match !== null) ? match.groups ?? {} : null;
+}
+
+Deno.test("pathToRegexp", () => {
+  assertEquals(testPattern("/:path", "/foo"), { path: "foo" });
+  assertEquals(testPattern("/:path", "/foo/bar"), null);
+  assertEquals(testPattern("/:path/bar", "/foo/bar"), { path: "foo" });
+  assertEquals(testPattern("/foo/:path", "/foo/bar"), { path: "bar" });
+  assertEquals(testPattern("/foo/:path", "/foo"), null);
+  assertEquals(testPattern("/foo/*", "/foo/asd/asdh/"), {});
+  assertEquals(testPattern("/foo{/bar}?", "/foo"), {});
+  assertEquals(testPattern("/foo/(\\d+)", "/foo"), null);
+  assertEquals(testPattern("/foo/(\\d+)", "/foo/1"), {});
+  assertEquals(testPattern("/foo/(\\d+)", "/foo/11231"), {});
+  assertEquals(testPattern("/foo/(bar)", "/foo/bar"), {});
+  assertEquals(testPattern("/foo/:path*", "/foo/bar/asdf"), {
+    path: "bar/asdf",
+  });
+  assertEquals(testPattern("/movies/:foo@:bar", "/movies/asdf@hehe"), {
+    foo: "asdf",
+    bar: "hehe",
+  });
+});
+
+Deno.test("IS_PATTERN", () => {
+  assertEquals(IS_PATTERN.test("/foo"), false);
+  assertEquals(IS_PATTERN.test("/foo/bar/baz.jpg"), false);
+  assertEquals(IS_PATTERN.test("/foo/:path"), true);
+  assertEquals(IS_PATTERN.test("/foo/*"), true);
+  assertEquals(IS_PATTERN.test("/foo{/bar}?"), true);
+  assertEquals(IS_PATTERN.test("/foo/(\\d+)"), true);
+  assertEquals(IS_PATTERN.test("/foo/(a)"), true);
+});


### PR DESCRIPTION
We can significantly speed up route matching by not using `URLPattern` and opting for a custom constructed `RegExp` instead. This is roughly 150-180x faster and I confirm that in live traces this greatly reduces CPU time.

```sh
benchmark      time (avg)        iter/s             (min … max)       p75       p99      p995
--------------------------------------------------------------- -----------------------------
pattern       160.12 µs/iter       6,245.2 (151.88 µs … 712.62 µs) 161.04 µs 191.46 µs 221.21 µs
regex         889.44 ns/iter   1,124,305.9 (870.65 ns … 965.37 ns) 892.66 ns 965.37 ns 965.37 ns
```

I've added an additional optimization that first checks if we're dealing with a pattern or an exact path match in the first place. If it's an exact match we can skip parsing it to a pattern entirely, which is even faster.