### PR TITLE
chore: update esbuild deno loader

### DIFF
--- a/src/build/deps.ts
+++ b/src/build/deps.ts
@@ -6,5 +6,5 @@ export {
   toFileUrl,
 } from "https://deno.land/std@0.211.0/path/mod.ts";
 export { escape as regexpEscape } from "https://deno.land/std@0.211.0/regexp/escape.ts";
-export { denoPlugins } from "https://deno.land/x/esbuild_deno_loader@0.8.3/mod.ts";
+export { denoPlugins } from "https://deno.land/x/esbuild_deno_loader@0.8.4/mod.ts";
 export { assertEquals } from "https://deno.land/std@0.211.0/assert/mod.ts";


### PR DESCRIPTION
This fixes a bunch of bugs related to `npm:` imports.
