### PR TITLE
feat(server): throwing Deno.errors.NotFound triggers 404

### DIFF
--- a/docs/canary/concepts/error-pages.md
+++ b/docs/canary/concepts/error-pages.md
@@ -1,0 +1,82 @@
+---
+description: |
+  Error pages can be used to customize the page that is shown when an error occurs in the application.
+---
+
+Fresh supports customizing the `404 Not Found`, and the
+`500 Internal Server Error` pages. These are shown when a request is made but no
+matching route exists, and when a middleware, route handler, or page component
+throws an error respectively.
+
+### 404: Not Found
+
+The 404 page can be customized by creating a `_404.tsx` file in the `routes/`
+folder. The file must have a default export that is a regular Preact component.
+A props object of type `UnknownPageProps` is passed in as an argument.
+
+```tsx routes/_404.tsx
+import { UnknownPageProps } from "$fresh/server.ts";
+
+export default function NotFoundPage({ url }: UnknownPageProps) {
+  return <p>404 not found: {url.pathname}</p>;
+}
+```
+
+#### Manually render 404 pages
+
+The `_404.tsx` file will be invoked automatically when no route matches the URL.
+In some cases, one needs to manually trigger the rendering of the 404 page, for
+example when the route did match, but the requested resource does not exist.
+This can be achieved with `ctx.renderNotFound`.
+
+```tsx routes/blog/[slug].tsx
+import { Handlers, PageProps } from "$fresh/server.ts";
+
+export const handler: Handlers = {
+  async GET(req, ctx) {
+    const blogpost = await fetchBlogpost(ctx.params.slug);
+    if (!blogpost) {
+      return ctx.renderNotFound({
+        custom: "prop",
+      });
+    }
+    return ctx.render({ blogpost });
+  },
+};
+
+export default function BlogpostPage({ data }) {
+  return (
+    <article>
+      <h1>{data.blogpost.title}</h1>
+      {/* rest of your page */}
+    </article>
+  );
+}
+```
+
+This can also be achieved by throwing an error, if you're uninterested in
+passing specific data to your 404 page:
+
+```tsx
+import { Handlers } from "$fresh/server.ts";
+
+export const handler: Handlers = {
+  GET(_req, _ctx) {
+    throw new Deno.errors.NotFound();
+  },
+};
+```
+
+### 500: Internal Server Error
+
+The 500 page can be customized by creating a `_500.tsx` file in the `routes/`
+folder. The file must have a default export that is a regular Preact component.
+A props object of type `ErrorPageProps` is passed in as an argument.
+
+```tsx routes/_500.tsx
+import { ErrorPageProps } from "$fresh/server.ts";
+
+export default function Error500Page({ error }: ErrorPageProps) {
+  return <p>500 internal error: {(error as Error).message}</p>;
+}
+```

