### PR TITLE
fix: init app use same width numbers

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -204,7 +204,7 @@ export default function Counter(props: CounterProps) {
   return (
     <div class="flex gap-8 py-6">
       <Button onClick={() => props.count.value -= 1}>-1</Button>
-      <p class="text-3xl">{props.count}</p>
+      <p class="text-3xl tabular-nums">{props.count}</p>
       <Button onClick={() => props.count.value += 1}>+1</Button>
     </div>
   );
@@ -440,6 +440,9 @@ html {
 }
 .hover\\:bg-gray-200:hover {
   background-color: #e5e7eb;
+}
+.tabular-nums {
+  font-variant-numeric: tabular-nums;
 }
 `;
 


### PR DESCRIPTION
This fixes buttons jumping a little around when the number in the counter changes.