### PR TITLE
chore(fresh-update): remove `preact-render-to-string` from import maps

### DIFF
--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -8,6 +8,7 @@ export {
   assert,
   assertEquals,
   assertExists,
+  assertFalse,
   assertMatch,
   assertNotEquals,
   assertNotMatch,

--- a/update.ts
+++ b/update.ts
@@ -139,6 +139,10 @@ freshImports(denoJson.imports);
 if (denoJson.imports["twind"]) {
   twindImports(denoJson.imports);
 }
+if (denoJson.imports["preact-render-to-string"]) {
+  // https://github.com/denoland/fresh/pull/1684
+  delete denoJson.imports["preact-render-to-string"];
+}
 await writeFormattedJson(DENO_JSON_PATH, denoJson);
 
 // Code mod for classic JSX -> automatic JSX.


### PR DESCRIPTION
`preact-render-to-string` is no longer managed by import maps (#1684). I think it would be good to have `fresh-update` remove `preact-render-to-string` from import maps