### PR TITLE
fix: `.vscode/tailwind.json` generation

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -683,7 +683,7 @@ const TAILWIND_CUSTOMDATA = `{
     },
     {
       "name": "@responsive",
-      "description": "You can generate responsive variants of your own classes by wrapping their definitions in the \`@responsive\` directive:\\n\`\`\`css\n@responsive {\\n  .alert {\n    background-color: #E53E3E;\\n  }\\n}\\n\`\`\`\\n",
+      "description": "You can generate responsive variants of your own classes by wrapping their definitions in the \`@responsive\` directive:\\n\`\`\`css\\n@responsive {\\n  .alert {\n    background-color: #E53E3E;\\n  }\\n}\\n\`\`\`\\n",
       "references": [
         {
           "name": "Tailwind Documentation",

--- a/init.ts
+++ b/init.ts
@@ -658,62 +658,70 @@ if (useVSCode) {
   );
 }
 
-const TAILWIND_CUSTOMDATA = `{
+const tailwindCustomData = {
   "version": 1.1,
   "atDirectives": [
     {
       "name": "@tailwind",
-      "description": "Use the \`@tailwind\` directive to insert Tailwind's \`base\`, \`components\`, \`utilities\` and \`screens\` styles into your CSS.",
+      "description":
+        "Use the `@tailwind` directive to insert Tailwind's `base`, `components`, `utilities` and `screens` styles into your CSS.",
       "references": [
         {
           "name": "Tailwind Documentation",
-          "url": "https://tailwindcss.com/docs/functions-and-directives#tailwind"
-        }
-      ]
+          "url":
+            "https://tailwindcss.com/docs/functions-and-directives#tailwind",
+        },
+      ],
     },
     {
       "name": "@apply",
-      "description": "Use the \`@apply\` directive to inline any existing utility classes into your own custom CSS. This is useful when you find a common utility pattern in your HTML that you’d like to extract to a new component.",
+      "description":
+        "Use the `@apply` directive to inline any existing utility classes into your own custom CSS. This is useful when you find a common utility pattern in your HTML that you’d like to extract to a new component.",
       "references": [
         {
           "name": "Tailwind Documentation",
-          "url": "https://tailwindcss.com/docs/functions-and-directives#apply"
-        }
-      ]
+          "url": "https://tailwindcss.com/docs/functions-and-directives#apply",
+        },
+      ],
     },
     {
       "name": "@responsive",
-      "description": "You can generate responsive variants of your own classes by wrapping their definitions in the \`@responsive\` directive:\\n\`\`\`css\\n@responsive {\\n  .alert {\\n    background-color: #E53E3E;\\n  }\\n}\\n\`\`\`\\n",
+      "description":
+        "You can generate responsive variants of your own classes by wrapping their definitions in the `@responsive` directive:\n```css\n@responsive {\n  .alert {\n    background-color: #E53E3E;\n  }\n}\n```\n",
       "references": [
         {
           "name": "Tailwind Documentation",
-          "url": "https://tailwindcss.com/docs/functions-and-directives#responsive"
-        }
-      ]
+          "url":
+            "https://tailwindcss.com/docs/functions-and-directives#responsive",
+        },
+      ],
     },
     {
       "name": "@screen",
-      "description": "The \`@screen\` directive allows you to create media queries that reference your breakpoints by **name** instead of duplicating their values in your own CSS:\\n\`\`\`css\\n@screen sm {\\n  /* ... */\\n}\\n\`\`\`\\n…gets transformed into this:\\n\`\`\`css\\n@media (min-width: 640px) {\\n  /* ... */\\n}\\n\`\`\`\\n",
+      "description":
+        "The `@screen` directive allows you to create media queries that reference your breakpoints by **name** instead of duplicating their values in your own CSS:\n```css\n@screen sm {\n  /* ... */\n}\n```\n…gets transformed into this:\n```css\n@media (min-width: 640px) {\n  /* ... */\n}\n```\n",
       "references": [
         {
           "name": "Tailwind Documentation",
-          "url": "https://tailwindcss.com/docs/functions-and-directives#screen"
-        }
-      ]
+          "url": "https://tailwindcss.com/docs/functions-and-directives#screen",
+        },
+      ],
     },
     {
       "name": "@variants",
-      "description": "Generate \`hover\`, \`focus\`, \`active\` and other **variants** of your own utilities by wrapping their definitions in the \`@variants\` directive:\\n\`\`\`css\\n@variants hover, focus {\\n   .btn-brand {\\n    background-color: #3182CE;\\n  }\\n}\\n\`\`\`\\n",
+      "description":
+        "Generate `hover`, `focus`, `active` and other **variants** of your own utilities by wrapping their definitions in the `@variants` directive:\n```css\n@variants hover, focus {\n   .btn-brand {\n    background-color: #3182CE;\n  }\n}\n```\n",
       "references": [
         {
           "name": "Tailwind Documentation",
-          "url": "https://tailwindcss.com/docs/functions-and-directives#variants"
-        }
-      ]
-    }
-  ]
-}
-`;
+          "url":
+            "https://tailwindcss.com/docs/functions-and-directives#variants",
+        },
+      ],
+    },
+  ],
+};
+const TAILWIND_CUSTOMDATA = JSON.stringify(tailwindCustomData, null, 2) + "\n";
 
 if (useVSCode && useTailwind) {
   await Deno.writeTextFile(

--- a/init.ts
+++ b/init.ts
@@ -693,7 +693,7 @@ const TAILWIND_CUSTOMDATA = `{
     },
     {
       "name": "@screen",
-      "description": "The \`@screen\` directive allows you to create media queries that reference your breakpoints by **name** instead of duplicating their values in your own CSS:\\n\`\`\`css\n@screen sm {\\n  /* ... */\\n}\\n\`\`\`\\n…gets transformed into this:\\n\`\`\`css\n@media (min-width: 640px) {\\n  /* ... */\\n}\\n\`\`\`\\n",
+      "description": "The \`@screen\` directive allows you to create media queries that reference your breakpoints by **name** instead of duplicating their values in your own CSS:\\n\`\`\`css\\n@screen sm {\\n  /* ... */\\n}\\n\`\`\`\\n…gets transformed into this:\\n\`\`\`css\\n@media (min-width: 640px) {\\n  /* ... */\\n}\\n\`\`\`\\n",
       "references": [
         {
           "name": "Tailwind Documentation",
@@ -703,7 +703,7 @@ const TAILWIND_CUSTOMDATA = `{
     },
     {
       "name": "@variants",
-      "description": "Generate \`hover\`, \`focus\`, \`active\` and other **variants** of your own utilities by wrapping their definitions in the \`@variants\` directive:\\n\`\`\`css\n@variants hover, focus {\\n   .btn-brand {\\n    background-color: #3182CE;\\n  }\\n}\\n\`\`\`\\n",
+      "description": "Generate \`hover\`, \`focus\`, \`active\` and other **variants** of your own utilities by wrapping their definitions in the \`@variants\` directive:\\n\`\`\`css\\n@variants hover, focus {\\n   .btn-brand {\\n    background-color: #3182CE;\\n  }\\n}\\n\`\`\`\\n",
       "references": [
         {
           "name": "Tailwind Documentation",

--- a/init.ts
+++ b/init.ts
@@ -683,7 +683,7 @@ const TAILWIND_CUSTOMDATA = `{
     },
     {
       "name": "@responsive",
-      "description": "You can generate responsive variants of your own classes by wrapping their definitions in the \`@responsive\` directive:\\n\`\`\`css\\n@responsive {\\n  .alert {\n    background-color: #E53E3E;\\n  }\\n}\\n\`\`\`\\n",
+      "description": "You can generate responsive variants of your own classes by wrapping their definitions in the \`@responsive\` directive:\\n\`\`\`css\\n@responsive {\\n  .alert {\\n    background-color: #E53E3E;\\n  }\\n}\\n\`\`\`\\n",
       "references": [
         {
           "name": "Tailwind Documentation",


### PR DESCRIPTION
Fixes #2184

Is there any reason for this not being `JSON.stringify({ ... that object ... })` and avoid a lat of escaping?