### PR TITLE
fix: make prompt a question to hint at user input

### DIFF
--- a/update.ts
+++ b/update.ts
@@ -33,7 +33,7 @@ const flags = parse(Deno.args, {});
 
 let unresolvedDirectory = Deno.args[0];
 if (flags._.length !== 1) {
-  const userInput = prompt("Project Directory", ".");
+  const userInput = prompt("Where is the project directory?", ".");
   if (!userInput) {
     error(help);
   }


### PR DESCRIPTION
It's a bit hard to see that input is required otherwise.

Before:

```txt
$ deno run -A update.ts 
Project Directory [.] 
```

After:

```txt
$ deno run -A update.ts 
Where is the project directory? [.] 
```