### PR TITLE
chore: bump deps

### DIFF
--- a/.vscode/import_map.json
+++ b/.vscode/import_map.json
@@ -12,7 +12,7 @@
     "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.5.0",
     "@preact/signals-core@1.2.3": "https://esm.sh/@preact/signals-core@1.2.3",
     "@preact/signals-core@1.3.0": "https://esm.sh/@preact/signals-core@1.3.0",
-    "$std/": "https://deno.land/std@0.193.0/",
+    "$std/": "https://deno.land/std@0.205.0/",
     "$ga4": "https://raw.githubusercontent.com/denoland/ga4/main/mod.ts",
     "$marked-mangle": "https://esm.sh/marked-mangle@1.0.1"
   }

--- a/src/build/deps.ts
+++ b/src/build/deps.ts
@@ -4,7 +4,7 @@ export {
   join,
   relative,
   toFileUrl,
-} from "https://deno.land/std@0.193.0/path/mod.ts";
-export { escape as regexpEscape } from "https://deno.land/std@0.193.0/regexp/escape.ts";
-
+} from "https://deno.land/std@0.205.0/path/mod.ts";
+export { escape as regexpEscape } from "https://deno.land/std@0.205.0/regexp/escape.ts";
 export { denoPlugins } from "https://deno.land/x/esbuild_deno_loader@0.8.2/mod.ts";
+export { assertEquals } from "https://deno.land/std@0.205.0/assert/mod.ts";

--- a/src/build/esbuild_test.ts
+++ b/src/build/esbuild_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "$std/testing/asserts.ts";
+import { assertEquals } from "./deps.ts";
 import { fromFileUrl, join, toFileUrl } from "../server/deps.ts";
 import { EsbuildBuilder } from "./esbuild.ts";
 

--- a/src/dev/build.ts
+++ b/src/dev/build.ts
@@ -1,6 +1,6 @@
 import { getServerContext } from "../server/context.ts";
 import { join } from "../server/deps.ts";
-import { colors, fs } from "./deps.ts";
+import { colors, emptyDir } from "./deps.ts";
 import { BuildSnapshotJson } from "../build/mod.ts";
 import { BUILD_ID } from "../server/build_id.ts";
 import { InternalFreshState } from "../server/types.ts";
@@ -12,7 +12,7 @@ export async function build(
   const plugins = state.config.plugins;
 
   // Ensure that build dir is empty
-  await fs.emptyDir(outDir);
+  await emptyDir(outDir);
 
   await Promise.all(plugins.map((plugin) => plugin.buildStart?.(state.config)));
 

--- a/src/dev/deps.ts
+++ b/src/dev/deps.ts
@@ -5,25 +5,27 @@ export {
   extname,
   fromFileUrl,
   join,
-  posix,
   relative,
   resolve,
   SEP,
   toFileUrl,
-} from "https://deno.land/std@0.193.0/path/mod.ts";
-export { DAY, WEEK } from "https://deno.land/std@0.193.0/datetime/constants.ts";
-export * as colors from "https://deno.land/std@0.193.0/fmt/colors.ts";
+} from "https://deno.land/std@0.205.0/path/mod.ts";
+export { normalize } from "https://deno.land/std@0.205.0/path/posix/mod.ts";
+export { DAY, WEEK } from "https://deno.land/std@0.205.0/datetime/constants.ts";
+export * as colors from "https://deno.land/std@0.205.0/fmt/colors.ts";
 export {
   walk,
   type WalkEntry,
   WalkError,
-} from "https://deno.land/std@0.193.0/fs/walk.ts";
-export { parse } from "https://deno.land/std@0.193.0/flags/mod.ts";
-export { gte } from "https://deno.land/std@0.193.0/semver/mod.ts";
-export { existsSync } from "https://deno.land/std@0.193.0/fs/mod.ts";
-export * as semver from "https://deno.land/std@0.195.0/semver/mod.ts";
-export * as JSONC from "https://deno.land/std@0.195.0/jsonc/mod.ts";
-export * as fs from "https://deno.land/std@0.195.0/fs/mod.ts";
+} from "https://deno.land/std@0.205.0/fs/walk.ts";
+export { parse } from "https://deno.land/std@0.205.0/flags/mod.ts";
+export {
+  gte,
+  lt,
+  parse as semverParse,
+} from "https://deno.land/std@0.205.0/semver/mod.ts";
+export { emptyDir, existsSync } from "https://deno.land/std@0.205.0/fs/mod.ts";
+export * as JSONC from "https://deno.land/std@0.205.0/jsonc/mod.ts";
 
 // ts-morph
