### PR TITLE
fix: ready color not readable in light themes

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -46,7 +46,7 @@ const flags = parse(Deno.args, {
 console.log();
 console.log(
   colors.bgRgb8(
-    colors.black(colors.bold(" 🍋 Fresh: The next-gen web framework. ")),
+    colors.rgb8(" 🍋 Fresh: The next-gen web framework. ", 0),
     121,
   ),
 );

--- a/src/server/boot.ts
+++ b/src/server/boot.ts
@@ -9,7 +9,7 @@ export async function startServer(
     opts.onListen = (params) => {
       console.log();
       console.log(
-        colors.bgRgb8(colors.black(colors.bold(" 🍋 Fresh ready ")), 121),
+        colors.bgRgb8(colors.rgb8(" 🍋 Fresh ready ", 0), 121),
       );
 
       const address = colors.cyan(`http://localhost:${params.port}/`);


### PR DESCRIPTION
Ensure that the text in the terminal on the greenish background is always black. Removed the bold styling too as many terminals automatically use a brighter color for bold text.

Fixes https://github.com/denoland/fresh/issues/2011