--- a/docs/toc.ts
+++ b/docs/toc.ts
@@ -54,7 +54,7 @@ const toc: RawTableOfContents = {
           ["islands", "Interactive islands", "link:latest"],
           ["static-files", "Static files", "link:latest"],
           ["middleware", "Middlewares", "link:latest"],
-          ["error-pages", "Error pages", "link:latest"],
+          ["error-pages", "Error pages", "link:canary"],
           ["partials", "Partials", "link:latest"],
           ["data-fetching", "Data fetching", "link:latest"],
           ["ahead-of-time-builds", "Ahead-of-time Builds", "link:latest"],

--- a/src/server/compose.ts
+++ b/src/server/compose.ts
@@ -90,6 +90,9 @@ export function composeMiddlewares(
           // the error case manually, by returning the `Error` as rejected promise.
           return Promise.resolve(handler());
         } catch (e) {
+          if (e instanceof Deno.errors.NotFound) {
+            return renderNotFound(req, paramsAndRouteResult.params, ctx);
+          }
           return Promise.reject(e);
         }
       },

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -2,79 +2,82 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $0 from "./routes/404-from-middleware/_middleware.ts";
-import * as $1 from "./routes/404-from-middleware/index.tsx";
-import * as $2 from "./routes/[name].tsx";
-import * as $3 from "./routes/_404.tsx";
-import * as $4 from "./routes/_500.tsx";
-import * as $5 from "./routes/_app.tsx";
-import * as $6 from "./routes/_middleware.ts";
-import * as $7 from "./routes/admin/[site].tsx";
-import * as $8 from "./routes/api/get_only.ts";
-import * as $9 from "./routes/api/head_override.ts";
-import * as $10 from "./routes/assetsCaching/index.tsx";
-import * as $11 from "./routes/books/[id].tsx";
-import * as $12 from "./routes/connInfo.ts";
-import * as $13 from "./routes/error_boundary.tsx";
-import * as $14 from "./routes/event_handler_string.tsx";
-import * as $15 from "./routes/event_handler_string_island.tsx";
-import * as $16 from "./routes/evil.tsx";
-import * as $17 from "./routes/failure.ts";
-import * as $18 from "./routes/head_deduplicate.tsx";
-import * as $19 from "./routes/hooks-server/island.tsx";
-import * as $20 from "./routes/hooks-server/useReducer.tsx";
-import * as $21 from "./routes/hooks-server/useState.tsx";
-import * as $22 from "./routes/i18n/[[lang]]/lang.tsx";
-import * as $23 from "./routes/index.tsx";
-import * as $24 from "./routes/intercept.tsx";
-import * as $25 from "./routes/intercept_args.tsx";
-import * as $26 from "./routes/islands/index.tsx";
-import * as $27 from "./routes/islands/multiple_island_exports.tsx";
-import * as $28 from "./routes/islands/returning_null.tsx";
-import * as $29 from "./routes/islands/root_fragment.tsx";
-import * as $30 from "./routes/islands/root_fragment_conditional_first.tsx";
-import * as $31 from "./routes/layeredMdw/_middleware.ts";
-import * as $32 from "./routes/layeredMdw/layer2-no-mw/without_mw.ts";
-import * as $33 from "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts";
-import * as $34 from "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts";
-import * as $35 from "./routes/layeredMdw/layer2-with-params/_middleware.ts";
-import * as $36 from "./routes/layeredMdw/layer2/_middleware.ts";
-import * as $37 from "./routes/layeredMdw/layer2/abc.ts";
-import * as $38 from "./routes/layeredMdw/layer2/index.ts";
-import * as $39 from "./routes/layeredMdw/layer2/layer3/[id].ts";
-import * as $40 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
-import * as $41 from "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx";
-import * as $42 from "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts";
-import * as $43 from "./routes/layeredMdw/nesting/[tenant]/_middleware.ts";
-import * as $44 from "./routes/layeredMdw/nesting/_middleware.ts";
-import * as $45 from "./routes/middleware-error-handler/_middleware.ts";
-import * as $46 from "./routes/middleware-error-handler/index.tsx";
-import * as $47 from "./routes/middleware_root.ts";
-import * as $48 from "./routes/movies/[foo].json.ts";
-import * as $49 from "./routes/movies/[foo]@[bar].ts";
-import * as $50 from "./routes/nonce_inline.tsx";
-import * as $51 from "./routes/not_found.ts";
-import * as $52 from "./routes/params.tsx";
-import * as $53 from "./routes/preact/boolean_attrs.tsx";
-import * as $54 from "./routes/props/[id].tsx";
-import * as $55 from "./routes/route-groups-islands/index.tsx";
-import * as $56 from "./routes/route-groups/(bar)/(baz)/_layout.tsx";
-import * as $57 from "./routes/route-groups/(bar)/(baz)/baz.tsx";
-import * as $58 from "./routes/route-groups/(bar)/_layout.tsx";
-import * as $59 from "./routes/route-groups/(bar)/bar.tsx";
-import * as $60 from "./routes/route-groups/(bar)/boof/index.tsx";
-import * as $61 from "./routes/route-groups/(foo)/_layout.tsx";
-import * as $62 from "./routes/route-groups/(foo)/index.tsx";
-import * as $63 from "./routes/signal_shared.tsx";
-import * as $64 from "./routes/state-in-props/_middleware.ts";
-import * as $65 from "./routes/state-in-props/index.tsx";
-import * as $66 from "./routes/state-middleware/_middleware.ts";
-import * as $67 from "./routes/state-middleware/foo/_middleware.ts";
-import * as $68 from "./routes/state-middleware/foo/index.tsx";
-import * as $69 from "./routes/static.tsx";
-import * as $70 from "./routes/status_overwrite.tsx";
-import * as $71 from "./routes/umlaut-äöüß.tsx";
-import * as $72 from "./routes/wildcard.tsx";
+import * as $0 from "./routes/404-from-middleware-throw/_middleware.ts";
+import * as $1 from "./routes/404-from-middleware-throw/index.tsx";
+import * as $2 from "./routes/404-from-middleware/_middleware.ts";
+import * as $3 from "./routes/404-from-middleware/index.tsx";
+import * as $4 from "./routes/404_from_throw.tsx";
+import * as $5 from "./routes/[name].tsx";
+import * as $6 from "./routes/_404.tsx";
+import * as $7 from "./routes/_500.tsx";
+import * as $8 from "./routes/_app.tsx";
+import * as $9 from "./routes/_middleware.ts";
+import * as $10 from "./routes/admin/[site].tsx";
+import * as $11 from "./routes/api/get_only.ts";
+import * as $12 from "./routes/api/head_override.ts";
+import * as $13 from "./routes/assetsCaching/index.tsx";
+import * as $14 from "./routes/books/[id].tsx";
+import * as $15 from "./routes/connInfo.ts";
+import * as $16 from "./routes/error_boundary.tsx";
+import * as $17 from "./routes/event_handler_string.tsx";
+import * as $18 from "./routes/event_handler_string_island.tsx";
+import * as $19 from "./routes/evil.tsx";
+import * as $20 from "./routes/failure.ts";
+import * as $21 from "./routes/head_deduplicate.tsx";
+import * as $22 from "./routes/hooks-server/island.tsx";
+import * as $23 from "./routes/hooks-server/useReducer.tsx";
+import * as $24 from "./routes/hooks-server/useState.tsx";
+import * as $25 from "./routes/i18n/[[lang]]/lang.tsx";
+import * as $26 from "./routes/index.tsx";
+import * as $27 from "./routes/intercept.tsx";
+import * as $28 from "./routes/intercept_args.tsx";
+import * as $29 from "./routes/islands/index.tsx";
+import * as $30 from "./routes/islands/multiple_island_exports.tsx";
+import * as $31 from "./routes/islands/returning_null.tsx";
+import * as $32 from "./routes/islands/root_fragment.tsx";
+import * as $33 from "./routes/islands/root_fragment_conditional_first.tsx";
+import * as $34 from "./routes/layeredMdw/_middleware.ts";
+import * as $35 from "./routes/layeredMdw/layer2-no-mw/without_mw.ts";
+import * as $36 from "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts";
+import * as $37 from "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts";
+import * as $38 from "./routes/layeredMdw/layer2-with-params/_middleware.ts";
+import * as $39 from "./routes/layeredMdw/layer2/_middleware.ts";
+import * as $40 from "./routes/layeredMdw/layer2/abc.ts";
+import * as $41 from "./routes/layeredMdw/layer2/index.ts";
+import * as $42 from "./routes/layeredMdw/layer2/layer3/[id].ts";
+import * as $43 from "./routes/layeredMdw/layer2/layer3/_middleware.ts";
+import * as $44 from "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx";
+import * as $45 from "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts";
+import * as $46 from "./routes/layeredMdw/nesting/[tenant]/_middleware.ts";
+import * as $47 from "./routes/layeredMdw/nesting/_middleware.ts";
+import * as $48 from "./routes/middleware-error-handler/_middleware.ts";
+import * as $49 from "./routes/middleware-error-handler/index.tsx";
+import * as $50 from "./routes/middleware_root.ts";
+import * as $51 from "./routes/movies/[foo].json.ts";
+import * as $52 from "./routes/movies/[foo]@[bar].ts";
+import * as $53 from "./routes/nonce_inline.tsx";
+import * as $54 from "./routes/not_found.ts";
+import * as $55 from "./routes/params.tsx";
+import * as $56 from "./routes/preact/boolean_attrs.tsx";
+import * as $57 from "./routes/props/[id].tsx";
+import * as $58 from "./routes/route-groups-islands/index.tsx";
+import * as $59 from "./routes/route-groups/(bar)/(baz)/_layout.tsx";
+import * as $60 from "./routes/route-groups/(bar)/(baz)/baz.tsx";
+import * as $61 from "./routes/route-groups/(bar)/_layout.tsx";
+import * as $62 from "./routes/route-groups/(bar)/bar.tsx";
+import * as $63 from "./routes/route-groups/(bar)/boof/index.tsx";
+import * as $64 from "./routes/route-groups/(foo)/_layout.tsx";
+import * as $65 from "./routes/route-groups/(foo)/index.tsx";
+import * as $66 from "./routes/signal_shared.tsx";
+import * as $67 from "./routes/state-in-props/_middleware.ts";
+import * as $68 from "./routes/state-in-props/index.tsx";
+import * as $69 from "./routes/state-middleware/_middleware.ts";
+import * as $70 from "./routes/state-middleware/foo/_middleware.ts";
+import * as $71 from "./routes/state-middleware/foo/index.tsx";
+import * as $72 from "./routes/static.tsx";
+import * as $73 from "./routes/status_overwrite.tsx";
+import * as $74 from "./routes/umlaut-äöüß.tsx";
+import * as $75 from "./routes/wildcard.tsx";
 import * as $$0 from "./islands/Counter.tsx";
 import * as $$1 from "./islands/FormIsland.tsx";
 import * as $$2 from "./islands/Greeter.tsx";
