### PR TITLE
docs: fix deprecated type usage in example code

### DIFF
--- a/docs/latest/concepts/routes.md
+++ b/docs/latest/concepts/routes.md
@@ -26,10 +26,10 @@ the handler's `render` function.
 Let's look at a basic route that returns a plain text string:
 
 ```tsx routes/plain.tsx
-import { HandlerContext, Handlers } from "$fresh/server.ts";
+import { FreshContext, Handlers } from "$fresh/server.ts";
 
 export const handler: Handlers = {
-  GET(_req: Request, _ctx: HandlerContext) {
+  GET(_req: Request, _ctx: FreshContext) {
     return new Response("Hello World");
   },
 };


### PR DESCRIPTION
Fixes deprecated example in docs.

<img width="760" alt="image" src="https://github.com/denoland/fresh/assets/6600962/1e239f0f-0798-4ca0-b84d-d4266b6dfc31">
