### PR TITLE
fix: head text nodes rendered into body

### DIFF
--- a/src/server/rendering/preact_hooks.ts
+++ b/src/server/rendering/preact_hooks.ts
@@ -269,6 +269,7 @@ options.__b = (vnode: VNode<Record<string, unknown>>) => {
           });
         }
         vnode.type = Fragment;
+        vnode.props = { children: null };
       } else if (LOADING_ATTR in vnode.props) {
         current.islandProps.push({
           [LOADING_ATTR]: vnode.props[LOADING_ATTR],

--- a/tests/fixture_render/fresh.gen.ts
+++ b/tests/fixture_render/fresh.gen.ts
@@ -2,17 +2,19 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $0 from "./routes/header_arr.tsx";
-import * as $1 from "./routes/header_instance.tsx";
-import * as $2 from "./routes/header_obj.tsx";
-import * as $3 from "./routes/index.tsx";
+import * as $0 from "./routes/head_style.tsx";
+import * as $1 from "./routes/header_arr.tsx";
+import * as $2 from "./routes/header_instance.tsx";
+import * as $3 from "./routes/header_obj.tsx";
+import * as $4 from "./routes/index.tsx";
 
 const manifest = {
   routes: {
-    "./routes/header_arr.tsx": $0,
-    "./routes/header_instance.tsx": $1,
-    "./routes/header_obj.tsx": $2,
-    "./routes/index.tsx": $3,
+    "./routes/head_style.tsx": $0,
+    "./routes/header_arr.tsx": $1,
+    "./routes/header_instance.tsx": $2,
+    "./routes/header_obj.tsx": $3,
+    "./routes/index.tsx": $4,
   },
   islands: {},
   baseUrl: import.meta.url,

--- a/tests/fixture_render/routes/head_style.tsx
+++ b/tests/fixture_render/routes/head_style.tsx
@@ -1,0 +1,19 @@
+import { RouteConfig } from "$fresh/src/server/types.ts";
+
+export const config: RouteConfig = {
+  skipAppWrapper: true,
+  skipInheritedLayouts: true,
+};
+
+export default function App() {
+  return (
+    <html>
+      <head>
+        <style>{`body { color: red }`}</style>
+      </head>
+      <body>
+        hello
+      </body>
+    </html>
+  );
+}

--- a/tests/render_test.ts
+++ b/tests/render_test.ts
@@ -1,5 +1,6 @@
 import {
   assertSelector,
+  assertTextMany,
   parseHtml,
   withFakeServe,
 } from "$fresh/tests/test_utils.ts";
@@ -44,5 +45,13 @@ Deno.test("render headers passed to ctx.render()", async () => {
     res = await server.get("/header_instance");
     assertEquals(res.headers.get("x-foo"), "Hello world!");
     await res.body?.cancel();
+  });
+});
+
+Deno.test("render head text nodes", async () => {
+  await withFakeServe("./tests/fixture_render/main.ts", async (server) => {
+    const doc = await server.getHtml("/head_style");
+    assertTextMany(doc, "style", ["body { color: red }"]);
+    assertEquals(doc.body.textContent, "hello");
   });
 });


### PR DESCRIPTION
Was an oversight on my part. Some head nodes like `<style>` have text children and I forgot to handle that.

Fixes https://github.com/denoland/fresh/issues/1995