### PR TITLE
fix: serve static file with parens

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -266,9 +266,8 @@ export class ServerContext {
       const { localUrl, path, size, contentType, etag } of this.#extractResult
         .staticFiles
     ) {
-      const route = sanitizePathToRegex(path);
-      staticRoutes[route] = {
-        baseRoute: toBaseRoute(route),
+      staticRoutes[path] = {
+        baseRoute: toBaseRoute(path),
         methods: {
           "HEAD": this.#staticFileHandler(
             localUrl,
@@ -587,18 +586,6 @@ export function normalizeURLPath(path: string): string | null {
   } catch {
     return null;
   }
-}
-
-function sanitizePathToRegex(path: string): string {
-  return path
-    .replaceAll("\*", "\\*")
-    .replaceAll("\+", "\\+")
-    .replaceAll("\?", "\\?")
-    .replaceAll("\{", "\\{")
-    .replaceAll("\}", "\\}")
-    .replaceAll("\(", "\\(")
-    .replaceAll("\)", "\\)")
-    .replaceAll("\:", "\\:");
 }
 
 function serializeCSPDirectives(csp: ContentSecurityPolicyDirectives): string {

--- a/tests/fixture/static/foo (bar).txt
+++ b/tests/fixture/static/foo (bar).txt
@@ -1,0 +1,1 @@
+it works

--- a/tests/fixture/static/foo bar.txt
+++ b/tests/fixture/static/foo bar.txt
@@ -1,0 +1,1 @@
+it works

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -359,6 +359,16 @@ Deno.test("static file - by file path", async () => {
   assertEquals(resp3.headers.get("content-type"), "text/plain");
 });
 
+Deno.test("static file - spaces or other characters in name", async () => {
+  const res = await handler(new Request("https://fresh.deno.dev/foo bar.txt"));
+  assertEquals(await res.text(), "it works");
+
+  const res2 = await handler(
+    new Request("https://fresh.deno.dev/foo (bar).txt"),
+  );
+  assertEquals(await res2.text(), "it works");
+});
+
 Deno.test("HEAD request", async () => {
   // Static file
   const resp = await handler(


### PR DESCRIPTION
This fixes an issue where we wouldn't serve a static file like `foo (bar).txt` because we'd treat this as a pattern and would escape the parens. Since we switched to string matches for static files, this escaping isn't necessary anymore and only causes problems. So we can just drop it.