### PR TITLE
docs: fix regression in navigation

### DIFF
--- a/tests/www/navigate_test.ts
+++ b/tests/www/navigate_test.ts
@@ -1,0 +1,12 @@
+import { waitForText, withPageName } from "$fresh/tests/test_utils.ts";
+
+Deno.test("www - docs navigation", async () => {
+  await withPageName("./www/main.ts", async (page, address) => {
+    await page.goto(`${address}`, { waitUntil: "networkidle2" });
+    await page.click(`a[href="/docs"]`);
+    await waitForText(page, "h1", "Introduction");
+
+    await page.click(`a[href="/docs/getting-started/create-a-project"]`);
+    await waitForText(page, "h1", "Create a project");
+  });
+});

--- a/www/components/DocsSidebar.tsx
+++ b/www/components/DocsSidebar.tsx
@@ -8,7 +8,6 @@ import VersionSelect from "../islands/VersionSelect.tsx";
 import { type VersionLink } from "../routes/docs/[...slug].tsx";
 import { Logo } from "$fresh/www/components/Header.tsx";
 import DocsTitle from "$fresh/www/components/DocsTitle.tsx";
-import docsearch from "https://esm.sh/@docsearch/js@3?target=es2020";
 
 export default function DocsSidebar(
   props: {
@@ -28,7 +27,7 @@ export default function DocsSidebar(
             </div>
             <hr />
           </div>
-          <SearchButton class="mr-4 sm:mr-0" docsearch={docsearch} />
+          <SearchButton class="mr-4 sm:mr-0" />
           <div class="mb-4">
             <VersionSelect
               selectedVersion={props.selectedVersion}

--- a/www/fresh.gen.ts
+++ b/www/fresh.gen.ts
@@ -2,44 +2,44 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $0 from "./routes/_404.tsx";
-import * as $1 from "./routes/_500.tsx";
-import * as $2 from "./routes/_middleware.ts";
-import * as $3 from "./routes/components.tsx";
-import * as $4 from "./routes/docs/[...slug].tsx";
-import * as $5 from "./routes/docs/index.tsx";
-import * as $6 from "./routes/index.tsx";
-import * as $7 from "./routes/raw.ts";
-import * as $8 from "./routes/showcase.tsx";
-import * as $9 from "./routes/update.tsx";
-import * as $$0 from "./islands/ComponentGallery.tsx";
-import * as $$1 from "./islands/CopyArea.tsx";
-import * as $$2 from "./islands/Counter.tsx";
-import * as $$3 from "./islands/LemonDrop.tsx";
-import * as $$4 from "./islands/SearchButton.tsx";
-import * as $$5 from "./islands/VersionSelect.tsx";
+import * as $_404 from "./routes/_404.tsx";
+import * as $_500 from "./routes/_500.tsx";
+import * as $_middleware from "./routes/_middleware.ts";
+import * as $components from "./routes/components.tsx";
+import * as $docs_slug_ from "./routes/docs/[...slug].tsx";
+import * as $docs_index from "./routes/docs/index.tsx";
+import * as $index from "./routes/index.tsx";
+import * as $raw from "./routes/raw.ts";
+import * as $showcase from "./routes/showcase.tsx";
+import * as $update from "./routes/update.tsx";
+import * as $$ComponentGallery from "./islands/ComponentGallery.tsx";
+import * as $$CopyArea from "./islands/CopyArea.tsx";
+import * as $$Counter from "./islands/Counter.tsx";
+import * as $$LemonDrop from "./islands/LemonDrop.tsx";
+import * as $$SearchButton from "./islands/SearchButton.tsx";
+import * as $$VersionSelect from "./islands/VersionSelect.tsx";
 import { Manifest } from "$fresh/server.ts";
 
 const manifest = {
   routes: {
-    "./routes/_404.tsx": $0,
-    "./routes/_500.tsx": $1,
-    "./routes/_middleware.ts": $2,
-    "./routes/components.tsx": $3,
-    "./routes/docs/[...slug].tsx": $4,
-    "./routes/docs/index.tsx": $5,
-    "./routes/index.tsx": $6,
-    "./routes/raw.ts": $7,
-    "./routes/showcase.tsx": $8,
-    "./routes/update.tsx": $9,
+    "./routes/_404.tsx": $_404,
+    "./routes/_500.tsx": $_500,
+    "./routes/_middleware.ts": $_middleware,
+    "./routes/components.tsx": $components,
+    "./routes/docs/[...slug].tsx": $docs_slug_,
+    "./routes/docs/index.tsx": $docs_index,
+    "./routes/index.tsx": $index,
+    "./routes/raw.ts": $raw,
+    "./routes/showcase.tsx": $showcase,
+    "./routes/update.tsx": $update,
   },
   islands: {
-    "./islands/ComponentGallery.tsx": $$0,
-    "./islands/CopyArea.tsx": $$1,
-    "./islands/Counter.tsx": $$2,
-    "./islands/LemonDrop.tsx": $$3,
-    "./islands/SearchButton.tsx": $$4,
-    "./islands/VersionSelect.tsx": $$5,
+    "./islands/ComponentGallery.tsx": $$ComponentGallery,
+    "./islands/CopyArea.tsx": $$CopyArea,
+    "./islands/Counter.tsx": $$Counter,
+    "./islands/LemonDrop.tsx": $$LemonDrop,
+    "./islands/SearchButton.tsx": $$SearchButton,
+    "./islands/VersionSelect.tsx": $$VersionSelect,
   },
   baseUrl: import.meta.url,
 } satisfies Manifest;

--- a/www/islands/SearchButton.tsx
+++ b/www/islands/SearchButton.tsx
@@ -1,5 +1,6 @@
 import { Head } from "$fresh/runtime.ts";
 import { useEffect, useRef } from "preact/hooks";
+import docsearch from "https://esm.sh/@docsearch/js@3.5.2?target=es2020";
 
 // Copied from algolia source code
 type DocSearchProps = {
@@ -10,12 +11,12 @@ type DocSearchProps = {
 };
 
 export default function SearchButton(
-  props: { docsearch: (args: DocSearchProps) => void; class?: string },
+  props: { docsearch?: (args: DocSearchProps) => void; class?: string },
 ) {
   const ref = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (ref.current) {
-      props.docsearch({
+      props.docsearch || docsearch({
         appId: "CWUS37S0PK",
         apiKey: "caa591b6dcb2c9308551361d954a728b",
         indexName: "fresh",


### PR DESCRIPTION
This regression was introduced in https://github.com/denoland/fresh/pull/1990 . There the change was made to pass `docsearch` function to an island as props, but we don't serialize functions.