### PR TITLE
fix: use real 500 error page in dev mode

### DIFF
--- a/src/server/fs_extract.ts
+++ b/src/server/fs_extract.ts
@@ -227,16 +227,6 @@ export async function extractRoutes(
         name,
         component,
         handler: (req, ctx) => {
-          if (config.dev) {
-            const prevComp = error.component;
-            error.component = DefaultErrorHandler;
-            try {
-              return ctx.render();
-            } finally {
-              error.component = prevComp;
-            }
-          }
-
           return handler
             ? handler(req, ctx)
             : router.defaultErrorHandler(req, ctx, ctx.error);

--- a/src/server/fs_extract.ts
+++ b/src/server/fs_extract.ts
@@ -226,11 +226,7 @@ export async function extractRoutes(
         url,
         name,
         component,
-        handler: (req, ctx) => {
-          return handler
-            ? handler(req, ctx)
-            : router.defaultErrorHandler(req, ctx, ctx.error);
-        },
+        handler: handler ?? router.defaultErrorHandler,
         csp: Boolean(routeConfig?.csp ?? false),
         appWrapper: !routeConfig?.skipAppWrapper,
         inheritLayouts: !routeConfig?.skipInheritedLayouts,

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -359,9 +359,12 @@ export async function render<Data>(
     pluginRenderResults: renderResults,
   });
 
-  // Append error overlay
+  // Dev only: Append error overlay
   const devErrorUrl = withBase(DEV_ERROR_OVERLAY_URL, basePath);
-  if (error !== undefined && url.pathname !== devErrorUrl) {
+  if (
+    error !== undefined && url.pathname !== devErrorUrl &&
+    opts.context.config.dev
+  ) {
     const url = new URL(devErrorUrl, "https://localhost/");
     if (error instanceof Error) {
       let message = error.message;

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -82,10 +82,9 @@ export function defaultOtherHandler(_req: Request): Response {
 
 export function defaultErrorHandler(
   _req: Request,
-  _ctx: FreshContext,
-  err: unknown,
+  ctx: FreshContext,
 ): Response {
-  console.error(err);
+  console.error(ctx.error);
 
   return new Response(null, {
     status: 500,

--- a/tests/dev_command_test.ts
+++ b/tests/dev_command_test.ts
@@ -115,13 +115,13 @@ Deno.test("shows custom 500 page for rendering errors when not in dev", async (t
 });
 
 Deno.test("show codeframe in dev mode even with custom 500", async () => {
-  await withFakeServe(
-    "./tests/fixture_dev_codeframe/dev.ts",
-    async (server) => {
-      const doc = await server.getHtml(`/`);
-      assertSelector(doc, ".frsh-error-page");
-    },
-  );
+  // await withFakeServe(
+  //   "./tests/fixture_dev_codeframe/dev.ts",
+  //   async (server) => {
+  //     const doc = await server.getHtml(`/`);
+  //     assertSelector(doc, ".frsh-error-page");
+  //   },
+  // );
 
   await withFakeServe(
     "./tests/fixture_dev_codeframe/main.ts",

--- a/tests/dev_command_test.ts
+++ b/tests/dev_command_test.ts
@@ -2,7 +2,6 @@ import { assert, assertEquals, assertStringIncludes } from "./deps.ts";
 import { STATUS_CODE } from "../server.ts";
 import {
   assertNotSelector,
-  assertSelector,
   assertTextMany,
   assertTextMatch,
   fetchHtml,

--- a/tests/dev_command_test.ts
+++ b/tests/dev_command_test.ts
@@ -115,20 +115,19 @@ Deno.test("shows custom 500 page for rendering errors when not in dev", async (t
 });
 
 Deno.test("show codeframe in dev mode even with custom 500", async () => {
-  // await withFakeServe(
-  //   "./tests/fixture_dev_codeframe/dev.ts",
-  //   async (server) => {
-  //     const doc = await server.getHtml(`/`);
-  //     assertSelector(doc, ".frsh-error-page");
-  //   },
-  // );
+  await withFakeServe(
+    "./tests/fixture_dev_codeframe/dev.ts",
+    async (server) => {
+      const { title } = await getErrorOverlay(server, "/");
+      assertEquals(title, "fail");
+    },
+  );
 
   await withFakeServe(
     "./tests/fixture_dev_codeframe/main.ts",
     async (server) => {
-      const doc = await server.getHtml(`/`);
-      assertNotSelector(doc, ".frsh-error-page");
-      assertSelector(doc, "h1");
+      const doc = await server.getHtml("/");
+      assertNotSelector(doc, "#fresh-error-overlay");
     },
   );
 });

--- a/tests/error_test.ts
+++ b/tests/error_test.ts
@@ -7,7 +7,8 @@ Deno.test("error page rendered", async () => {
     const resp = await server.get("/");
     assertEquals(resp.status, STATUS_CODE.InternalServerError);
     assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
-    await resp.text(); // Consume
+    const body = await resp.text();
+    assertStringIncludes(body, "<p>500 page</p>");
 
     const { title, stack } = await getErrorOverlay(server, "/");
     assertStringIncludes(title, `boom!`);

--- a/tests/fixture_error/fresh.gen.ts
+++ b/tests/fixture_error/fresh.gen.ts
@@ -3,6 +3,7 @@
 // This file is automatically updated during development when running `dev.ts`.
 
 import * as $_all_ from "./routes/[...all].ts";
+import * as $_500 from "./routes/_500.tsx";
 import * as $index from "./routes/index.tsx";
 
 import { type Manifest } from "$fresh/server.ts";
@@ -10,6 +11,7 @@ import { type Manifest } from "$fresh/server.ts";
 const manifest = {
   routes: {
     "./routes/[...all].ts": $_all_,
+    "./routes/_500.tsx": $_500,
     "./routes/index.tsx": $index,
   },
   islands: {},

--- a/tests/fixture_error/routes/_500.tsx
+++ b/tests/fixture_error/routes/_500.tsx
@@ -1,0 +1,3 @@
+export default function Error500() {
+  return <p>500 page</p>;
+}


### PR DESCRIPTION
In #1978 it was said the "real" error page behind the error code frame should now be shown. But I don't think this  works correctly, as in dev-mode, the `DefaultErrorHandler` is always used over the real `_500.tsx` error page.

This solves part of #2131.