### PR TITLE
fix(server): use relative import instead of relying on an import map

### DIFF
--- a/src/server/default_error_page.tsx
+++ b/src/server/default_error_page.tsx
@@ -1,7 +1,7 @@
 import { ComponentChildren, h } from "preact";
 import { DEBUG } from "./constants.ts";
 import type { ErrorPageProps, RouteConfig } from "./types.ts";
-import { colors } from "$fresh/src/server/deps.ts";
+import { colors } from "./deps.ts";
 
 export const config: RouteConfig = {
   skipAppWrapper: true,


### PR DESCRIPTION
I haven't setup a local development environment to test this, but I'm pretty sure this fixes #2033