### PR TITLE
docs: fix typo in active links introduction

### DIFF
--- a/docs/latest/examples/active-links.md
+++ b/docs/latest/examples/active-links.md
@@ -3,7 +3,7 @@ description: |
   Style active links with ease in Fresh
 ---
 
-Fresh automatically enhances the accessibility of <a> elements by adding the
+Fresh automatically enhances the accessibility of `<a>` elements by adding the
 aria-current attribute when rendering links that match the current URL. This
 attribute is recognized by assistive technologies and clearly indicates the
 current page within a set of pages.


### PR DESCRIPTION
Fixes an `<a>` in the active link markdown from being interpreted as an actual link, rather than part of the text.

Before:

![](https://github.com/denoland/fresh/assets/1732331/fa5665f8-deed-439f-b6de-4589b494edd7)

Before with rogue anchor element in hover state:

![](https://github.com/denoland/fresh/assets/1732331/e6b286d6-e76a-4def-8446-ec0f8752967a)


After:
![](https://github.com/denoland/fresh/assets/1732331/1f441b30-871e-4076-837e-1cf5e64a82b0)

