### PR TITLE
docs: getting started - running locally

### DIFF
--- a/docs/latest/getting-started/running-locally.md
+++ b/docs/latest/getting-started/running-locally.md
@@ -39,7 +39,7 @@ If you want to change the port or host, modify the config bag of the `start()`
 call in `main.ts` to include an explicit port number:
 
 ```js main.ts
-await start(manifest, { port: 3000 });
+await start(manifest, { server: { port: 3000 } });
 ```
 
 You can also change the port by setting the `PORT` environment variable:


### PR DESCRIPTION
Removes description of changing the port number with the deprecated `port` property and updates  with `server.port`.

![Screenshot 2024-01-12 190452](https://github.com/denoland/fresh/assets/138949169/84ac96b2-6c55-438d-8be1-22184f309a22)
