### PR TITLE
docs: Remove references to deprecated types

### DIFF
--- a/docs/latest/concepts/app-wrapper.md
+++ b/docs/latest/concepts/app-wrapper.md
@@ -14,9 +14,9 @@ template which can be conditioned based on state and params. Note that any state
 set by middleware is available via `props.state`.
 
 ```tsx routes/_app.tsx
-import { AppProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function App({ Component, state }: AppProps) {
+export default function App({ Component, state }: PageProps) {
   // do something with state here
   return (
     <html>

--- a/docs/latest/concepts/app-wrapper.md
+++ b/docs/latest/concepts/app-wrapper.md
@@ -37,12 +37,12 @@ export default function App({ Component, state }: PageProps) {
 
 Similar to routes and layouts, the app wrapper can be made asynchronous. This
 changes the function signature so that the first argument is the `Request`
-instance and the second one is the `AppContext`.
+instance and the second one is the `FreshContext`.
 
 ```tsx routes/_app.tsx
-import { AppContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export default async function App(req: Request, ctx: AppContext) {
+export default async function App(req: Request, ctx: FreshContext) {
   const data = await loadData();
 
   return (

--- a/docs/latest/concepts/data-fetching.md
+++ b/docs/latest/concepts/data-fetching.md
@@ -36,7 +36,7 @@ export default function ProjectPage(props: PageProps<Project>) {
 }
 ```
 
-The type parameter on the `PageProps`, `Handlers`, `Handler`, and
-`HandlerContext` can be used to enforce a TypeScript type to use for the render
-data. Fresh enforces during type checking that the types in all of these fields
-are compatible within a single page.
+The type parameter on the `PageProps`, `Handlers`, `Handler`, and `FreshContext`
+can be used to enforce a TypeScript type to use for the render data. Fresh
+enforces during type checking that the types in all of these fields are
+compatible within a single page.

--- a/docs/latest/concepts/error-pages.md
+++ b/docs/latest/concepts/error-pages.md
@@ -71,12 +71,12 @@ export const handler: Handlers = {
 
 The 500 page can be customized by creating a `_500.tsx` file in the `routes/`
 folder. The file must have a default export that is a regular Preact component.
-A props object of type `ErrorPageProps` is passed in as an argument.
+A props object of type `PageProps` is passed in as an argument.
 
 ```tsx routes/_500.tsx
-import { ErrorPageProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function Error500Page({ error }: ErrorPageProps) {
+export default function Error500Page({ error }: PageProps) {
   return <p>500 internal error: {(error as Error).message}</p>;
 }
 ```

--- a/docs/latest/concepts/error-pages.md
+++ b/docs/latest/concepts/error-pages.md
@@ -12,12 +12,12 @@ throws an error respectively.
 
 The 404 page can be customized by creating a `_404.tsx` file in the `routes/`
 folder. The file must have a default export that is a regular Preact component.
-A props object of type `UnknownPageProps` is passed in as an argument.
+A props object of type `PageProps` is passed in as an argument.
 
 ```tsx routes/_404.tsx
-import { UnknownPageProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function NotFoundPage({ url }: UnknownPageProps) {
+export default function NotFoundPage({ url }: PageProps) {
   return <p>404 not found: {url.pathname}</p>;
 }
 ```

--- a/docs/latest/concepts/layouts.md
+++ b/docs/latest/concepts/layouts.md
@@ -25,9 +25,9 @@ template which can be conditioned based on state and params. Note that any state
 set by middleware is available via `props.state`.
 
 ```tsx routes/sub/_layout.tsx
-import { LayoutProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
-export default function Layout({ Component, state }: LayoutProps) {
+export default function Layout({ Component, state }: PageProps) {
   // do something with state here
   return (
     <div class="layout">
@@ -43,7 +43,7 @@ In case you need to fetch data asynchronously before rendering the layout, you
 can use an async layout to do so.
 
 ```tsx routes/sub/_layout.tsx
-import { LayoutProps } from "$fresh/server.ts";
+import { PageProps } from "$fresh/server.ts";
 
 export default async function Layout(req: Request, ctx: LayoutContext) {
   // do something with state here

--- a/docs/latest/concepts/layouts.md
+++ b/docs/latest/concepts/layouts.md
@@ -43,9 +43,9 @@ In case you need to fetch data asynchronously before rendering the layout, you
 can use an async layout to do so.
 
 ```tsx routes/sub/_layout.tsx
-import { PageProps } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export default async function Layout(req: Request, ctx: LayoutContext) {
+export default async function Layout(req: Request, ctx: FreshContext) {
   // do something with state here
   const data = await loadData();
 

--- a/docs/latest/concepts/middleware.md
+++ b/docs/latest/concepts/middleware.md
@@ -18,7 +18,7 @@ properties, e.g. `ctx.state.loggedIn = true`, but you can also replace the
 entire object like `ctx.state = { loggedIn: true }`.
 
 ```ts routes/_middleware.ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
 interface State {
   data: string;
@@ -26,7 +26,7 @@ interface State {
 
 export async function handler(
   req: Request,
-  ctx: MiddlewareHandlerContext<State>,
+  ctx: FreshContext<State>,
 ) {
   ctx.state.data = "myData";
   const resp = await ctx.next();
@@ -100,9 +100,9 @@ It should be noted that `middleware` has access to route parameters. If you're
 running a fictitious `routes/[tenant]/admin/_middleware.ts` like this:
 
 ```ts routes/[tenant]/admin/_middleware.ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export async function handler(_req: Request, ctx: MiddlewareHandlerContext) {
+export async function handler(_req: Request, ctx: FreshContext) {
   const currentTenant = ctx.params.tenant;
   //do something with the tenant
   const resp = await ctx.next();
@@ -115,10 +115,12 @@ the value of `acme` in your middleware.
 
 ## Middleware Destination
 
-To set the stage for this section, `MiddlewareHandlerContext` looks like this:
+To set the stage for this section, let's focus on the part of `FreshContext`
+that looks like this:
 
 ```ts
-export interface MiddlewareHandlerContext<State = Record<string, unknown>> {
+export interface FreshContext<State = Record<string, unknown>> {
+  ...
   next: () => Promise<Response>;
   state: State;
   destination: router.DestinationKind;
@@ -127,6 +129,7 @@ export interface MiddlewareHandlerContext<State = Record<string, unknown>> {
     hostname: string;
     port: number;
   };
+  ...
 }
 ```
 
@@ -145,9 +148,9 @@ Initiate a new Fresh project (`deno run -A -r https://fresh.deno.dev/`) and then
 create a `_middleware.ts` file in the `routes` folder like this:
 
 ```ts routes/_middleware.ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export async function handler(req: Request, ctx: MiddlewareHandlerContext) {
+export async function handler(req: Request, ctx: FreshContext) {
   console.log(ctx.destination);
   console.log(req.url);
   const resp = await ctx.next();

--- a/docs/latest/concepts/partials.md
+++ b/docs/latest/concepts/partials.md
@@ -18,10 +18,10 @@ The quickest way to get started is to enable partials for every page in
 `routes/_app.tsx` by making the following changes.
 
 ```diff routes/_app.tsx
-  import { AppProps } from "$fresh/server.ts";
+  import { PageProps } from "$fresh/server.ts";
 + import { Partial } from "$fresh/runtime.ts";
 
-  export default function App({ Component }: AppProps) {
+  export default function App({ Component }: PageProps) {
     return (
       <html>
         <head>

--- a/docs/latest/examples/dealing-with-cors.md
+++ b/docs/latest/examples/dealing-with-cors.md
@@ -16,9 +16,9 @@ requests. You can CORS enable all the routes affected by some `middleware` by
 doing the following:
 
 ```ts routes/_middleware.ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export async function handler(req: Request, ctx: MiddlewareHandlerContext) {
+export async function handler(req: Request, ctx: FreshContext) {
   const origin = req.headers.get("Origin") || "*";
   const resp = await ctx.next();
   const headers = resp.headers;
@@ -45,9 +45,9 @@ deal with "preflight requests". Let's imagine you're trying to support a
 `DELETE` route. Then you'd need to do something like this:
 
 ```ts routes/_middleware.ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
-export async function handler(_req: Request, ctx: MiddlewareHandlerContext) {
+export async function handler(_req: Request, ctx: FreshContext) {
   if (_req.method == "OPTIONS") {
     const resp = new Response(null, {
       status: 204,

--- a/docs/latest/examples/handling-complex-routes.md
+++ b/docs/latest/examples/handling-complex-routes.md
@@ -17,10 +17,10 @@ Let's look at the example from the routing page more closely. We'll flesh out
 the handler so that we end up with something like the following:
 
 ```ts routes/x.tsx
-import { HandlerContext, RouteConfig } from "$fresh/server.ts";
+import { FreshContext, RouteConfig } from "$fresh/server.ts";
 
 export const handler = {
-  GET(_req: Request, { params }: HandlerContext) {
+  GET(_req: Request, { params }: FreshContext) {
     console.log(params);
     return new Response(params.path);
   },
@@ -48,10 +48,10 @@ show the following:
 Let's look at something a bit more complex:
 
 ```ts routes/api.tsx
-import { HandlerContext, RouteConfig } from "$fresh/server.ts";
+import { FreshContext, RouteConfig } from "$fresh/server.ts";
 
 export const handler = {
-  GET(_req: Request, { params }: HandlerContext) {
+  GET(_req: Request, { params }: FreshContext) {
     console.log(params);
     return new Response(params.path);
   },

--- a/docs/latest/examples/init-the-server.md
+++ b/docs/latest/examples/init-the-server.md
@@ -35,7 +35,7 @@ export default defineConfig({
 But what's going on in this new `_middleware.ts` we've created?
 
 ```ts routes/_middleware.ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
 export interface State {
   context: Context;
@@ -64,7 +64,7 @@ export class Context {
 
 export async function handler(
   _req: Request,
-  ctx: MiddlewareHandlerContext<State>,
+  ctx: FreshContext<State>,
 ) {
   ctx.state.context = Context.instance();
   if (ctx.destination === "route") {

--- a/docs/latest/examples/using-csp.md
+++ b/docs/latest/examples/using-csp.md
@@ -324,10 +324,10 @@ export const config: RouteConfig = {
 ```
 
 ```ts routes/reportHandler.ts
-import { HandlerContext } from "$fresh/server.ts";
+import { FreshContext } from "$fresh/server.ts";
 
 export const handler = {
-  async POST(req: Request, _ctx: HandlerContext) {
+  async POST(req: Request, _ctx: FreshContext) {
     const body = await req.json();
     const report = JSON.stringify(body, null, 2);
 


### PR DESCRIPTION
As per the [1.6 release](https://deno.com/blog/fresh-1.6#simplified-typings), and commentary by @csvn [here](https://github.com/denoland/fresh/issues/2108#issuecomment-1836625789), this PR aims to replace the references to deprecated typing in the documentation.

Please see inline commentary for parts I'm unclear on.