@@ -93,79 +96,82 @@ import * as $$14 from "./routes/route-groups-islands/(_islands)/invalid.tsx";
 
 const manifest = {
   routes: {
-    "./routes/404-from-middleware/_middleware.ts": $0,
-    "./routes/404-from-middleware/index.tsx": $1,
-    "./routes/[name].tsx": $2,
-    "./routes/_404.tsx": $3,
-    "./routes/_500.tsx": $4,
-    "./routes/_app.tsx": $5,
-    "./routes/_middleware.ts": $6,
-    "./routes/admin/[site].tsx": $7,
-    "./routes/api/get_only.ts": $8,
-    "./routes/api/head_override.ts": $9,
-    "./routes/assetsCaching/index.tsx": $10,
-    "./routes/books/[id].tsx": $11,
-    "./routes/connInfo.ts": $12,
-    "./routes/error_boundary.tsx": $13,
-    "./routes/event_handler_string.tsx": $14,
-    "./routes/event_handler_string_island.tsx": $15,
-    "./routes/evil.tsx": $16,
-    "./routes/failure.ts": $17,
-    "./routes/head_deduplicate.tsx": $18,
-    "./routes/hooks-server/island.tsx": $19,
-    "./routes/hooks-server/useReducer.tsx": $20,
-    "./routes/hooks-server/useState.tsx": $21,
-    "./routes/i18n/[[lang]]/lang.tsx": $22,
-    "./routes/index.tsx": $23,
-    "./routes/intercept.tsx": $24,
-    "./routes/intercept_args.tsx": $25,
-    "./routes/islands/index.tsx": $26,
-    "./routes/islands/multiple_island_exports.tsx": $27,
-    "./routes/islands/returning_null.tsx": $28,
-    "./routes/islands/root_fragment.tsx": $29,
-    "./routes/islands/root_fragment_conditional_first.tsx": $30,
-    "./routes/layeredMdw/_middleware.ts": $31,
-    "./routes/layeredMdw/layer2-no-mw/without_mw.ts": $32,
-    "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts": $33,
-    "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts": $34,
-    "./routes/layeredMdw/layer2-with-params/_middleware.ts": $35,
-    "./routes/layeredMdw/layer2/_middleware.ts": $36,
-    "./routes/layeredMdw/layer2/abc.ts": $37,
-    "./routes/layeredMdw/layer2/index.ts": $38,
-    "./routes/layeredMdw/layer2/layer3/[id].ts": $39,
-    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $40,
-    "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx": $41,
-    "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts": $42,
-    "./routes/layeredMdw/nesting/[tenant]/_middleware.ts": $43,
-    "./routes/layeredMdw/nesting/_middleware.ts": $44,
-    "./routes/middleware-error-handler/_middleware.ts": $45,
-    "./routes/middleware-error-handler/index.tsx": $46,
-    "./routes/middleware_root.ts": $47,
-    "./routes/movies/[foo].json.ts": $48,
-    "./routes/movies/[foo]@[bar].ts": $49,
-    "./routes/nonce_inline.tsx": $50,
-    "./routes/not_found.ts": $51,
-    "./routes/params.tsx": $52,
-    "./routes/preact/boolean_attrs.tsx": $53,
-    "./routes/props/[id].tsx": $54,
-    "./routes/route-groups-islands/index.tsx": $55,
-    "./routes/route-groups/(bar)/(baz)/_layout.tsx": $56,
-    "./routes/route-groups/(bar)/(baz)/baz.tsx": $57,
-    "./routes/route-groups/(bar)/_layout.tsx": $58,
-    "./routes/route-groups/(bar)/bar.tsx": $59,
-    "./routes/route-groups/(bar)/boof/index.tsx": $60,
-    "./routes/route-groups/(foo)/_layout.tsx": $61,
-    "./routes/route-groups/(foo)/index.tsx": $62,
-    "./routes/signal_shared.tsx": $63,
-    "./routes/state-in-props/_middleware.ts": $64,
-    "./routes/state-in-props/index.tsx": $65,
-    "./routes/state-middleware/_middleware.ts": $66,
-    "./routes/state-middleware/foo/_middleware.ts": $67,
-    "./routes/state-middleware/foo/index.tsx": $68,
-    "./routes/static.tsx": $69,
-    "./routes/status_overwrite.tsx": $70,
-    "./routes/umlaut-äöüß.tsx": $71,
-    "./routes/wildcard.tsx": $72,
+    "./routes/404-from-middleware-throw/_middleware.ts": $0,
+    "./routes/404-from-middleware-throw/index.tsx": $1,
+    "./routes/404-from-middleware/_middleware.ts": $2,
+    "./routes/404-from-middleware/index.tsx": $3,
+    "./routes/404_from_throw.tsx": $4,
+    "./routes/[name].tsx": $5,
+    "./routes/_404.tsx": $6,
+    "./routes/_500.tsx": $7,
+    "./routes/_app.tsx": $8,
+    "./routes/_middleware.ts": $9,
+    "./routes/admin/[site].tsx": $10,
+    "./routes/api/get_only.ts": $11,
+    "./routes/api/head_override.ts": $12,
+    "./routes/assetsCaching/index.tsx": $13,
+    "./routes/books/[id].tsx": $14,
+    "./routes/connInfo.ts": $15,
+    "./routes/error_boundary.tsx": $16,
+    "./routes/event_handler_string.tsx": $17,
+    "./routes/event_handler_string_island.tsx": $18,
+    "./routes/evil.tsx": $19,
+    "./routes/failure.ts": $20,
+    "./routes/head_deduplicate.tsx": $21,
+    "./routes/hooks-server/island.tsx": $22,
+    "./routes/hooks-server/useReducer.tsx": $23,
+    "./routes/hooks-server/useState.tsx": $24,
+    "./routes/i18n/[[lang]]/lang.tsx": $25,
+    "./routes/index.tsx": $26,
+    "./routes/intercept.tsx": $27,
+    "./routes/intercept_args.tsx": $28,
+    "./routes/islands/index.tsx": $29,
+    "./routes/islands/multiple_island_exports.tsx": $30,
+    "./routes/islands/returning_null.tsx": $31,
+    "./routes/islands/root_fragment.tsx": $32,
+    "./routes/islands/root_fragment_conditional_first.tsx": $33,
+    "./routes/layeredMdw/_middleware.ts": $34,
+    "./routes/layeredMdw/layer2-no-mw/without_mw.ts": $35,
+    "./routes/layeredMdw/layer2-with-params/[tenantId]/[id].ts": $36,
+    "./routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts": $37,
+    "./routes/layeredMdw/layer2-with-params/_middleware.ts": $38,
+    "./routes/layeredMdw/layer2/_middleware.ts": $39,
+    "./routes/layeredMdw/layer2/abc.ts": $40,
+    "./routes/layeredMdw/layer2/index.ts": $41,
+    "./routes/layeredMdw/layer2/layer3/[id].ts": $42,
+    "./routes/layeredMdw/layer2/layer3/_middleware.ts": $43,
+    "./routes/layeredMdw/nesting/[tenant]/[environment]/[id].tsx": $44,
+    "./routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts": $45,
+    "./routes/layeredMdw/nesting/[tenant]/_middleware.ts": $46,
+    "./routes/layeredMdw/nesting/_middleware.ts": $47,
+    "./routes/middleware-error-handler/_middleware.ts": $48,
+    "./routes/middleware-error-handler/index.tsx": $49,
+    "./routes/middleware_root.ts": $50,
+    "./routes/movies/[foo].json.ts": $51,
+    "./routes/movies/[foo]@[bar].ts": $52,
+    "./routes/nonce_inline.tsx": $53,
+    "./routes/not_found.ts": $54,
+    "./routes/params.tsx": $55,
+    "./routes/preact/boolean_attrs.tsx": $56,
+    "./routes/props/[id].tsx": $57,
+    "./routes/route-groups-islands/index.tsx": $58,
+    "./routes/route-groups/(bar)/(baz)/_layout.tsx": $59,
+    "./routes/route-groups/(bar)/(baz)/baz.tsx": $60,
+    "./routes/route-groups/(bar)/_layout.tsx": $61,
+    "./routes/route-groups/(bar)/bar.tsx": $62,
+    "./routes/route-groups/(bar)/boof/index.tsx": $63,
+    "./routes/route-groups/(foo)/_layout.tsx": $64,
+    "./routes/route-groups/(foo)/index.tsx": $65,
+    "./routes/signal_shared.tsx": $66,
+    "./routes/state-in-props/_middleware.ts": $67,
+    "./routes/state-in-props/index.tsx": $68,
+    "./routes/state-middleware/_middleware.ts": $69,
+    "./routes/state-middleware/foo/_middleware.ts": $70,
+    "./routes/state-middleware/foo/index.tsx": $71,
+    "./routes/static.tsx": $72,
+    "./routes/status_overwrite.tsx": $73,
+    "./routes/umlaut-äöüß.tsx": $74,
+    "./routes/wildcard.tsx": $75,
   },
   islands: {
     "./islands/Counter.tsx": $$0,

--- a/tests/fixture/routes/404-from-middleware-throw/_middleware.ts
+++ b/tests/fixture/routes/404-from-middleware-throw/_middleware.ts
@@ -1,0 +1,10 @@
+import { MiddlewareHandlerContext } from "$fresh/server.ts";
+
+// handlers are supposed to return something, so in order to make type checker on the manifest happy, we'll use any to escape it
+export function handler(
+  _req: Request,
+  _ctx: MiddlewareHandlerContext,
+  // deno-lint-ignore no-explicit-any
+): any {
+  throw new Deno.errors.NotFound();
+}

--- a/tests/fixture/routes/404-from-middleware-throw/index.tsx
+++ b/tests/fixture/routes/404-from-middleware-throw/index.tsx
@@ -1,0 +1,5 @@
+import { defineRoute } from "$fresh/server.ts";
+
+export default defineRoute((req, ctx) => {
+  return "This never gets shown, because the middleware throws an error.";
+});

--- a/tests/fixture/routes/404_from_throw.tsx
+++ b/tests/fixture/routes/404_from_throw.tsx
@@ -1,0 +1,7 @@
+import { Handlers } from "$fresh/server.ts";
+
+export const handler: Handlers = {
+  GET(_req, _ctx) {
+    throw new Deno.errors.NotFound();
+  },
+};

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -733,6 +733,42 @@ Deno.test({
   },
 });
 
+Deno.test({
+  name: "404 from throw",
+  fn: async () => {
+    const resp = await handler(
+      new Request(
+        "https://fresh.deno.dev/404_from_throw",
+      ),
+    );
+    assert(resp);
+    assertEquals(resp.status, Status.NotFound);
+    const body = await resp.text();
+    assertStringIncludes(
+      body,
+      "404 not found: /404_from_throw",
+    );
+  },
+});
+
+Deno.test({
+  name: "404 from middleware throw",
+  fn: async () => {
+    const resp = await handler(
+      new Request(
+        "https://fresh.deno.dev/404-from-middleware-throw",
+      ),
+    );
+    assert(resp);
+    assertEquals(resp.status, Status.NotFound);
+    const body = await resp.text();
+    assertStringIncludes(
+      body,
+      "404 not found: /404-from-middleware-throw",
+    );
+  },
+});
+
 Deno.test("jsx pragma works", async (t) => {
   // Preparation
   const { serverProcess, lines, address } = await startFreshServer({


### PR DESCRIPTION
closes https://github.com/denoland/fresh/issues/1759

I've branched the documentation to canary because I've added the following snippet:
````
This can also be achieved by throwing an error, if you're uninterested in
passing specific data to your 404 page:

```tsx
import { Handlers } from "$fresh/server.ts";

export const handler: Handlers = {
  GET(_req, _ctx) {
    throw new Deno.errors.NotFound();
  },
};
```
````

Note: this soft-conflicts with https://github.com/denoland/fresh/pull/1983, since I don't have that addition to the page.