### PR TITLE
fix: switch back to URLPattern for correctness

### DIFF
--- a/src/server/compose.ts
+++ b/src/server/compose.ts
@@ -56,7 +56,7 @@ export function composeMiddlewares(
   middlewares: MiddlewareRoute[],
   errorHandler: ErrorHandler,
   paramsAndRoute: (
-    url: string,
+    url: URL,
   ) => RouteResult,
   renderNotFound: UnknownRenderFunction,
   basePath: string,
@@ -67,7 +67,7 @@ export function composeMiddlewares(
     inner: FinalHandler,
   ) => {
     const handlers: (() => Response | Promise<Response>)[] = [];
-    const paramsAndRouteResult = paramsAndRoute(req.url);
+    const paramsAndRouteResult = paramsAndRoute(ctx.url);
     ctx.params = paramsAndRouteResult.params;
 
     // identify middlewares to apply, if any.

--- a/src/server/router_test.ts
+++ b/src/server/router_test.ts
@@ -1,42 +1,5 @@
 import { assertEquals } from "./deps.ts";
-import { IS_PATTERN, patternToRegExp } from "./router.ts";
-
-function testPattern(input: string, test: string) {
-  const regex = patternToRegExp(input);
-  const match = test.match(regex);
-  return (match !== null) ? match.groups ?? {} : null;
-}
-
-Deno.test("pathToRegexp", () => {
-  assertEquals(testPattern("/:path", "/foo"), { path: "foo" });
-  assertEquals(testPattern("/:path", "/foo/bar"), null);
-  assertEquals(testPattern("/:path/bar", "/foo/bar"), { path: "foo" });
-  assertEquals(testPattern("/foo/:path", "/foo/bar"), { path: "bar" });
-  assertEquals(testPattern("/foo/:path", "/foo"), null);
-  assertEquals(testPattern("/foo/*", "/foo/asd/asdh/"), {});
-  assertEquals(testPattern("/foo{/bar}?", "/foo"), {});
-  assertEquals(testPattern("/foo{/bar}?", "/foo/bar"), {});
-  assertEquals(testPattern("/foo/(\\d+)", "/foo"), null);
-  assertEquals(testPattern("/foo/(\\d+)", "/foo/1"), {});
-  assertEquals(testPattern("/foo/(\\d+)", "/foo/11231"), {});
-  assertEquals(testPattern("/foo/(bar)", "/foo/bar"), {});
-  assertEquals(testPattern("/foo/:path*", "/foo/bar/asdf"), {
-    path: "bar/asdf",
-  });
-  assertEquals(testPattern("/movies/:foo@:bar", "/movies/asdf@hehe"), {
-    foo: "asdf",
-    bar: "hehe",
-  });
-  assertEquals(
-    testPattern(
-      "{/:lang(fr|es|pt-BR)}?/cs2-server-status",
-      "/fr/cs2-server-status",
-    ),
-    {
-      lang: "fr",
-    },
-  );
-});
+import { IS_PATTERN } from "./router.ts";
 
 Deno.test("IS_PATTERN", () => {
   assertEquals(IS_PATTERN.test("/foo"), false);

--- a/www/components/gallery/Footer.tsx
+++ b/www/components/gallery/Footer.tsx
@@ -1,11 +1,7 @@
-import { ComponentChildren } from "preact";
 import LemonIcon from "https://deno.land/x/tabler_icons_tsx@0.0.3/tsx/lemon-2.tsx";
 import BrandGithub from "https://deno.land/x/tabler_icons_tsx@0.0.3/tsx/brand-github.tsx";
-type Props = {
-  children: ComponentChildren;
-};
 
-export default function Footer({ children }: Props) {
+export default function Footer() {
   const menus = [
     {
       title: "Documentation",

--- a/www/islands/ComponentGallery.tsx
+++ b/www/islands/ComponentGallery.tsx
@@ -106,8 +106,7 @@ export default function ComponentGallery(props: ComponentGalleryProps) {
       </Section>
 
       <Section title="Footer" source={props.sources.Footer}>
-        <Footer>
-        </Footer>
+        <Footer />
       </Section>
 
       <Section title="Hero" source={props.sources.Hero}>


### PR DESCRIPTION
Whilst our regex variant is much faster it was lacking support for many valid patterns. Adding support for these is certainly doable but would take a while, so I've decided to revert that change for now in the name of correctness.