### PR TITLE
fix: add note about viewport meta when migrating to Tailwind

### DIFF
--- a/docs/latest/examples/migrating-to-tailwind.md
+++ b/docs/latest/examples/migrating-to-tailwind.md
@@ -59,6 +59,10 @@ export default {
   }
 ```
 
+**Note:** Be sure
+`<meta name="viewport" content="width=device-width, initial-scale=1.0" />` is
+set in your head. This was previously set by twind automatically.
+
 4. Replace the `twind` plugin with `tailwind`
 
 ```diff fresh.config.ts


### PR DESCRIPTION
The purpose of this PR is to add a note about setting the `<meta name="viewport" content="width=device-width, initial-scale=1.0" />` in the `<head>` when migrating to Tailwind from Twind. This took me a while to figure out.