### PR TITLE
refactor: use `--env` CLI arg

### DIFF
--- a/demo/deno.json
+++ b/demo/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": false,
   "tasks": {
-    "start": "deno run -A --watch=static/,routes/ dev.ts"
+    "start": "deno run -A --watch=static/,routes/ --env dev.ts"
   },
   "imports": {
     "$fresh/": "../",

--- a/docs/latest/examples/changing-the-src-dir.md
+++ b/docs/latest/examples/changing-the-src-dir.md
@@ -44,8 +44,8 @@ Here's what the diff of `deno.json` looks like:
  {
    "lock": false,
    "tasks": {
--    "start": "deno run -A --watch=static/,routes/ dev.ts"
-+    "start": "deno run -A --watch=src/static/,src/routes/ src/dev.ts"
+-    "start": "deno run -A --watch=static/,routes/ --env dev.ts"
++    "start": "deno run -A --watch=src/static/,src/routes/ --env src/dev.ts"
    },
    "imports": {
      "$fresh/": "file:///Users/reed/code/fresh/",

--- a/docs/latest/examples/using-twind-v1.md
+++ b/docs/latest/examples/using-twind-v1.md
@@ -13,8 +13,6 @@ you'll end up with a `main.ts` like the following:
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 
-import "$std/dotenv/load.ts";
-
 import { start } from "$fresh/server.ts";
 import manifest from "./fresh.gen.ts";
 import config from "./fresh.config.ts";

--- a/init.ts
+++ b/init.ts
@@ -523,8 +523,6 @@ let MAIN_TS = `/// <reference no-default-lib="true" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 
-import "$std/dotenv/load.ts";
-
 import { start } from "$fresh/server.ts";
 import manifest from "./fresh.gen.ts";
 import config from "./fresh.config.ts";
@@ -539,8 +537,6 @@ const DEV_TS = `#!/usr/bin/env -S deno run -A --watch=static/,routes/
 
 import dev from "$fresh/dev.ts";
 import config from "./fresh.config.ts";
-
-import "$std/dotenv/load.ts";
 
 await dev(import.meta.url, "./main.ts", config);
 `;
@@ -559,7 +555,7 @@ const config = {
       "deno fmt --check && deno lint && deno check **/*.ts && deno check **/*.tsx",
     cli: "echo \"import '\\$fresh/src/dev/cli.ts'\" | deno run --unstable -A -",
     manifest: "deno task cli manifest $(pwd)",
-    start: "deno run -A --watch=static/,routes/ dev.ts",
+    start: "deno run -A --watch=static/,routes/ --env dev.ts",
     build: "deno run -A dev.ts build",
     preview: "deno run -A main.ts",
     update: "deno run -A -r https://fresh.deno.dev/update .",

--- a/tests/fixture_base_path/deno.json
+++ b/tests/fixture_base_path/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": false,
   "tasks": {
-    "start": "deno run -A --watch=static/,routes/ dev.ts"
+    "start": "deno run -A --watch=static/,routes/ --env dev.ts"
   },
   "imports": {
     "$fresh/": "../../",

--- a/tests/fixture_island_nesting/deno.json
+++ b/tests/fixture_island_nesting/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": false,
   "tasks": {
-    "start": "deno run -A --watch=static/,routes/ dev.ts"
+    "start": "deno run -A --watch=static/,routes/ --env dev.ts"
   },
   "imports": {
     "$fresh/": "../../",

--- a/tests/fixture_partials/deno.json
+++ b/tests/fixture_partials/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": false,
   "tasks": {
-    "start": "deno run -A --watch=static/,routes/ dev.ts"
+    "start": "deno run -A --watch=static/,routes/ --env dev.ts"
   },
   "imports": {
     "$fresh/": "../../",

--- a/tests/fixture_route_analysis/deno.json
+++ b/tests/fixture_route_analysis/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": false,
   "tasks": {
-    "start": "deno run -A --watch=static/,routes/ dev.ts",
+    "start": "deno run -A --watch=static/,routes/ --env dev.ts",
     "update": "deno run -A -r https://fresh.deno.dev/update ."
   },
   "imports": {

--- a/tests/fixture_route_analysis/main.ts
+++ b/tests/fixture_route_analysis/main.ts
@@ -4,8 +4,6 @@
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 
-import "$std/dotenv/load.ts";
-
 import { start } from "$fresh/server.ts";
 import manifest from "./fresh.gen.ts";
 

--- a/tests/fixture_server_components/deno.json
+++ b/tests/fixture_server_components/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": false,
   "tasks": {
-    "start": "deno run -A --watch=static/,routes/ dev.ts"
+    "start": "deno run -A --watch=static/,routes/ --env dev.ts"
   },
   "imports": {
     "$fresh/": "../../",

--- a/tests/fixture_twind_app/deno.json
+++ b/tests/fixture_twind_app/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": false,
   "tasks": {
-    "start": "deno run -A --watch=static/,routes/ dev.ts"
+    "start": "deno run -A --watch=static/,routes/ --env dev.ts"
   },
   "imports": {
     "$fresh/": "../../",

--- a/tests/fixture_twind_hydrate/deno.json
+++ b/tests/fixture_twind_hydrate/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": false,
   "tasks": {
-    "start": "deno run -A --watch=static/,routes/ dev.ts"
+    "start": "deno run -A --watch=static/,routes/ --env dev.ts"
   },
   "imports": {
     "$fresh/": "../../",

--- a/tests/init_test.ts
+++ b/tests/init_test.ts
@@ -406,7 +406,7 @@ Deno.test({
 
     await t.step("start up the server", async () => {
       const { serverProcess, lines, address } = await startFreshServer({
-        args: ["run", "-A", "--no-check", "dev.ts"],
+        args: ["task", "start"],
         cwd: tmpDirName,
       });
 

--- a/tests/init_test.ts
+++ b/tests/init_test.ts
@@ -406,7 +406,7 @@ Deno.test({
 
     await t.step("start up the server", async () => {
       const { serverProcess, lines, address } = await startFreshServer({
-        args: ["task", "start"],
+        args: ["run", "-A", "--no-check", "--env", "dev.ts"],
         cwd: tmpDirName,
       });
 
@@ -433,7 +433,7 @@ Deno.test({
       }).output();
 
       const { serverProcess, lines, address, output } = await startFreshServer({
-        args: ["run", "-A", "--no-check", "main.ts"],
+        args: ["run", "-A", "--no-check", "--env", "main.ts"],
         cwd: tmpDirName,
       });
 

--- a/www/deno.json
+++ b/www/deno.json
@@ -2,7 +2,7 @@
   "lock": false,
   "nodeModulesDir": true,
   "tasks": {
-    "start": "deno run -A --watch=static/,routes/,../src,../docs dev.ts",
+    "start": "deno run -A --watch=static/,routes/,../src,../docs --env dev.ts",
     "build": "deno run -A dev.ts build",
     "preview": "deno run -A main.ts"
   },


### PR DESCRIPTION
This change replaces the use of the Standard Library's `dotenv.load()` with the native `--env` CLI flag.

The benefits include:
* One less dependency
* More obvious consumption of the `.env` file in the CLI output