### PR TITLE
fix: precompile JSX mapped arrays

### DIFF
--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -20,7 +20,7 @@ export {
 export { toHashString } from "https://deno.land/std@0.205.0/crypto/to_hash_string.ts";
 export { escape } from "https://deno.land/std@0.205.0/regexp/escape.ts";
 export * as JSONC from "https://deno.land/std@0.205.0/jsonc/mod.ts";
-export { renderToString } from "https://esm.sh/*preact-render-to-string@6.3.0";
+export { renderToString } from "https://esm.sh/*preact-render-to-string@6.3.1";
 export {
   assertEquals,
   assertThrows,


### PR DESCRIPTION
Published a new version of `preact-render-to-string` to address an issue with nested array children.

```jsx
<ul>
  {[1, 2, 3].map(x => <li>{x}</li>)}
  <li>4</li>
</ul>
```