### PR TITLE
chore: reuse puppeteer instance

### DIFF
--- a/tests/islands_test.ts
+++ b/tests/islands_test.ts
@@ -1,14 +1,37 @@
-import { assert, assertEquals, assertStringIncludes, Page } from "./deps.ts";
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+  delay,
+  Page,
+} from "./deps.ts";
 import {
   assertNoPageComments,
   assertNotSelector,
   clickWhenListenerReady,
+  closeBrowser,
   getErrorOverlay,
+  launchOrGetBrowser,
   parseHtml,
   waitForText,
   withFakeServe,
   withPageName,
 } from "./test_utils.ts";
+
+globalThis.addEventListener("load", async () => {
+  await launchOrGetBrowser();
+});
+
+globalThis.addEventListener("beforeunload", async () => {
+  await closeBrowser();
+});
+
+Deno.test("dummy test", {
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async () => {
+  await delay(1000);
+});
 
 Deno.test("island tests", async (t) => {
   await withPage(async (page, address) => {

--- a/tests/partials_test.ts
+++ b/tests/partials_test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertMatch, Page } from "./deps.ts";
+import { assert, assertEquals, assertMatch, delay, Page } from "./deps.ts";
 import {
   assertMetaContent,
   assertNoComments,
@@ -6,7 +6,9 @@ import {
   assertNotSelector,
   assertSelector,
   assertTextMany,
+  closeBrowser,
   getErrorOverlay,
+  launchOrGetBrowser,
   parseHtml,
   waitFor,
   waitForText,
@@ -18,6 +20,21 @@ async function assertLogs(page: Page, expected: string[]) {
   const text = expected.length > 0 ? expected.join("\n") + "\n" : "";
   await waitForText(page, "#logs", text);
 }
+
+globalThis.addEventListener("load", async () => {
+  await launchOrGetBrowser();
+});
+
+globalThis.addEventListener("beforeunload", async () => {
+  await closeBrowser();
+});
+
+Deno.test("dummy test", {
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async () => {
+  await delay(1000);
+});
 
 Deno.test("injects server content with no islands present", async () => {
   await withPageName(

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -1,3 +1,4 @@
+import { Browser } from "https://deno.land/x/puppeteer@16.2.0/mod.ts";
 import {
   FromManifestConfig,
   Manifest,
@@ -43,6 +44,26 @@ export async function startFreshServer(options: Deno.CommandOptions) {
   }
 
   return { serverProcess, lines, address, output };
+}
+
+let PUPPETEER_BROWSER: Browser;
+export async function launchOrGetBrowser() {
+  if (PUPPETEER_BROWSER) {
+    return PUPPETEER_BROWSER;
+  }
+
+  const start = Date.now();
+  console.log("starting browser");
+  const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
+  console.log("browser started in", Date.now() - start, "ms");
+  PUPPETEER_BROWSER = browser;
+  return browser;
+}
+
+export async function closeBrowser() {
+  if (typeof PUPPETEER_BROWSER !== "undefined") {
+    await PUPPETEER_BROWSER.close();
+  }
 }
 
 export async function fetchHtml(url: string) {
@@ -225,14 +246,10 @@ export async function withPageName(
   });
 
   try {
-    const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
+    const browser = await launchOrGetBrowser();
 
-    try {
-      const page = await browser.newPage();
-      await fn(page, address);
-    } finally {
-      await browser.close();
-    }
+    const page = await browser.newPage();
+    await fn(page, address);
   } finally {
     serverProcess.kill("SIGTERM");
     // Wait until the process exits


### PR DESCRIPTION
Refreshing #1418, along with some minimal perf numbers by running `deno test -A tests/partials_test.ts --reporter=dot`:

before the change
* ok | 50 passed | 0 failed (1m11s)
* ok | 50 passed | 0 failed (1m16s)
* ok | 50 passed | 0 failed (1m20s)

after the change:
* ok | 51 passed | 0 failed (55s)
* ok | 51 passed | 0 failed (50s)
* ok | 51 passed | 0 failed (53s)

So this seems like a sizable improvement. It seems like the test runner doesn't wait for `globalThis` to finish doing its thing before starting, so I added some dummy tests at the top of the two modified files to make sure everything is warm before continuing. If there's a better way, please let me know.