### PR TITLE
fix: tailwind failing on non-existant files

### DIFF
--- a/plugins/tailwind.ts
+++ b/plugins/tailwind.ts
@@ -82,8 +82,8 @@ export default function tailwind(): Plugin {
   const tailwindMiddleware: PluginMiddleware = {
     path: "/",
     middleware: {
-      handler: async (req, ctx) => {
-        const pathname = new URL(req.url).pathname;
+      handler: async (_req, ctx) => {
+        const pathname = ctx.url.pathname;
 
         if (pathname.endsWith(".css.map")) {
           const cached = cache.get(pathname);
@@ -110,6 +110,12 @@ export default function tailwind(): Plugin {
             };
             cache.set(pathname, cached);
           } catch (err) {
+            // If the file is not found than it's likely a virtual file
+            // by the user that they respond to via a middleware.
+            if (err instanceof Deno.errors.NotFound) {
+              return ctx.next();
+            }
+
             cached = {
               content: text,
               map: "",

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -124,7 +124,7 @@ export async function getInternalFreshState(
   return {
     config: internalConfig,
     manifest,
-    loadSnapshot: !isLegacyDev,
+    loadSnapshot: !isLegacyDev && !config.dev,
     denoJsonPath,
     denoJson,
     build: false,

--- a/tests/fixture_tailwind/fresh.gen.ts
+++ b/tests/fixture_tailwind/fresh.gen.ts
@@ -3,6 +3,7 @@
 // This file is automatically updated during development when running `dev.ts`.
 
 import * as $_app from "./routes/_app.tsx";
+import * as $_middleware from "./routes/_middleware.ts";
 import * as $index from "./routes/index.tsx";
 
 import { type Manifest } from "$fresh/server.ts";
@@ -10,6 +11,7 @@ import { type Manifest } from "$fresh/server.ts";
 const manifest = {
   routes: {
     "./routes/_app.tsx": $_app,
+    "./routes/_middleware.ts": $_middleware,
     "./routes/index.tsx": $index,
   },
   islands: {},

--- a/tests/fixture_tailwind/routes/_middleware.ts
+++ b/tests/fixture_tailwind/routes/_middleware.ts
@@ -1,0 +1,15 @@
+import { FreshContext } from "$fresh/server.ts";
+
+export async function handler(
+  _req: Request,
+  ctx: FreshContext,
+) {
+  if (ctx.url.pathname === "/middleware-only.css") {
+    return new Response(".foo-bar { color: red }", {
+      headers: {
+        "Content-Type": "text/css",
+      },
+    });
+  }
+  return await ctx.next();
+}

--- a/tests/tailwind_test.ts
+++ b/tests/tailwind_test.ts
@@ -37,3 +37,15 @@ Deno.test("TailwindCSS - config", async () => {
     { loadConfig: true },
   );
 });
+
+Deno.test("TailwindCSS - middleware only css", async () => {
+  await withFakeServe(
+    "./tests/fixture_tailwind/dev.ts",
+    async (server) => {
+      const res = await server.get("/middleware-only.css");
+      const content = await res.text();
+      assertStringIncludes(content, ".foo-bar");
+    },
+    { loadConfig: true },
+  );
+});


### PR DESCRIPTION
Sometimes a middleware may respond to `*.css` and serve CSS on the fly instead of from a static css file. Our tailwind plugin still tried to serve these and failed because there is no file on disk.