### PR TITLE
feat: improve tailwind deployment flow

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -308,10 +308,50 @@ export default {
   ],
 } satisfies Config;
 `;
+const AOT_GH_ACTION = `name: Deploy
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: main
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # Needed for auth with Deno Deploy
+      contents: read # Needed to clone the repository
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Install Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Build step
+        run: "deno task build" # 📝 Update the build command(s) if necessary
+
+      - name: Upload to Deno Deploy
+        uses: denoland/deployctl@v1
+        with:
+          project: "example-project" # 📝 Update the deploy project name if necessary
+          entrypoint: "./main.ts" # 📝 Update the entrypoint if necessary
+`;
 if (useTailwind) {
   await Deno.writeTextFile(
     join(resolvedDirectory, "tailwind.config.ts"),
     TAILWIND_CONFIG_TS,
+  );
+  const ghWorkflowDir = join(resolvedDirectory, ".github", "workflows");
+  await Deno.mkdir(ghWorkflowDir, { recursive: true });
+  await Deno.writeTextFile(
+    join(ghWorkflowDir, "deploy.yml"),
+    AOT_GH_ACTION,
   );
 }
 

--- a/init.ts
+++ b/init.ts
@@ -2,6 +2,7 @@ import { basename, colors, join, parse, resolve } from "./src/dev/deps.ts";
 import { error } from "./src/dev/error.ts";
 import { collect, ensureMinDenoVersion, generate } from "./src/dev/mod.ts";
 import {
+  AOT_GH_ACTION,
   dotenvImports,
   freshImports,
   tailwindImports,
@@ -307,40 +308,6 @@ export default {
     "{routes,islands,components}/**/*.{ts,tsx}",
   ],
 } satisfies Config;
-`;
-const AOT_GH_ACTION = `name: Deploy
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: main
-
-jobs:
-  deploy:
-    name: Deploy
-    runs-on: ubuntu-latest
-
-    permissions:
-      id-token: write # Needed for auth with Deno Deploy
-      contents: read # Needed to clone the repository
-
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
-      - name: Install Deno
-        uses: denoland/setup-deno@v1
-        with:
-          deno-version: v1.x
-
-      - name: Build step
-        run: "deno task build" # 📝 Update the build command(s) if necessary
-
-      - name: Upload to Deno Deploy
-        uses: denoland/deployctl@v1
-        with:
-          project: "example-project" # 📝 Update the deploy project name if necessary
-          entrypoint: "./main.ts" # 📝 Update the entrypoint if necessary
 `;
 if (useTailwind) {
   await Deno.writeTextFile(

--- a/src/dev/imports.ts
+++ b/src/dev/imports.ts
@@ -31,3 +31,38 @@ export function tailwindImports(imports: Record<string, string>) {
 export function dotenvImports(imports: Record<string, string>) {
   imports["$std/"] = `https://deno.land/std@${RECOMMENDED_STD_VERSION}/`;
 }
+
+export const AOT_GH_ACTION = `name: Deploy
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: main
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # Needed for auth with Deno Deploy
+      contents: read # Needed to clone the repository
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Install Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Build step
+        run: "deno task build" # 📝 Update the build command(s) if necessary
+
+      - name: Upload to Deno Deploy
+        uses: denoland/deployctl@v1
+        with:
+          project: "example-project" # 📝 Update the deploy project name if necessary
+          entrypoint: "./main.ts" # 📝 Update the entrypoint if necessary
+`;

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -125,6 +125,7 @@ export async function getInternalFreshState(
     config: internalConfig,
     manifest,
     loadSnapshot: !isLegacyDev && !config.dev,
+    didLoadSnapshot: false,
     denoJsonPath,
     denoJson,
     build: false,

--- a/src/server/tailwind_aot_error_page.tsx
+++ b/src/server/tailwind_aot_error_page.tsx
@@ -10,10 +10,7 @@ export default function TailwindErrorPage() {
         <p style="line-height: 1.6;margin-bottom: 1rem;">
           The <b>tailwindcss</b>{" "}
           plugin requires ahead of time builds to be set up for production
-          usage. To resolve this error{" "}
-          <a href={LINK}>
-            set up ahead of time builds
-          </a>.
+          usage. To finish the setup, follow these steps:
         </p>
         <ol style="line-height: 1.6; margin-bottom: 1.5rem">
           <li>

--- a/src/server/tailwind_aot_error_page.tsx
+++ b/src/server/tailwind_aot_error_page.tsx
@@ -1,0 +1,83 @@
+import { AOT_GH_ACTION } from "../dev/imports.ts";
+
+const LINK = "https://fresh.deno.dev/docs/concepts/ahead-of-time-builds";
+
+export default function TailwindErrorPage() {
+  return (
+    <div class="frsh-error-page">
+      <div style="max-width: 48rem; padding: 2rem 1rem; margin: 0 auto; font-family: sans-serif">
+        <h1>Finish setting up Fresh</h1>
+        <p style="line-height: 1.6;margin-bottom: 1rem;">
+          The <b>tailwindcss</b>{" "}
+          plugin requires ahead of time builds to be set up for production
+          usage. To resolve this error{" "}
+          <a href={LINK}>
+            set up ahead of time builds
+          </a>.
+        </p>
+        <ol style="line-height: 1.6; margin-bottom: 1.5rem">
+          <li>
+            Go to your project in Deno Deploy and click the{" "}
+            <code>Settings</code> tab.
+          </li>
+          <li>
+            Set Git-Integration to <code>GitHub Action</code>.<br />
+            <i style="display: block; font-style: italic; color: gray;">
+              Unlink the repository first if it is already linked via{"  "}
+              <code>Automatic</code> and re-link it again.
+            </i>
+          </li>
+          <li>
+            Add the file <code>.github/workflows/deploy.yml</code>{" "}
+            to your repository with the following contents:<br />
+            <span style="background: #f0f0f0;display: block; position: relative;">
+              <button
+                id="copy-gh-action"
+                style="position: absolute; top: .5rem; right: .5rem;z-index: 100"
+              >
+                copy code
+              </button>
+              <pre style="height: 200px; overflow: auto;padding: 1rem;"><code>{AOT_GH_ACTION}</code></pre>
+            </span>
+          </li>
+          <li>
+            Copy the project name under <code>Setting {">"} Project Name</code>
+            {" "}
+            and replace "example project" with your actual project name in{" "}
+            <code>.github/workflows/deploy.yml</code>.
+          </li>
+          <li>
+            Commit the file you created and merge it into the <code>main</code>
+            {" "}
+            branch. This will trigger a new deployment and finish the setup.
+          </li>
+        </ol>
+        <p>
+          See the detailed guide here: <a href={LINK}>{LINK}</a>.
+        </p>
+      </div>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `
+            const copyBtn = document.querySelector("#copy-gh-action");
+            if (copyBtn) {
+              let timeout;
+              const text = copyBtn.textContent;
+              copyBtn.addEventListener("click", async () => {
+                copyBtn.textContent = "copied!";
+
+                clearTimeout(timeout);
+                timeout = setTimeout(() => {
+                  copyBtn.textContent = text
+                }, 2000);
+
+                const code = \`${AOT_GH_ACTION}\`;
+                await navigator.clipboard.writeText(code);
+              })
+            }
+            `,
+        }}
+      />
+    </div>
+  );
+}

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -101,6 +101,7 @@ export interface InternalFreshState {
   config: ResolvedFreshConfig;
   manifest: Manifest;
   loadSnapshot: boolean;
+  didLoadSnapshot: boolean;
   denoJsonPath: string;
   denoJson: DenoConfig;
   build: boolean;

--- a/tests/init_test.ts
+++ b/tests/init_test.ts
@@ -185,6 +185,7 @@ Deno.test({
       "/.vscode/settings.json",
       "/.vscode/extensions.json",
       "/.gitignore",
+      "/.github/workflows/deploy.yml",
     ];
 
     await t.step("check generated files", async () => {

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -218,11 +218,22 @@ export async function withFresh(
 }
 
 export async function withPageName(
-  name: string,
+  name: string | { name: string; options: Omit<Deno.CommandOptions, "args"> },
   fn: (page: Page, address: string) => Promise<void>,
 ) {
+  let file: string;
+  let options = {};
+
+  if (typeof name === "object") {
+    file = name.name;
+    options = name.options ?? {};
+  } else {
+    file = name;
+  }
+
   const { lines, serverProcess, address } = await startFreshServer({
-    args: ["run", "-A", name],
+    ...options,
+    args: ["run", "-A", file],
   });
 
   try {


### PR DESCRIPTION
By moving folks from `twind` over to the `tailwind` plugin we have traded support questions about "how to get twind autocompletion working?" with "my styles are not showing up in automatic mode". The tailwind plugin has a hard requirement on having a build step. We have documented this at various places and have a guide on how to set everything up, but it's much better if we float those steps from Fresh itself when we detect this.

With this PR we will prepare a `.github/workflows/deploy.yml` file already where the user only needs to swap out the project name.

When Fresh is started in production mode, the tailwind plugin is active and no snapshot files were loaded, then we print a helpful hint to the console:

```sh
No pre-compiled tailwind styles found.

Did you forget to run "deno task build" prior to starting the production server?
```

When we are running inside Deno Deploy this PR goes one step further. Since it is the first time many users might use Deno Deploy we'll also show a simple page that shows how to finish the tailwind setup. I've intentionally tried to not present this as a warning but rather as a "finishing" step to avoid scaring users off. It's not the prettiest page, but it's good enough for now.

<img width="892" alt="Screenshot 2024-01-09 at 23 41 27" src="https://github.com/denoland/fresh/assets/1062408/9bf2a61b-5551-4d8e-bdf8-b498072f8e98">


Fixes https://github.com/denoland/fresh/issues/2223
