### PR TITLE
feat: Use `@/` by default to allow absolute path specification.

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -153,7 +153,7 @@ CMD ["run", "-A", "main.ts"]
 }
 
 const ROUTES_INDEX_TSX = `import { useSignal } from "@preact/signals";
-import Counter from "../islands/Counter.tsx";
+import Counter from "@/islands/Counter.tsx";
 
 export default function Home() {
   const count = useSignal(3);
@@ -194,7 +194,7 @@ export function Button(props: JSX.HTMLAttributes<HTMLButtonElement>) {
 `;
 
 const ISLANDS_COUNTER_TSX = `import type { Signal } from "@preact/signals";
-import { Button } from "../components/Button.tsx";
+import { Button } from "@/components/Button.tsx";
 
 interface CounterProps {
   count: Signal<number>;

--- a/src/dev/imports.ts
+++ b/src/dev/imports.ts
@@ -14,7 +14,7 @@ export function freshImports(imports: Record<string, string>) {
   imports["@preact/signals-core"] =
     `https://esm.sh/*@preact/signals-core@${RECOMMENDED_PREACT_SIGNALS_CORE_VERSION}`;
 
-  imports["@/"] = "./"
+  imports["@/"] = "./";
 }
 
 export function twindImports(imports: Record<string, string>) {

--- a/src/dev/imports.ts
+++ b/src/dev/imports.ts
@@ -13,6 +13,8 @@ export function freshImports(imports: Record<string, string>) {
     `https://esm.sh/*@preact/signals@${RECOMMENDED_PREACT_SIGNALS_VERSION}`;
   imports["@preact/signals-core"] =
     `https://esm.sh/*@preact/signals-core@${RECOMMENDED_PREACT_SIGNALS_CORE_VERSION}`;
+
+  imports["@/"] = "../"
 }
 
 export function twindImports(imports: Record<string, string>) {

--- a/src/dev/imports.ts
+++ b/src/dev/imports.ts
@@ -14,7 +14,7 @@ export function freshImports(imports: Record<string, string>) {
   imports["@preact/signals-core"] =
     `https://esm.sh/*@preact/signals-core@${RECOMMENDED_PREACT_SIGNALS_CORE_VERSION}`;
 
-  imports["@/"] = "../"
+  imports["@/"] = "./"
 }
 
 export function twindImports(imports: Record<string, string>) {


### PR DESCRIPTION
Use `@/` by default to allow absolute path specification.
This is expected to improve the outlook for dependencies between components.

You should be able to count on this EXAMPLE
```tsx
// routes/orgs/[name].tsx
import OrgProfile from "../../islands/orgs/profile.tsx"

export default function OrgsProfile() {
    return ....
}
```

If absolute paths are possible

```tsx
// routes/orgs/[name].tsx
import OrgProfile from "@/islands/orgs/profile.tsx"

export default function OrgsProfile() {
    return ....
}
```

beautiful : )