### PR TITLE
fix: prototype pollution in deserializer

### DIFF
--- a/src/runtime/deserializer.ts
+++ b/src/runtime/deserializer.ts
@@ -19,7 +19,6 @@ const INVALID_REFERENCE_ERROR = "Invalid reference";
 
 function getPropertyFromPath(o: object, path: string[]): object {
   for (const key of path) {
-    if (key === null) return o;
     if (!Object.hasOwn(o, key)) throw new Error(INVALID_REFERENCE_ERROR);
     // deno-lint-ignore no-explicit-any
     o = (o as any)[key];

--- a/src/runtime/deserializer.ts
+++ b/src/runtime/deserializer.ts
@@ -19,7 +19,10 @@ const INVALID_REFERENCE_ERROR = "Invalid reference";
 
 function getPropertyFromPath(o: object, path: string[]): object {
   for (const key of path) {
-    if (!Object.hasOwn(o, key)) throw new Error(INVALID_REFERENCE_ERROR);
+    if (key === null) continue;
+    if (key !== "value" && !Object.hasOwn(o, key)) {
+      throw new Error(INVALID_REFERENCE_ERROR);
+    }
     // deno-lint-ignore no-explicit-any
     o = (o as any)[key];
   }
@@ -61,7 +64,9 @@ export function deserialize(
       // set the reference to the target object
       const parent = getPropertyFromPath(v, refPath.slice(0, -1));
       const key = refPath[refPath.length - 1]!;
-      if (!Object.hasOwn(parent, key)) throw new Error(INVALID_REFERENCE_ERROR);
+      if (key !== "value" && !Object.hasOwn(parent, key)) {
+        throw new Error(INVALID_REFERENCE_ERROR);
+      }
       // deno-lint-ignore no-explicit-any
       (parent as any)[key] = target;
     }

--- a/src/runtime/deserializer.ts
+++ b/src/runtime/deserializer.ts
@@ -1,6 +1,3 @@
-// Run `deno run -A npm:esbuild --minify src/runtime/deserializer.ts` to minify
-// this file. It is embedded into src/server/deserializer_code.ts.
-
 export const KEY = "_f";
 
 interface Signal<T> {
@@ -16,6 +13,18 @@ function b64decode(b64: string): Uint8Array {
     bytes[i] = binString.charCodeAt(i);
   }
   return bytes;
+}
+
+const INVALID_REFERENCE_ERROR = "Invalid reference";
+
+function getPropertyFromPath(o: object, path: string[]): object {
+  for (const key of path) {
+    if (key === null) return o;
+    if (!Object.hasOwn(o, key)) throw new Error(INVALID_REFERENCE_ERROR);
+    // deno-lint-ignore no-explicit-any
+    o = (o as any)[key];
+  }
+  return o;
 }
 
 export function deserialize(
@@ -44,19 +53,18 @@ export function deserialize(
     }
     return value;
   }
-
   const { v, r } = JSON.parse(str, reviver);
   const references = (r ?? []) as [string[], ...string[][]][];
   for (const [targetPath, ...refPaths] of references) {
-    const target = targetPath.reduce((o, k) => k === null ? o : o[k], v);
+    const target = getPropertyFromPath(v, targetPath);
     for (const refPath of refPaths) {
-      if (refPath.length === 0) throw new Error("Invalid reference");
+      if (refPath.length === 0) throw new Error(INVALID_REFERENCE_ERROR);
       // set the reference to the target object
-      const parent = refPath.slice(0, -1).reduce(
-        (o, k) => k === null ? o : o[k],
-        v,
-      );
-      parent[refPath[refPath.length - 1]!] = target;
+      const parent = getPropertyFromPath(v, refPath.slice(0, -1));
+      const key = refPath[refPath.length - 1]!;
+      if (!Object.hasOwn(parent, key)) throw new Error(INVALID_REFERENCE_ERROR);
+      // deno-lint-ignore no-explicit-any
+      (parent as any)[key] = target;
     }
   }
   return v;

--- a/src/server/serializer_test.ts
+++ b/src/server/serializer_test.ts
@@ -1,7 +1,12 @@
 // deno-lint-ignore-file no-explicit-any
 
 import { serialize } from "./serializer.ts";
-import { assert, assertEquals, assertSnapshot } from "../../tests/deps.ts";
+import {
+  assert,
+  assertEquals,
+  assertSnapshot,
+  assertThrows,
+} from "../../tests/deps.ts";
 import { deserialize, KEY } from "../runtime/deserializer.ts";
 import { signal } from "@preact/signals-core";
 import { signal as signal130 } from "@preact/signals-core@1.3.0";
@@ -212,4 +217,17 @@ Deno.test("serializer - multiple reference in signal", async (t) => {
   assertEquals(deserialized.s.value, inner);
   assertEquals(deserialized.s.peek(), inner);
   assertEquals(deserialized.inner, inner);
+});
+
+Deno.test("deserializer - no prototype pollution with manual input", () => {
+  const serialized = String.raw`{
+    "v": {
+      "*": ["onerror"]
+    },
+    "r": [
+      [["*"], ["constructor", "prototype", "*"]]
+    ]
+  }`;
+  assertThrows(() => deserialize(serialized, signal));
+  assertEquals({}.constructor.prototype["*"], undefined);
 });

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -14,6 +14,7 @@ export {
   assertNotMatch,
   assertRejects,
   assertStringIncludes,
+  assertThrows,
 } from "https://deno.land/std@0.211.0/assert/mod.ts";
 export { assertSnapshot } from "https://deno.land/std@0.211.0/testing/snapshot.ts";
 export {


### PR DESCRIPTION
This is not exploitable in practice unless a user maliciously crafts serialized values in __FRSH_STATE, because `serializer()` never outputs serialized representation that would be vulnerable to prototype pollution. But hey, defense in depth.
