### PR TITLE
fix: island module type in manifest

### DIFF
--- a/src/server/fs_extract.ts
+++ b/src/server/fs_extract.ts
@@ -300,7 +300,8 @@ export async function extractRoutes(
         id,
         name,
         url: processedIsland.path,
-        component: exportedFunction,
+        // deno-lint-ignore no-explicit-any
+        component: exportedFunction as ComponentType<any>,
         exportName,
       });
     }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -537,7 +537,7 @@ export interface Middleware<State = Record<string, unknown>> {
 
 export interface IslandModule {
   // deno-lint-ignore no-explicit-any
-  [key: string]: ComponentType<any>;
+  [key: string]: ComponentType<any> | unknown;
 }
 
 export interface Island {


### PR DESCRIPTION
This loosens the island module type definition we have internally. It would assume that every export is a component function which is wrong.