### PR TITLE
chore: update types in tests, init, update

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -273,7 +273,7 @@ await Deno.writeTextFile(
   ROUTES_GREET_TSX,
 );
 
-const ROUTES_API_JOKE_TS = `import { HandlerContext } from "$fresh/server.ts";
+const ROUTES_API_JOKE_TS = `import { FreshContext } from "$fresh/server.ts";
 
 // Jokes courtesy of https://punsandoneliners.com/randomness/programmer-jokes/
 const JOKES = [
@@ -289,7 +289,7 @@ const JOKES = [
   "An SEO expert walked into a bar, pub, inn, tavern, hostelry, public house.",
 ];
 
-export const handler = (_req: Request, _ctx: HandlerContext): Response => {
+export const handler = (_req: Request, _ctx: FreshContext): Response => {
   const randomIndex = Math.floor(Math.random() * JOKES.length);
   const body = JOKES[randomIndex];
   return new Response(body);
@@ -443,8 +443,8 @@ html {
 }
 `;
 
-const APP_WRAPPER = `import { type AppProps } from "$fresh/server.ts";
-export default function App({ Component }: AppProps) {
+const APP_WRAPPER = `import { type PageProps } from "$fresh/server.ts";
+export default function App({ Component }: PageProps) {
   return (
     <html>
       <head>

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -1,15 +1,6 @@
 import { PARTIAL_SEARCH_PARAM } from "../constants.ts";
-import {
-  BaseRoute,
-  ErrorHandlerContext,
-  FreshContext,
-  ServeHandlerInfo,
-} from "./types.ts";
+import { BaseRoute, FreshContext } from "./types.ts";
 import { isIdentifierChar, isIdentifierStart } from "./init_safe_deps.ts";
-
-type HandlerContext<T = unknown> = T & ServeHandlerInfo & {
-  isPartial: boolean;
-};
 
 export type Handler<T = Record<string, unknown>> = (
   req: Request,
@@ -91,7 +82,7 @@ export function defaultOtherHandler(_req: Request): Response {
 
 export function defaultErrorHandler(
   _req: Request,
-  _ctx: ErrorHandlerContext,
+  _ctx: FreshContext,
   err: unknown,
 ): Response {
   console.error(err);
@@ -103,7 +94,7 @@ export function defaultErrorHandler(
 
 export function defaultUnknownMethodHandler(
   _req: Request,
-  _ctx: HandlerContext,
+  _ctx: FreshContext,
   knownMethods: KnownMethod[],
 ): Response {
   return new Response(null, {

--- a/tests/fixture/routes/404-from-middleware-throw/_middleware.ts
+++ b/tests/fixture/routes/404-from-middleware-throw/_middleware.ts
@@ -1,9 +1,9 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
 // handlers are supposed to return something, so in order to make type checker on the manifest happy, we'll use any to escape it
 export function handler(
   _req: Request,
-  _ctx: MiddlewareHandlerContext,
+  _ctx: FreshContext,
   // deno-lint-ignore no-explicit-any
 ): any {
   throw new Deno.errors.NotFound();

--- a/tests/fixture/routes/_404.tsx
+++ b/tests/fixture/routes/_404.tsx
@@ -1,10 +1,10 @@
-import { UnknownPageProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
 type Data = { hello: string };
 type State = { root: string };
 
 export default function NotFoundPage(
-  { data, state, url }: UnknownPageProps<Data | undefined, State>,
+  { data, state, url }: PageProps<Data | undefined, State>,
 ) {
   // Checks that we have the correct type for state
   state.root satisfies string;

--- a/tests/fixture/routes/_500.tsx
+++ b/tests/fixture/routes/_500.tsx
@@ -1,5 +1,5 @@
-import { ErrorPageProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function Error500Page({ error }: ErrorPageProps) {
+export default function Error500Page({ error }: PageProps) {
   return <p>500 internal error: {(error as Error).message}</p>;
 }

--- a/tests/fixture/routes/_app.tsx
+++ b/tests/fixture/routes/_app.tsx
@@ -1,12 +1,12 @@
 import { Head } from "$fresh/runtime.ts";
-import { AppProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
 export type TestState = {
   root: string;
   stateInProps: string;
 };
 
-export default function App(props: AppProps<unknown, TestState>) {
+export default function App(props: PageProps<unknown, TestState>) {
   const statefulValue = props.state?.root === "root_mw"
     ? "The freshest framework!"
     : "";

--- a/tests/fixture/routes/intercept.tsx
+++ b/tests/fixture/routes/intercept.tsx
@@ -1,11 +1,11 @@
-import { HandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
 export default function Page() {
   return <div>This is HTML</div>;
 }
 
 export const handler = {
-  GET(req: Request, { render }: HandlerContext) {
+  GET(req: Request, { render }: FreshContext) {
     if (req.headers.get("accept")?.includes("text/html")) {
       return render();
     } else {

--- a/tests/fixture/routes/layeredMdw/_middleware.ts
+++ b/tests/fixture/routes/layeredMdw/_middleware.ts
@@ -1,6 +1,6 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export async function handler(_req: Request, ctx: MiddlewareHandlerContext) {
+export async function handler(_req: Request, ctx: FreshContext) {
   ctx.state.layer1 = "layer1_mw";
   const resp = await ctx.next();
   resp.headers.set("server", "fresh test server layer1");

--- a/tests/fixture/routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts
+++ b/tests/fixture/routes/layeredMdw/layer2-with-params/[tenantId]/_middleware.ts
@@ -1,6 +1,6 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export async function handler(_req: Request, ctx: MiddlewareHandlerContext) {
+export async function handler(_req: Request, ctx: FreshContext) {
   const resp = await ctx.next();
   resp.headers.set("middlewareParams_inner", JSON.stringify(ctx.params));
   return resp;

--- a/tests/fixture/routes/layeredMdw/layer2-with-params/_middleware.ts
+++ b/tests/fixture/routes/layeredMdw/layer2-with-params/_middleware.ts
@@ -1,6 +1,6 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export async function handler(_req: Request, ctx: MiddlewareHandlerContext) {
+export async function handler(_req: Request, ctx: FreshContext) {
   const resp = await ctx.next();
   resp.headers.set("middlewareParams_outer", JSON.stringify(ctx.params));
   return resp;

--- a/tests/fixture/routes/layeredMdw/layer2/_middleware.ts
+++ b/tests/fixture/routes/layeredMdw/layer2/_middleware.ts
@@ -1,4 +1,4 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
 interface State {
   root: string;
@@ -8,7 +8,7 @@ interface State {
 
 export async function handler(
   _req: Request,
-  ctx: MiddlewareHandlerContext<State>,
+  ctx: FreshContext<State>,
 ) {
   ctx.state.layer2 = "layer2_mw";
   const resp = await ctx.next();

--- a/tests/fixture/routes/layeredMdw/layer2/layer3/_middleware.ts
+++ b/tests/fixture/routes/layeredMdw/layer2/layer3/_middleware.ts
@@ -1,6 +1,6 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export async function handler(_req: Request, ctx: MiddlewareHandlerContext) {
+export async function handler(_req: Request, ctx: FreshContext) {
   ctx.state.layer3 = "layer3_mw";
   const resp = await ctx.next();
   resp.headers.set("server", "fresh test server layer3");

--- a/tests/fixture/routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts
+++ b/tests/fixture/routes/layeredMdw/nesting/[tenant]/[environment]/_middleware.ts
@@ -1,6 +1,6 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export async function handler(_req: Request, ctx: MiddlewareHandlerContext) {
+export async function handler(_req: Request, ctx: FreshContext) {
   ctx.state.middlewareNestingOrder += "3";
   const resp = await ctx.next();
   return resp;

--- a/tests/fixture/routes/layeredMdw/nesting/[tenant]/_middleware.ts
+++ b/tests/fixture/routes/layeredMdw/nesting/[tenant]/_middleware.ts
@@ -1,6 +1,6 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export async function handler(_req: Request, ctx: MiddlewareHandlerContext) {
+export async function handler(_req: Request, ctx: FreshContext) {
   ctx.state.middlewareNestingOrder += "2";
   const resp = await ctx.next();
   return resp;

--- a/tests/fixture/routes/layeredMdw/nesting/_middleware.ts
+++ b/tests/fixture/routes/layeredMdw/nesting/_middleware.ts
@@ -1,6 +1,6 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export async function handler(_req: Request, ctx: MiddlewareHandlerContext) {
+export async function handler(_req: Request, ctx: FreshContext) {
   ctx.state.middlewareNestingOrder = "1";
   const resp = await ctx.next();
   return resp;

--- a/tests/fixture/routes/middleware-error-handler/_middleware.ts
+++ b/tests/fixture/routes/middleware-error-handler/_middleware.ts
@@ -1,8 +1,8 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
 export async function handler(
   _req: Request,
-  ctx: MiddlewareHandlerContext,
+  ctx: FreshContext,
 ) {
   try {
     ctx.state.flag = true;

--- a/tests/fixture/routes/params.tsx
+++ b/tests/fixture/routes/params.tsx
@@ -1,7 +1,7 @@
-import { HandlerContext, RouteConfig } from "$fresh/server.ts";
+import { FreshContext, RouteConfig } from "$fresh/server.ts";
 
 export const handler = {
-  GET(_req: Request, { params }: HandlerContext) {
+  GET(_req: Request, { params }: FreshContext) {
     return new Response(params.path);
   },
 };

--- a/tests/fixture/routes/route-groups/(bar)/(baz)/_layout.tsx
+++ b/tests/fixture/routes/route-groups/(bar)/(baz)/_layout.tsx
@@ -1,6 +1,6 @@
-import { LayoutProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function BarLayout({ Component }: LayoutProps) {
+export default function BarLayout({ Component }: PageProps) {
   return (
     <div>
       <p class="baz-layout">Baz layout</p>

--- a/tests/fixture/routes/route-groups/(bar)/_layout.tsx
+++ b/tests/fixture/routes/route-groups/(bar)/_layout.tsx
@@ -1,6 +1,6 @@
-import { LayoutProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function BarLayout({ Component }: LayoutProps) {
+export default function BarLayout({ Component }: PageProps) {
   return (
     <div>
       <p class="bar-layout">Bar layout</p>

--- a/tests/fixture/routes/route-groups/(foo)/_layout.tsx
+++ b/tests/fixture/routes/route-groups/(foo)/_layout.tsx
@@ -1,6 +1,6 @@
-import { LayoutProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function FooLayout({ Component }: LayoutProps) {
+export default function FooLayout({ Component }: PageProps) {
   return (
     <div>
       <p class="foo-layout">Foo layout</p>

--- a/tests/fixture/routes/state-in-props/_middleware.ts
+++ b/tests/fixture/routes/state-in-props/_middleware.ts
@@ -1,9 +1,9 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 import { TestState } from "../_app.tsx";
 
 export async function handler(
   _req: Request,
-  ctx: MiddlewareHandlerContext<TestState>,
+  ctx: FreshContext<TestState>,
 ) {
   ctx.state.stateInProps = "look, i am set from middleware";
   const resp = await ctx.next();

--- a/tests/fixture/routes/state-middleware/_middleware.ts
+++ b/tests/fixture/routes/state-middleware/_middleware.ts
@@ -1,6 +1,6 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export const handler = (_req: Request, ctx: MiddlewareHandlerContext) => {
+export const handler = (_req: Request, ctx: FreshContext) => {
   ctx.state = { handler1: "it works" };
   return ctx.next();
 };

--- a/tests/fixture/routes/state-middleware/foo/_middleware.ts
+++ b/tests/fixture/routes/state-middleware/foo/_middleware.ts
@@ -1,6 +1,6 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export const handler = (_req: Request, ctx: MiddlewareHandlerContext) => {
+export const handler = (_req: Request, ctx: FreshContext) => {
   ctx.state.handler2 = "it works";
   return ctx.next();
 };

--- a/tests/fixture/routes/state-middleware/foo/index.tsx
+++ b/tests/fixture/routes/state-middleware/foo/index.tsx
@@ -1,6 +1,6 @@
-import { HandlerContext, PageProps } from "$fresh/server.ts";
+import { FreshContext, PageProps } from "$fresh/server.ts";
 
-export const handler = (_req: Request, ctx: HandlerContext) => {
+export const handler = (_req: Request, ctx: FreshContext) => {
   ctx.state.handler3 = "it works";
   return ctx.render();
 };

--- a/tests/fixture/routes/status_overwrite.tsx
+++ b/tests/fixture/routes/status_overwrite.tsx
@@ -1,11 +1,11 @@
-import { HandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
 export default function Page() {
   return <div>This is HTML</div>;
 }
 
 export const handler = {
-  GET(req: Request, { render }: HandlerContext) {
+  GET(req: Request, { render }: FreshContext) {
     return render(undefined, {
       status: 401,
       headers: { "x-some-header": "foo" },

--- a/tests/fixture_async_app/routes/_app.tsx
+++ b/tests/fixture_async_app/routes/_app.tsx
@@ -1,7 +1,7 @@
 import { delay } from "$std/async/delay.ts";
-import { AppContext } from "$fresh/src/server/types.ts";
+import { FreshContext } from "$fresh/src/server/types.ts";
 
-export default async function App(req: Request, ctx: AppContext) {
+export default async function App(req: Request, ctx: FreshContext) {
   await delay(100);
 
   return (

--- a/tests/fixture_async_app/routes/_layout.tsx
+++ b/tests/fixture_async_app/routes/_layout.tsx
@@ -1,9 +1,9 @@
-import { LayoutContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 import { delay } from "$std/async/delay.ts";
 
 export default async function AsyncLayout(
   req: Request,
-  ctx: LayoutContext,
+  ctx: FreshContext,
 ) {
   await delay(10);
   return (

--- a/tests/fixture_base_path/routes/_middleware.ts
+++ b/tests/fixture_base_path/routes/_middleware.ts
@@ -1,8 +1,8 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
 export async function handler(
   _req: Request,
-  ctx: MiddlewareHandlerContext<{ data: string }>,
+  ctx: FreshContext<{ data: string }>,
 ) {
   ctx.state.data = "it works";
   const resp = await ctx.next();

--- a/tests/fixture_custom_500/routes/_500.tsx
+++ b/tests/fixture_custom_500/routes/_500.tsx
@@ -1,9 +1,9 @@
-import { ErrorHandler, ErrorPageProps } from "../../../server.ts";
+import { ErrorHandler, PageProps } from "../../../server.ts";
 
 export const handler: ErrorHandler = (_req, ctx) => {
   return ctx.render();
 };
 
-export default function Error500Page({ error }: ErrorPageProps) {
+export default function Error500Page({ error }: PageProps) {
   return <p class="custom-500">Custom 500: {(error as Error).message}</p>;
 }

--- a/tests/fixture_explicit_app/routes/_app.tsx
+++ b/tests/fixture_explicit_app/routes/_app.tsx
@@ -1,4 +1,4 @@
-import { AppProps, Handler } from "$fresh/server.ts";
+import { Handler, PageProps } from "$fresh/server.ts";
 
 export const handler: Handler = (_req, ctx) => {
   ctx.state.lang = "de";
@@ -6,7 +6,7 @@ export const handler: Handler = (_req, ctx) => {
 };
 
 export default function App(
-  { Component, state }: AppProps<unknown, { lang: string }>,
+  { Component, state }: PageProps<unknown, { lang: string }>,
 ) {
   return (
     <html lang={state.lang} class="html">

--- a/tests/fixture_layouts/routes/_app.tsx
+++ b/tests/fixture_layouts/routes/_app.tsx
@@ -1,6 +1,6 @@
-import { AppProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function App({ Component, state }: AppProps) {
+export default function App({ Component, state }: PageProps) {
   return (
     <div class="app">
       <Component />

--- a/tests/fixture_layouts/routes/_layout.tsx
+++ b/tests/fixture_layouts/routes/_layout.tsx
@@ -1,8 +1,8 @@
-import { LayoutProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 import { LayoutState } from "./_middleware.ts";
 
 export default function RootLayout(
-  { Component, state }: LayoutProps<unknown, LayoutState>,
+  { Component, state }: PageProps<unknown, LayoutState>,
 ) {
   return (
     <div class="root-layout">

--- a/tests/fixture_layouts/routes/_middleware.ts
+++ b/tests/fixture_layouts/routes/_middleware.ts
@@ -1,4 +1,4 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
 export type LayoutState = {
   something: string;
@@ -6,7 +6,7 @@ export type LayoutState = {
 
 export const handler = (
   _req: Request,
-  ctx: MiddlewareHandlerContext<LayoutState>,
+  ctx: FreshContext<LayoutState>,
 ) => {
   ctx.state.something = "it works";
   return ctx.next();

--- a/tests/fixture_layouts/routes/async/_layout.tsx
+++ b/tests/fixture_layouts/routes/async/_layout.tsx
@@ -1,9 +1,9 @@
-import { LayoutContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 import { delay } from "$fresh/tests/deps.ts";
 
 export default async function AsyncLayout(
   req: Request,
-  ctx: LayoutContext,
+  ctx: FreshContext,
 ) {
   await delay(10);
   return (

--- a/tests/fixture_layouts/routes/async/redirect/_layout.tsx
+++ b/tests/fixture_layouts/routes/async/redirect/_layout.tsx
@@ -1,9 +1,9 @@
-import { LayoutContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 import { delay } from "$std/async/mod.ts";
 
 export default async function AsyncSubLayout(
   req: Request,
-  ctx: LayoutContext,
+  ctx: FreshContext,
 ) {
   await delay(10);
   return new Response(null, {

--- a/tests/fixture_layouts/routes/async/sub/_layout.tsx
+++ b/tests/fixture_layouts/routes/async/sub/_layout.tsx
@@ -1,8 +1,8 @@
-import { LayoutContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
 export default async function AsyncSubLayout(
   req: Request,
-  ctx: LayoutContext,
+  ctx: FreshContext,
 ) {
   await new Promise((r) => setTimeout(r, 10));
   return (

--- a/tests/fixture_layouts/routes/files/ts/_layout.ts
+++ b/tests/fixture_layouts/routes/files/ts/_layout.ts
@@ -1,6 +1,6 @@
 import { h } from "preact";
-import { LayoutProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function TsLayout({ Component }: LayoutProps) {
+export default function TsLayout({ Component }: PageProps) {
   return h("div", { class: "ts-layout" }, h(Component, null));
 }

--- a/tests/fixture_layouts/routes/files/tsx/_layout.tsx
+++ b/tests/fixture_layouts/routes/files/tsx/_layout.tsx
@@ -1,7 +1,7 @@
 import { h } from "preact";
-import { LayoutProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function TsxLayout({ Component }: LayoutProps) {
+export default function TsxLayout({ Component }: PageProps) {
   return (
     <div class="tsx-layout">
       <Component />

--- a/tests/fixture_layouts/routes/foo/_layout.tsx
+++ b/tests/fixture_layouts/routes/foo/_layout.tsx
@@ -1,6 +1,6 @@
-import { LayoutProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function FooLayout({ Component }: LayoutProps) {
+export default function FooLayout({ Component }: PageProps) {
   return (
     <div class="foo-layout">
       <Component />

--- a/tests/fixture_layouts/routes/override/_layout.tsx
+++ b/tests/fixture_layouts/routes/override/_layout.tsx
@@ -1,10 +1,10 @@
-import { LayoutConfig, LayoutProps } from "$fresh/server.ts";
+import { LayoutConfig, PageProps } from "$fresh/server.ts";
 
 export const config: LayoutConfig = {
   skipInheritedLayouts: true,
 };
 
-export default function OverrideLayout({ Component }: LayoutProps) {
+export default function OverrideLayout({ Component }: PageProps) {
   return (
     <div class="override-layout">
       <Component />

--- a/tests/fixture_layouts/routes/override/layout_no_app/_layout.tsx
+++ b/tests/fixture_layouts/routes/override/layout_no_app/_layout.tsx
@@ -1,10 +1,10 @@
-import { LayoutConfig, LayoutProps } from "$fresh/server.ts";
+import { LayoutConfig, PageProps } from "$fresh/server.ts";
 
 export const config: LayoutConfig = {
   skipAppWrapper: true,
 };
 
-export default function OverrideLayout({ Component }: LayoutProps) {
+export default function OverrideLayout({ Component }: PageProps) {
   return (
     <div class="no-app-layout">
       <Component />

--- a/tests/fixture_layouts/routes/skip/sub/_layout.tsx
+++ b/tests/fixture_layouts/routes/skip/sub/_layout.tsx
@@ -1,6 +1,6 @@
-import { LayoutProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function SubLayout({ Component }: LayoutProps) {
+export default function SubLayout({ Component }: PageProps) {
   return (
     <div class="sub-layout">
       <Component />

--- a/tests/fixture_layouts_2/routes/_layout.tsx
+++ b/tests/fixture_layouts_2/routes/_layout.tsx
@@ -1,7 +1,7 @@
-import { LayoutProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
 export default function RootLayout(
-  { Component }: LayoutProps<unknown>,
+  { Component }: PageProps<unknown>,
 ) {
   return (
     <div class="root-layout">

--- a/tests/fixture_partials/routes/active_nav_partial/_layout.tsx
+++ b/tests/fixture_partials/routes/active_nav_partial/_layout.tsx
@@ -1,6 +1,6 @@
-import { LayoutProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function Layout({ Component }: LayoutProps) {
+export default function Layout({ Component }: PageProps) {
   return (
     <div f-client-nav>
       <Component />

--- a/tests/fixture_partials/routes/client_nav/_layout.tsx
+++ b/tests/fixture_partials/routes/client_nav/_layout.tsx
@@ -1,8 +1,8 @@
-import { AppProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 import { Partial } from "$fresh/runtime.ts";
 import { Fader } from "../../islands/Fader.tsx";
 
-export default function AppLayout({ Component }: AppProps) {
+export default function AppLayout({ Component }: PageProps) {
   return (
     <html>
       <head>

--- a/tests/fixture_partials/routes/client_nav_both/_layout.tsx
+++ b/tests/fixture_partials/routes/client_nav_both/_layout.tsx
@@ -1,8 +1,8 @@
-import { AppProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 import { Partial } from "$fresh/runtime.ts";
 import { Fader } from "../../islands/Fader.tsx";
 
-export default function AppLayout({ Component }: AppProps) {
+export default function AppLayout({ Component }: PageProps) {
   return (
     <html>
       <head>

--- a/tests/fixture_partials/routes/client_nav_opt_out/_layout.tsx
+++ b/tests/fixture_partials/routes/client_nav_opt_out/_layout.tsx
@@ -1,8 +1,8 @@
-import { AppProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 import { Partial } from "$fresh/runtime.ts";
 import { Fader } from "../../islands/Fader.tsx";
 
-export default function AppLayout({ Component }: AppProps) {
+export default function AppLayout({ Component }: PageProps) {
   return (
     <html>
       <head>

--- a/tests/fixture_partials/routes/isPartial/_middleware.ts
+++ b/tests/fixture_partials/routes/isPartial/_middleware.ts
@@ -1,4 +1,4 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
 export type IsPartialInContextState = {
   setFromMiddleware: boolean;
@@ -7,7 +7,7 @@ export type IsPartialInContextState = {
 
 export async function handler(
   _req: Request,
-  ctx: MiddlewareHandlerContext<IsPartialInContextState>,
+  ctx: FreshContext<IsPartialInContextState>,
 ) {
   if (ctx.isPartial) {
     ctx.state.setFromMiddleware = true;

--- a/tests/fixture_plugin/routes/test.tsx
+++ b/tests/fixture_plugin/routes/test.tsx
@@ -1,7 +1,7 @@
-import { HandlerContext, Handlers, PageProps } from "../../../server.ts";
+import { FreshContext, Handlers, PageProps } from "../../../server.ts";
 
 export const handler: Handlers<unknown, { test: string }> = {
-  async GET(_req, ctx: HandlerContext<unknown, { test: string }>) {
+  async GET(_req, ctx: FreshContext<{ test: string }, unknown>) {
     const resp = await ctx.render();
     return resp;
   },

--- a/tests/fixture_plugin/utils/route-plugin.ts
+++ b/tests/fixture_plugin/utils/route-plugin.ts
@@ -1,4 +1,4 @@
-import { MiddlewareHandlerContext, Plugin } from "$fresh/server.ts";
+import { FreshContext, Plugin } from "$fresh/server.ts";
 import { handler as testMiddleware } from "./sample_routes/_middleware.ts";
 import { AppBuilder } from "./sample_routes/AppBuilder.tsx";
 import IslandPluginComponent from "./sample_routes/PluginRouteWithIsland.tsx";
@@ -16,14 +16,14 @@ export type PluginMiddlewareState = {
 const twoPointlessMiddlewares = [
   async (
     _req: Request,
-    ctx: MiddlewareHandlerContext<PluginMiddlewareState>,
+    ctx: FreshContext<PluginMiddlewareState>,
   ) => {
     ctx.state.num = ctx.state.num === undefined ? 1 : ctx.state.num + 1;
     return await ctx.next();
   },
   async (
     _req: Request,
-    ctx: MiddlewareHandlerContext<PluginMiddlewareState>,
+    ctx: FreshContext<PluginMiddlewareState>,
   ) => {
     ctx.state.num = ctx.state.num === undefined ? 1 : ctx.state.num + 1;
     return await ctx.next();

--- a/tests/fixture_plugin/utils/sample_routes/AppBuilder.tsx
+++ b/tests/fixture_plugin/utils/sample_routes/AppBuilder.tsx
@@ -1,9 +1,9 @@
-import { AppProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 import { Head } from "../../../../runtime.ts";
 import { Options } from "../route-plugin.ts";
 
 export function AppBuilder(options: Options) {
-  return ({ Component }: AppProps) => {
+  return ({ Component }: PageProps) => {
     return (
       <>
         <Head>

--- a/tests/fixture_plugin/utils/sample_routes/_middleware.ts
+++ b/tests/fixture_plugin/utils/sample_routes/_middleware.ts
@@ -1,9 +1,9 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 import { PluginMiddlewareState } from "../../utils/route-plugin.ts";
 
 export async function handler(
   _req: Request,
-  ctx: MiddlewareHandlerContext<PluginMiddlewareState>,
+  ctx: FreshContext<PluginMiddlewareState>,
 ) {
   ctx.state.test = "look, i'm set from a plugin!";
   const resp = await ctx.next();

--- a/tests/fixture_plugin/utils/second-middleware-plugin.ts
+++ b/tests/fixture_plugin/utils/second-middleware-plugin.ts
@@ -1,4 +1,4 @@
-import { MiddlewareHandlerContext, Plugin } from "$fresh/server.ts";
+import { FreshContext, Plugin } from "$fresh/server.ts";
 import { PluginMiddlewareState } from "./route-plugin.ts";
 
 export default function secondMiddlewarePlugin(): Plugin<
@@ -10,7 +10,7 @@ export default function secondMiddlewarePlugin(): Plugin<
       middleware: {
         handler: async (
           _req: Request,
-          ctx: MiddlewareHandlerContext<PluginMiddlewareState>,
+          ctx: FreshContext<PluginMiddlewareState>,
         ) => {
           return await ctx.next();
         },
@@ -20,7 +20,7 @@ export default function secondMiddlewarePlugin(): Plugin<
       middleware: {
         handler: async (
           _req: Request,
-          ctx: MiddlewareHandlerContext<PluginMiddlewareState>,
+          ctx: FreshContext<PluginMiddlewareState>,
         ) => {
           ctx.state.num = ctx.state.num === undefined ? 1 : ctx.state.num + 1;
           return await ctx.next();
@@ -31,7 +31,7 @@ export default function secondMiddlewarePlugin(): Plugin<
       middleware: {
         handler: async (
           _req: Request,
-          ctx: MiddlewareHandlerContext<PluginMiddlewareState>,
+          ctx: FreshContext<PluginMiddlewareState>,
         ) => {
           return await ctx.next();
         },

--- a/tests/fixture_plugin_middleware/routes/_middleware.ts
+++ b/tests/fixture_plugin_middleware/routes/_middleware.ts
@@ -1,6 +1,6 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export async function handler(req: Request, ctx: MiddlewareHandlerContext) {
+export async function handler(req: Request, ctx: FreshContext) {
   console.log(ctx.destination);
   console.log(req.url);
   const resp = await ctx.next();

--- a/tests/fixture_tailwind/routes/_app.tsx
+++ b/tests/fixture_tailwind/routes/_app.tsx
@@ -1,6 +1,6 @@
-import { AppProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function App({ Component }: AppProps) {
+export default function App({ Component }: PageProps) {
   return (
     <html>
       <head>

--- a/tests/fixture_tailwind_build/routes/_app.tsx
+++ b/tests/fixture_tailwind_build/routes/_app.tsx
@@ -1,6 +1,6 @@
-import { AppProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function App({ Component }: AppProps) {
+export default function App({ Component }: PageProps) {
   return (
     <html>
       <head>

--- a/tests/fixture_tailwind_config/routes/_app.tsx
+++ b/tests/fixture_tailwind_config/routes/_app.tsx
@@ -1,6 +1,6 @@
-import { AppProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function App({ Component }: AppProps) {
+export default function App({ Component }: PageProps) {
   return (
     <html>
       <head>

--- a/tests/fixture_twind_app/routes/_app.tsx
+++ b/tests/fixture_twind_app/routes/_app.tsx
@@ -1,6 +1,6 @@
-import { AppProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function App({ Component }: AppProps) {
+export default function App({ Component }: PageProps) {
   return (
     <html className="bg-slate-800">
       <head className="bg-slate-800">

--- a/tests/fixture_twind_hydrate/routes/island_twind/_layout.tsx
+++ b/tests/fixture_twind_hydrate/routes/island_twind/_layout.tsx
@@ -1,8 +1,8 @@
 import { Partial } from "$fresh/runtime.ts";
-import { LayoutProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
 export default function Layout(
-  { Component }: LayoutProps<unknown, unknown>,
+  { Component }: PageProps<unknown, unknown>,
 ) {
   return (
     <div f-client-nav>

--- a/update.ts
+++ b/update.ts
@@ -278,9 +278,9 @@ await start(manifest, { plugins: [twindPlugin(twindConfig)] });\n`;
 // Add default _app.tsx if not present
 const routes = Array.from(Deno.readDirSync(join(srcDirectory, "routes")));
 if (!routes.find((entry) => entry.isFile && entry.name.startsWith("_app."))) {
-  const APP_TSX = `import { AppProps } from "$fresh/server.ts";
+  const APP_TSX = `import { PageProps } from "$fresh/server.ts";
 
-export default function App({ Component }: AppProps) {
+export default function App({ Component }: PageProps) {
   return (
     <html>
       <head>

--- a/www/routes/_app.tsx
+++ b/www/routes/_app.tsx
@@ -1,6 +1,6 @@
-import { AppProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function App({ Component }: AppProps) {
+export default function App({ Component }: PageProps) {
   return (
     <html lang="en">
       <head>


### PR DESCRIPTION
Of particular note is the change to `tests/fixture_plugin/routes/test.tsx`. Note how I do this:
```diff
-  async GET(_req, ctx: HandlerContext<unknown, { test: string }>) {
+  async GET(_req, ctx: FreshContext<{ test: string }, unknown>) {
```

I find it strange and confusing that the order of the type parameters has "changed". This makes it impossible to do a simple search and replace, because people now have to change order as well.

Most of the types have been declared as `<T, S>`, i.e. data before state:
* `PageProps<T = any, S = Record<string, unknown>>`
* `RouteContext<T = any, S = Record<string, unknown>>`
* `Handler<T = any, State = Record<string, unknown>>`
* `Handlers<T = any, State = Record<string, unknown>> `
* `AsyncRoute<T = any, S = Record<string, unknown>>`
* `PageComponent<T = any, S = Record<string, unknown>> `
* `AsyncLayout<T = any, S = Record<string, unknown>>`

And then `FreshContext` comes around like 
```
export interface FreshContext<
  State = Record<string, unknown>,
  // deno-lint-ignore no-explicit-any
  Data = any,
  NotFoundData = Data,
>
```
and switches it all up.

Not a huge issue, but just something to be aware of that others might report.