### PR TITLE
feat(tool): add a tool to release docs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -9,7 +9,8 @@
     "ok": "deno fmt --check && deno lint && deno task check:types && deno task test",
     "install-puppeteer": "PUPPETEER_PRODUCT=chrome deno run -A --unstable https://deno.land/x/puppeteer@16.2.0/install.ts && PUPPETEER_PRODUCT=firefox deno run -A --unstable https://deno.land/x/puppeteer@16.2.0/install.ts",
     "test:www": "deno test -A tests/www/",
-    "manifests": "deno run -A genAllManifest.ts"
+    "manifests": "deno run -A genAllManifest.ts",
+    "docs:release": "deno run -A tools/docs_release.ts"
   },
   "exclude": [
     "**/_fresh/*",

--- a/docs/toc.ts
+++ b/docs/toc.ts
@@ -72,7 +72,7 @@ const toc: RawTableOfContents = {
         title: "Examples",
         link: "latest",
         pages: [
-          ["migrating-to-tailwind", "Migrating to Tailwind", "link:canary"],
+          ["migrating-to-tailwind", "Migrating to Tailwind", "link:latest"],
           ["modifying-the-head", "Modifying the <head>", "link:latest"],
           ["writing-tests", "Writing tests", "link:latest"],
           [

--- a/tools/docs_release.ts
+++ b/tools/docs_release.ts
@@ -1,0 +1,107 @@
+import { walk } from "https://deno.land/std@0.208.0/fs/mod.ts";
+import {
+  ArrayLiteralExpression,
+  ObjectLiteralElementLike,
+  ObjectLiteralExpression,
+  Project,
+  PropertyAssignment,
+  ResolutionHosts,
+  SyntaxKind,
+} from "https://deno.land/x/ts_morph@20.0.0/mod.ts";
+
+async function main() {
+  // copy canary docs over to latest and delete
+  for await (const entry of walk("./docs/canary")) {
+    if (entry.isFile) {
+      if (entry.path === "docs/canary/the-canary-version/index.md") {
+        continue;
+      }
+      const destPath = entry.path.replace("/canary/", "/latest/");
+      await Deno.copyFile(entry.path, destPath);
+      await Deno.remove(entry.path);
+    }
+  }
+
+  // modify toc.ts
+  await modifyTOCFile();
+}
+
+async function modifyTOCFile(): Promise<void> {
+  const project = new Project({
+    resolutionHost: ResolutionHosts.deno,
+  });
+  const tocTs = project.addSourceFileAtPath("./docs/toc.ts");
+  const tocObject = tocTs.getVariableDeclarationOrThrow("toc")
+    .getInitializerIfKindOrThrow(SyntaxKind.ObjectLiteralExpression);
+
+  const canaryObject = getInitializerFromProperty<ObjectLiteralExpression>(
+    tocObject,
+    "canary",
+    SyntaxKind.ObjectLiteralExpression,
+  );
+  const contentObject = getInitializerFromProperty<ObjectLiteralExpression>(
+    canaryObject,
+    "content",
+    SyntaxKind.ObjectLiteralExpression,
+  );
+  updateLinksInContentObject(contentObject);
+
+  await Deno.writeTextFile("./docs/toc.ts", tocTs.getFullText());
+}
+
+function getInitializerFromProperty<T extends ObjectLiteralExpression>(
+  parentObject: ObjectLiteralExpression,
+  propertyName: string,
+  kind: SyntaxKind,
+): T {
+  const property = parentObject.getPropertyOrThrow(propertyName);
+  if (!PropertyAssignment.isPropertyAssignment(property)) {
+    throw new Error(`'${propertyName}' is not a PropertyAssignment.`);
+  }
+  return property.getInitializerIfKindOrThrow(kind) as T;
+}
+
+function updateLinksInContentObject(contentObject: ObjectLiteralExpression) {
+  contentObject.getProperties().forEach((subsectionProperty) => {
+    const pagesArray = getPagesArrayFromSubsection(subsectionProperty);
+    if (pagesArray) {
+      updateLinksInPagesArray(pagesArray);
+    }
+  });
+}
+
+function getPagesArrayFromSubsection(
+  subsectionElement: ObjectLiteralElementLike,
+) {
+  if (PropertyAssignment.isPropertyAssignment(subsectionElement)) {
+    const subsectionObject = subsectionElement.getInitializerIfKindOrThrow(
+      SyntaxKind.ObjectLiteralExpression,
+    );
+    const pagesProperty = subsectionObject.getProperty("pages");
+    if (
+      pagesProperty && PropertyAssignment.isPropertyAssignment(pagesProperty)
+    ) {
+      return pagesProperty.getInitializerIfKindOrThrow(
+        SyntaxKind.ArrayLiteralExpression,
+      );
+    }
+  }
+  return undefined;
+}
+
+function updateLinksInPagesArray(pagesArray: ArrayLiteralExpression) {
+  pagesArray.getElements().forEach((element) => {
+    const tuple = element.asKind(SyntaxKind.ArrayLiteralExpression);
+    if (tuple && tuple.getElements().length >= 3) {
+      const linkElement = tuple.getElements()[2];
+      if (
+        linkElement.getKind() === SyntaxKind.StringLiteral &&
+        linkElement.getText() === '"link:canary"'
+      ) {
+        linkElement.replaceWithText('"link:latest"');
+      }
+    }
+  });
+}
+
+main();


### PR DESCRIPTION
After playing around with ts-morph in #2088 (the ts-morph part eventually got removed), I wanted to continue trying it out. Here's a tool that should make the release process slightly easier. It does three things:
1. copy canary docs to latest
2. deletes canary docs
3. update the toc.ts

There's possibly an easier way to do, so please let me know. But a bit of learning is never a bad thing, and I think the end result is pretty slick. Here's how I tested this:

```
git checkout 0c3dc04 (the primary commit here)
git reset HEAD^
git checkout bd372b9 (right before 1.6.0 was released)
git add . (just to get these changes out of the working directory)
deno task docs:release
git status
```

So then I have a nice diff showing what would have happened if you used this to release the docs last week. Except this shows there's actually a small bug (I think!) in `toc.ts` right now.
https://github.com/denoland/fresh/blob/c72f534369d6ddcc6e35f69c57b2407a879eeb53/docs/toc.ts#L75 should be at `latest` instead of `canary`.