### PR TITLE
fix: Prevent update doc title from partial if not present

### DIFF
--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -710,7 +710,9 @@ export async function applyPartials(res: Response): Promise<void> {
   }
 
   // Update <head>
-  document.title = doc.title;
+  if (doc.title) {
+    document.title = doc.title;
+  }
 
   // Needs to be converted to an array otherwise somehow <link>-tags
   // are missing.

--- a/tests/fixture_partials/fresh.gen.ts
+++ b/tests/fixture_partials/fresh.gen.ts
@@ -51,6 +51,7 @@ import * as $head_merge_duplicate from "./routes/head_merge/duplicate.tsx";
 import * as $head_merge_index from "./routes/head_merge/index.tsx";
 import * as $head_merge_injected from "./routes/head_merge/injected.tsx";
 import * as $head_merge_update from "./routes/head_merge/update.tsx";
+import * as $head_merge_without_title from "./routes/head_merge/without_title.tsx";
 import * as $index from "./routes/index.tsx";
 import * as $isPartial_middleware from "./routes/isPartial/_middleware.ts";
 import * as $isPartial_async from "./routes/isPartial/async.tsx";
@@ -185,6 +186,7 @@ const manifest = {
     "./routes/head_merge/index.tsx": $head_merge_index,
     "./routes/head_merge/injected.tsx": $head_merge_injected,
     "./routes/head_merge/update.tsx": $head_merge_update,
+    "./routes/head_merge/without_title.tsx": $head_merge_without_title,
     "./routes/index.tsx": $index,
     "./routes/isPartial/_middleware.ts": $isPartial_middleware,
     "./routes/isPartial/async.tsx": $isPartial_async,

--- a/tests/fixture_partials/routes/head_merge/index.tsx
+++ b/tests/fixture_partials/routes/head_merge/index.tsx
@@ -33,6 +33,15 @@ export default function SlotDemo() {
           duplicate
         </a>
       </p>
+      <p>
+        <a
+          class="without-title"
+          href="/head_merge/injected"
+          f-partial="/head_merge/without_title"
+        >
+          without title
+        </a>
+      </p>
     </div>
   );
 }

--- a/tests/fixture_partials/routes/head_merge/without_title.tsx
+++ b/tests/fixture_partials/routes/head_merge/without_title.tsx
@@ -1,0 +1,24 @@
+import { defineRoute } from "$fresh/src/server/defines.ts";
+import { RouteConfig } from "$fresh/server.ts";
+import { Head, Partial } from "$fresh/runtime.ts";
+import { Fader } from "../../islands/Fader.tsx";
+
+export const config: RouteConfig = {
+  skipAppWrapper: true,
+  skipInheritedLayouts: true,
+};
+
+export default defineRoute((req, ctx) => {
+  return (
+    <>
+      <Head>
+        <link rel="stylesheet" href="/style.css" />
+      </Head>
+      <Partial name="slot-1">
+        <Fader>
+          <p class="page-without-title">page without title</p>
+        </Fader>
+      </Partial>
+    </>
+  );
+});

--- a/tests/partials_test.ts
+++ b/tests/partials_test.ts
@@ -1538,3 +1538,34 @@ Deno.test("render 404 partial", async () => {
     },
   );
 });
+
+Deno.test("render partial with title", async () => {
+  await withPageName(
+    "./tests/fixture_partials/main.ts",
+    async (page, address) => {
+      await page.goto(`${address}/head_merge`);
+      await page.waitForSelector(".status-initial");
+
+      await page.click(".duplicate-link");
+      await page.waitForSelector(".status-duplicated");
+
+      const doc = parseHtml(await page.content());
+      assertEquals(doc.title, "Head merge duplicated");
+    },
+  );
+});
+
+Deno.test("render partial without title", async () => {
+  await withPageName(
+    "./tests/fixture_partials/main.ts",
+    async (page, address) => {
+      await page.goto(`${address}/head_merge`);
+      await page.click(".without-title");
+
+      await page.waitForSelector(".page-without-title");
+
+      const doc = parseHtml(await page.content());
+      assertEquals(doc.title, "Head merge");
+    },
+  );
+});


### PR DESCRIPTION
fixes #2243 