### PR TITLE
docs: update server configuration page

### DIFF
--- a/docs/latest/concepts/server-configuration.md
+++ b/docs/latest/concepts/server-configuration.md
@@ -14,18 +14,35 @@ export async function start(manifest: Manifest, config: FreshConfig = {});
 ## Configuration
 
 `Manifest` comes from `fresh.gen.ts`, so nothing to do there. `config` is where
-things get interesting. `FreshConfig` looks like this:
+things get interesting.
+[`FreshConfig`](https://deno.land/x/fresh/server.ts?s=FreshConfig) looks like
+this:
 
 ```ts
 export interface FreshConfig {
+  build?: {
+    /**
+     * The directory to write generated files to when `dev.ts build` is run.
+     * This can be an absolute path, a file URL or a relative path.
+     */
+    outDir?: string;
+    /**
+     * This sets the target environment for the generated code. Newer
+     * language constructs will be transformed to match the specified
+     * support range. See https://esbuild.github.io/api/#target
+     * @default {"es2022"}
+     */
+    target?: string | string[];
+  };
   render?: RenderFunction;
   plugins?: Plugin[];
   staticDir?: string;
   router?: RouterOptions;
+  server?: Partial<Deno.ServeTlsOptions>;
 }
 ```
 
-And for brevity here are the remaining two types:
+And for completeness here are the remaining two types:
 
 ```ts
 export type RenderFunction = (
@@ -35,16 +52,53 @@ export type RenderFunction = (
 
 export interface RouterOptions {
   /**
+   *  Controls whether Fresh will append a trailing slash to the URL.
    *  @default {false}
    */
   trailingSlash?: boolean;
+  /**
+   *  Configures the pattern of files to ignore in islands and routes.
+   *
+   *  By default Fresh will ignore test files,
+   *  for example files with a `.test.ts` or a `_test.ts` suffix.
+   *
+   *  @default {/(?:[^/]*_|[^/]*\.|)test\.(?:ts|tsx|mts|js|mjs|jsx|)\/*$/}
+   */
+  ignoreFilePattern?: RegExp;
 }
+```
+
+## Build
+
+### outDir
+
+As the comment suggests, this can be used to configure where generated files are
+written:
+
+```tsx
+await dev(import.meta.url, "./main.ts", {
+  build: {
+    outDir: Deno.env.get("FRESH_TEST_OUTDIR") ?? undefined,
+  },
+});
+```
+
+### target
+
+This should be a valid ES Build target.
+
+```tsx
+await dev(import.meta.url, "./main.ts", {
+  build: {
+    target: "es2015",
+  },
+});
 ```
 
 ## Plugins
 
-See the [docs](/docs/concepts/plugins) on this topic for more detail. But for
-completion, you can do something like this to load plugins:
+See the [docs](/docs/concepts/plugins) on this topic for more detail. But as a
+quick example, you can do something like this to load plugins:
 
 ```ts main.ts
 await start(manifest, { plugins: [twindPlugin(twindConfig)] });
@@ -64,9 +118,6 @@ await start(manifest, { staticDir: "./custom_static" });
 This is by far the most complicated option currently available. It allows you to
 configure how your components get rendered.
 
-A detailed, concrete example of this is changing the language of the `<html>`
-tag. See the documentation [here](/docs/examples/setting-the-language).
-
 ## RouterOptions
 
 ### TrailingSlash
@@ -78,3 +129,54 @@ you can configure this to `https://www.example.com/about/` by using the
 ```ts main.ts
 await start(manifest, { router: { trailingSlash: true } });
 ```
+
+### ignoreFilePattern
+
+By default Fresh ignores test files which are co-located next routes and
+islands. If you want, you can change the pattern Fresh uses ignore these files
+
+## Server
+
+Now that Deno has stabilized [Deno.serve](https://deno.land/api?s=Deno.serve)
+and Fresh has switched to using this API, all server configuration options are
+embedded in `server` inside the `FreshConfig`. The fully expanded set of
+parameters looks like this:
+
+```ts
+server: {
+  /** Server private key in PEM format */
+  cert: string;
+
+  /** Cert chain in PEM format */
+  key: string;
+
+  /** The port to listen on.
+   *
+   * @default {8000} */
+  port?: number;
+
+  /** A literal IP address or host name that can be resolved to an IP address.
+   *
+   * __Note about `0.0.0.0`__ While listening `0.0.0.0` works on all platforms,
+   * the browsers on Windows don't work with the address `0.0.0.0`.
+   * You should show the message like `server running on localhost:8080` instead of
+   * `server running on 0.0.0.0:8080` if your program supports Windows.
+   *
+   * @default {"0.0.0.0"} */
+  hostname?: string;
+
+  /** An {@linkcode AbortSignal} to close the server and all connections. */
+  signal?: AbortSignal;
+
+  /** Sets `SO_REUSEPORT` on POSIX systems. */
+  reusePort?: boolean;
+
+  /** The handler to invoke when route handlers throw an error. */
+  onError?: (error: unknown) => Response | Promise<Response>;
+
+  /** The callback which is called when the server starts listening. */
+  onListen?: (params: { hostname: string; port: number }) => void;
+}
+```
+
+Use these to configure your server as you see fit.

--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -51,6 +51,7 @@ export type {
   RenderFunction,
   RouteConfig,
   RouteContext,
+  RouterOptions,
   ServeHandlerInfo,
   StartOptions,
   UnknownHandler,


### PR DESCRIPTION
In response to https://github.com/denoland/fresh/pull/1994, I noticed that this page is also terribly out of date.

Even as of 1.4 using `ctx.lang` wasn't encouraged, but a link to the deprecated documentation was still included on this page! (I see `setting-the-language` is no longer included in the ToC, which is great.)

Other changes include:
* export `RouterOptions`, since it's part of the exported `FreshConfig`
* minor grammatical changes to improve the feeling of sentences
* include the latest structure of types/interfaces for reference
* links to API documentation (e.g. https://deno.land/x/fresh/server.ts?s=FreshConfig)
* document `ignoreFilePattern` and the `build` options!