-export { Node, Project } from "https://deno.land/x/ts_morph@17.0.1/mod.ts";
+export { Node, Project } from "https://deno.land/x/ts_morph@20.0.0/mod.ts";

--- a/src/dev/imports.ts
+++ b/src/dev/imports.ts
@@ -2,7 +2,7 @@ export const RECOMMENDED_PREACT_VERSION = "10.18.1";
 export const RECOMMENDED_PREACT_SIGNALS_VERSION = "1.2.1";
 export const RECOMMENDED_PREACT_SIGNALS_CORE_VERSION = "1.5.0";
 export const RECOMMENDED_TWIND_VERSION = "0.16.19";
-export const RECOMMENDED_STD_VERSION = "0.193.0";
+export const RECOMMENDED_STD_VERSION = "0.205.0";
 
 export function freshImports(imports: Record<string, string>) {
   imports["$fresh/"] = new URL("../../", import.meta.url).href;

--- a/src/dev/mod.ts
+++ b/src/dev/mod.ts
@@ -1,11 +1,19 @@
-import { gte, join, posix, relative, walk, WalkEntry } from "./deps.ts";
+import {
+  gte,
+  join,
+  normalize,
+  relative,
+  semverParse,
+  walk,
+  WalkEntry,
+} from "./deps.ts";
 import { error } from "./error.ts";
 const MIN_DENO_VERSION = "1.31.0";
 const TEST_FILE_PATTERN = /[._]test\.(?:[tj]sx?|[mc][tj]s)$/;
 
 export function ensureMinDenoVersion() {
   // Check that the minimum supported Deno version is being used.
-  if (!gte(Deno.version.deno, MIN_DENO_VERSION)) {
+  if (!gte(semverParse(Deno.version.deno), semverParse(MIN_DENO_VERSION))) {
     let message =
       `Deno version ${MIN_DENO_VERSION} or higher is required. Please update Deno.\n\n`;
 
@@ -100,7 +108,7 @@ export async function collect(
  * Import specifiers must have forward slashes
  */
 function toImportSpecifier(file: string) {
-  let specifier = posix.normalize(file).replace(/\\/g, "/");
+  let specifier = normalize(file).replace(/\\/g, "/");
   if (!specifier.startsWith(".")) {
     specifier = "./" + specifier;
   }

--- a/src/dev/update_check.ts
+++ b/src/dev/update_check.ts
@@ -1,4 +1,4 @@
-import { colors, join, semver } from "./deps.ts";
+import { colors, join, lt, semverParse } from "./deps.ts";
 
 export interface CheckFile {
   last_checked: string;
@@ -113,12 +113,12 @@ export async function updateCheck(
   }
 
   // Only show update message if current version is smaller than latest
-  const currentVersion = semver.parse(checkFile.current_version);
-  const latestVersion = semver.parse(checkFile.latest_version);
+  const currentVersion = semverParse(checkFile.current_version);
+  const latestVersion = semverParse(checkFile.latest_version);
   if (
     (!checkFile.last_shown ||
       Date.now() >= new Date(checkFile.last_shown).getTime() + interval) &&
-    semver.lt(currentVersion, latestVersion)
+    lt(currentVersion, latestVersion)
   ) {
     checkFile.last_shown = new Date().toISOString();
 

--- a/src/server/code_frame_test.ts
+++ b/src/server/code_frame_test.ts
@@ -1,7 +1,6 @@
-import { assertEquals } from "$std/testing/asserts.ts";
 import { assertSnapshot } from "$std/testing/snapshot.ts";
 import { createCodeFrame, getFirstUserFile } from "./code_frame.ts";
-import { colors } from "./deps.ts";
+import { assertEquals, colors } from "./deps.ts";
 
 function testCodeFrame(text: string, line: number, column: number) {
   const codeFrame = createCodeFrame(text, line, column);

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -6,18 +6,22 @@ export {
   isAbsolute,
   join,
   toFileUrl,
-} from "https://deno.land/std@0.193.0/path/mod.ts";
-export { walk } from "https://deno.land/std@0.193.0/fs/walk.ts";
-export * as colors from "https://deno.land/std@0.193.0/fmt/colors.ts";
+} from "https://deno.land/std@0.205.0/path/mod.ts";
+export { walk } from "https://deno.land/std@0.205.0/fs/walk.ts";
+export * as colors from "https://deno.land/std@0.205.0/fmt/colors.ts";
 export {
   type Handler as ServeHandler,
   serve,
-} from "https://deno.land/std@0.193.0/http/server.ts";
-export { Status } from "https://deno.land/std@0.193.0/http/http_status.ts";
+} from "https://deno.land/std@0.205.0/http/server.ts";
+export { Status } from "https://deno.land/std@0.205.0/http/http_status.ts";
 export {
   typeByExtension,
-} from "https://deno.land/std@0.193.0/media_types/mod.ts";
-export { toHashString } from "https://deno.land/std@0.193.0/crypto/to_hash_string.ts";
-export { escape } from "https://deno.land/std@0.193.0/regexp/escape.ts";
-export * as JSONC from "https://deno.land/std@0.193.0/jsonc/mod.ts";
+} from "https://deno.land/std@0.205.0/media_types/mod.ts";
+export { toHashString } from "https://deno.land/std@0.205.0/crypto/to_hash_string.ts";
+export { escape } from "https://deno.land/std@0.205.0/regexp/escape.ts";
+export * as JSONC from "https://deno.land/std@0.205.0/jsonc/mod.ts";
 export { renderToString } from "https://esm.sh/*preact-render-to-string@6.2.2";
+export {
+  assertEquals,
+  assertThrows,
+} from "https://deno.land/std@0.205.0/assert/mod.ts";

--- a/src/server/fs_extract_test.ts
+++ b/src/server/fs_extract_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "$std/testing/asserts.ts";
+import { assertEquals, assertThrows } from "./deps.ts";
 import { pathToPattern, sortRoutePaths } from "./fs_extract.ts";
 
 Deno.test("pathToPattern", async (t) => {

--- a/src/server/router_test.ts
+++ b/src/server/router_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "$std/testing/asserts.ts";
+import { assertEquals } from "./deps.ts";
 import { IS_PATTERN, patternToRegExp } from "./router.ts";
 
 function testPattern(input: string, test: string) {

--- a/tests/build_test.ts
+++ b/tests/build_test.ts
@@ -1,14 +1,16 @@
 import * as path from "$std/path/mod.ts";
-import { puppeteer } from "./deps.ts";
-import { assert } from "$std/_util/asserts.ts";
+import {
+  assert,
+  assertNotMatch,
+  assertStringIncludes,
+  puppeteer,
+} from "./deps.ts";
 import {
   getStdOutput,
   startFreshServer,
   waitForText,
 } from "$fresh/tests/test_utils.ts";
 import { BuildSnapshotJson } from "$fresh/src/build/mod.ts";
-import { assertStringIncludes } from "$std/testing/asserts.ts";
-import { assertNotMatch } from "$std/testing/asserts.ts";
 
 function runBuild(fixture: string, subDirPath: string, outDir: string) {
   return new Deno.Command(Deno.execPath(), {

--- a/tests/cli_update_check_test.ts
+++ b/tests/cli_update_check_test.ts
@@ -5,7 +5,7 @@ import {
   assertMatch,
   assertNotEquals,
   assertNotMatch,
-} from "$std/testing/asserts.ts";
+} from "./deps.ts";
 import versions from "../versions.json" assert { type: "json" };
 import { CheckFile } from "$fresh/src/dev/update_check.ts";
 import { WEEK } from "$fresh/src/dev/deps.ts";

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -9,16 +9,17 @@ export {
   assertEquals,
   assertExists,
   assertMatch,
+  assertNotEquals,
   assertNotMatch,
   assertRejects,
   assertStringIncludes,
-} from "https://deno.land/std@0.193.0/testing/asserts.ts";
-export { assertSnapshot } from "https://deno.land/std@0.193.0/testing/snapshot.ts";
+} from "https://deno.land/std@0.205.0/assert/mod.ts";
+export { assertSnapshot } from "https://deno.land/std@0.205.0/testing/snapshot.ts";
 export {
   TextLineStream,
-} from "https://deno.land/std@0.193.0/streams/text_line_stream.ts";
-export { delay } from "https://deno.land/std@0.193.0/async/delay.ts";
-export { retry } from "https://deno.land/std@0.193.0/async/retry.ts";
+} from "https://deno.land/std@0.205.0/streams/text_line_stream.ts";
+export { delay } from "https://deno.land/std@0.205.0/async/delay.ts";
+export { retry } from "https://deno.land/std@0.205.0/async/retry.ts";
 export {
   default as puppeteer,
   Page,
@@ -31,11 +32,13 @@ export {
 } from "https://esm.sh/linkedom@0.15.1";
 export { defineConfig, type Preset } from "https://esm.sh/@twind/core@1.1.3";
 export { default as presetTailwind } from "https://esm.sh/@twind/preset-tailwind@1.1.4";
-export * as fs from "https://deno.land/std@0.195.0/fs/mod.ts";
+export { copy } from "https://deno.land/std@0.205.0/fs/mod.ts";
 export {
   basename,
   dirname,
+  extname,
   fromFileUrl,
   join,
   relative,
-} from "https://deno.land/std@0.193.0/path/mod.ts";
+} from "https://deno.land/std@0.205.0/path/mod.ts";
+export * as JSONC from "https://deno.land/std@0.205.0/jsonc/mod.ts";

--- a/tests/explicit_app_template_test.ts
+++ b/tests/explicit_app_template_test.ts
@@ -4,7 +4,7 @@ import {
   assertTextMany,
   withFakeServe,
 } from "$fresh/tests/test_utils.ts";
-import { assertNotMatch } from "$std/testing/asserts.ts";
+import { assertNotMatch } from "./deps.ts";
 
 Deno.test("doesn't apply internal app template", async () => {
   await withFakeServe(

--- a/tests/fixture_hmr/routes/index.tsx
+++ b/tests/fixture_hmr/routes/index.tsx
@@ -1,11 +1,11 @@
-import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
+import { basename, dirname, extname, fromFileUrl } from "../../deps.ts";
 
-const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
+const __dirname = dirname(fromFileUrl(import.meta.url));
 
 const links: string[] = [];
 for (const file of Deno.readDirSync(__dirname)) {
   if (file.name.startsWith("index")) continue;
-  const name = path.basename(file.name, path.extname(file.name));
+  const name = basename(file.name, extname(file.name));
   links.push(name);
 }
 

--- a/tests/fixture_island_nesting/routes/index.tsx
+++ b/tests/fixture_island_nesting/routes/index.tsx
@@ -1,11 +1,11 @@
-import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
+import { basename, dirname, extname, fromFileUrl } from "../../deps.ts";
 
-const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
+const __dirname = dirname(fromFileUrl(import.meta.url));
 
 const links: string[] = [];
 for (const file of Deno.readDirSync(__dirname)) {
   if (file.name.startsWith("index")) continue;
-  const name = path.basename(file.name, path.extname(file.name));
+  const name = basename(file.name, extname(file.name));
   links.push(name);
 }
 

--- a/tests/fixture_partials/routes/index.tsx
+++ b/tests/fixture_partials/routes/index.tsx
@@ -1,11 +1,11 @@
-import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
+import { basename, dirname, extname, fromFileUrl } from "../../deps.ts";
 
-const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
+const __dirname = dirname(fromFileUrl(import.meta.url));
 
 const links: string[] = [];
 for (const file of Deno.readDirSync(__dirname)) {
   if (file.name.startsWith("index")) continue;
-  const name = path.basename(file.name, path.extname(file.name));
+  const name = basename(file.name, extname(file.name));
   links.push(name);
 }
 

--- a/tests/fixture_plugin_lifecycle/fresh.config.ts
+++ b/tests/fixture_plugin_lifecycle/fresh.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "$fresh/src/server/defines.ts";
-import * as path from "https://deno.land/std@0.193.0/path/mod.ts";
+import { relative } from "../deps.ts";
 
 export default defineConfig({
   plugins: [
@@ -24,7 +24,7 @@ export default defineConfig({
     {
       name: "c",
       buildStart(config) {
-        const outDir = path.relative(Deno.cwd(), config.build.outDir);
+        const outDir = relative(Deno.cwd(), config.build.outDir);
         console.log(`Plugin c: ${outDir}`);
       },
     },

--- a/tests/fixture_render/routes/index.tsx
+++ b/tests/fixture_render/routes/index.tsx
@@ -1,11 +1,11 @@
-import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
+import { basename, dirname, extname, fromFileUrl } from "../../deps.ts";
 
-const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
+const __dirname = dirname(fromFileUrl(import.meta.url));
 
 const links: string[] = [];
 for (const file of Deno.readDirSync(__dirname)) {
   if (file.name.startsWith("index")) continue;
-  const name = path.basename(file.name, path.extname(file.name));
+  const name = basename(file.name, extname(file.name));
   links.push(name);
 }
 

--- a/tests/fixture_route_analysis/deno.json
+++ b/tests/fixture_route_analysis/deno.json
@@ -10,7 +10,7 @@
     "preact/": "https://esm.sh/preact@10.15.1/",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.2.3",
-    "$std/": "https://deno.land/std@0.190.0/"
+    "$std/": "https://deno.land/std@0.205.0/"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/tests/fixture_server_components/routes/index.tsx
+++ b/tests/fixture_server_components/routes/index.tsx
@@ -1,11 +1,11 @@
-import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
+import { basename, dirname, extname, fromFileUrl } from "../../deps.ts";
 
-const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
+const __dirname = dirname(fromFileUrl(import.meta.url));
 
 const links: string[] = [];
 for (const file of Deno.readDirSync(__dirname)) {
   if (file.name.startsWith("index")) continue;
-  const name = path.basename(file.name, path.extname(file.name));
+  const name = basename(file.name, extname(file.name));
   links.push(name);
 }
 

--- a/tests/fixture_twind_app/routes/index.tsx
+++ b/tests/fixture_twind_app/routes/index.tsx
@@ -1,11 +1,11 @@
-import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
+import { basename, dirname, extname, fromFileUrl } from "../../deps.ts";
 
-const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
+const __dirname = dirname(fromFileUrl(import.meta.url));
 
 const links: string[] = [];
 for (const file of Deno.readDirSync(__dirname)) {
   if (file.name.startsWith("index")) continue;
-  const name = path.basename(file.name, path.extname(file.name));
+  const name = basename(file.name, extname(file.name));
   links.push(name);
 }
 

--- a/tests/hmr_test.ts
+++ b/tests/hmr_test.ts
@@ -1,6 +1,6 @@
-import { copy } from "https://deno.land/std@0.204.0/fs/copy.ts";
 import {
   basename,
+  copy,
   delay,
   dirname,
   join,

--- a/tests/partials_test.ts
+++ b/tests/partials_test.ts
@@ -1,5 +1,4 @@
-import { assert, assertEquals, assertMatch } from "$std/testing/asserts.ts";
-import { Page } from "./deps.ts";
+import { assert, assertEquals, assertMatch, Page } from "./deps.ts";
 import {
   assertMetaContent,
   assertNoComments,

--- a/tests/plugin_test.ts
+++ b/tests/plugin_test.ts
@@ -1,8 +1,8 @@
-import { assertMatch } from "$std/testing/asserts.ts";
 import { ServerContext, Status } from "../server.ts";
 import {
   assert,
   assertEquals,
+  assertMatch,
   assertStringIncludes,
   delay,
   join,

--- a/tests/render_test.ts
+++ b/tests/render_test.ts
@@ -3,7 +3,7 @@ import {
   parseHtml,
   withFakeServe,
 } from "$fresh/tests/test_utils.ts";
-import { assertEquals } from "$std/testing/asserts.ts";
+import { assertEquals } from "./deps.ts";
 import { createHandler } from "$fresh/server.ts";
 import manifest from "./fixture/fresh.gen.ts";
 import config from "./fixture/fresh.config.ts";

--- a/tests/route_analysis_test.ts
+++ b/tests/route_analysis_test.ts
@@ -1,9 +1,8 @@
 import { startFreshServerExpectErrors } from "./test_utils.ts";
 import { dirname, join } from "$std/path/mod.ts";
-import { assertStringIncludes } from "./deps.ts";
+import { assertEquals, assertStringIncludes } from "./deps.ts";
 import { ServerContext } from "$fresh/server.ts";
 import manifest from "./fixture/fresh.gen.ts";
-import { assertEquals } from "$std/testing/asserts.ts";
 
 const dir = dirname(import.meta.url);
 

--- a/tests/route_groups_test.ts
+++ b/tests/route_groups_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "$std/testing/asserts.ts";
+import { assertEquals } from "./deps.ts";
 import {
   assertTextMany,
   parseHtml,

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -1,5 +1,4 @@
 import { colors, toFileUrl } from "$fresh/src/server/deps.ts";
-import { assert } from "$std/_util/asserts.ts";
 import * as path from "$std/path/mod.ts";
 import {
   FromManifestConfig,
@@ -8,6 +7,7 @@ import {
   ServerContext,
 } from "$fresh/server.ts";
 import {
+  assert,
   assertEquals,
   basename,
   delay,

--- a/tests/update_test.ts
+++ b/tests/update_test.ts
@@ -1,12 +1,12 @@
 import * as path from "$std/path/mod.ts";
 import { DenoConfig } from "$fresh/server.ts";
-import { JSONC } from "../src/server/deps.ts";
 import {
   assertEquals,
   assertExists,
   assertMatch,
   assertRejects,
   assertStringIncludes,
+  JSONC,
   retry,
 } from "./deps.ts";
 

--- a/update.ts
+++ b/update.ts
@@ -231,7 +231,7 @@ await start(manifest, { plugins: [twindPlugin(twindConfig)] });\n`;
     for (const n of nodes) {
       if (!n.wasForgotten() && Node.isJsxAttribute(n)) {
         const init = n.getInitializer();
-        const name = n.getName();
+        const name = n.getStructure().name;
         if (
           Node.isJsxExpression(init) &&
           (name === "class" || name === "className")

--- a/www/deno.json
+++ b/www/deno.json
@@ -13,7 +13,7 @@
     "preact/": "https://esm.sh/preact@10.15.1/",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
     "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.2.3",
-    "$std/": "https://deno.land/std@0.193.0/",
+    "$std/": "https://deno.land/std@0.205.0/",
     "$ga4": "https://raw.githubusercontent.com/denoland/ga4/main/mod.ts",
     "$marked-mangle": "https://esm.sh/marked-mangle@1.0.1"
   },

--- a/www/main_test.ts
+++ b/www/main_test.ts
@@ -1,4 +1,4 @@
-import { assertArrayIncludes, assertEquals } from "$std/testing/asserts.ts";
+import { assertArrayIncludes, assertEquals } from "$std/assert/mod.ts";
 import { withPageName } from "../tests/test_utils.ts";
 import { dirname, join } from "$std/path/mod.ts";
 import VERSIONS from "../versions.json" assert { type: "json" };

--- a/www/utils/screenshot.ts
+++ b/www/utils/screenshot.ts
@@ -1,6 +1,6 @@
 import puppeteer from "https://deno.land/x/puppeteer@16.2.0/mod.ts";
 import { Image } from "https://deno.land/x/imagescript@1.2.15/mod.ts";
-import { join } from "https://deno.land/std@0.193.0/path/mod.ts";
+import { join } from "https://deno.land/std@0.205.0/path/mod.ts";
 
 const url = Deno.args[0];
 const id = Deno.args[1];


### PR DESCRIPTION
This primarily updates `std` to 0.205.0. We were previously using 0.193.0, which was just about four months old. (Although some places were using other versions as well).

I also pulled lots of import statements out of individual files and pushed them into various `deps.ts` files, in order to make this sort of thing easier in the future.

This also updates ts-morph to 20.0.0.