### PR TITLE
fix: no-window lint error

### DIFF
--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -111,6 +111,7 @@ export function revive(
       );
     };
 
+    // deno-lint-ignore no-window
     "scheduler" in window
       // `scheduler.postTask` is async but that can easily
       // fire in the background. We don't want waiting for
@@ -892,11 +893,11 @@ function maybeUpdateHistory(nextUrl: URL) {
   // Only add history entry when URL is new. Still apply
   // the partials because sometimes users click a link to
   // "refresh" the current page.
-  if (nextUrl.href !== window.location.href) {
+  if (nextUrl.href !== globalThis.location.href) {
     const state: FreshHistoryState = {
       index,
-      scrollX: window.scrollX,
-      scrollY: window.scrollY,
+      scrollX: globalThis.scrollX,
+      scrollY: globalThis.scrollY,
     };
 
     // Store current scroll position

--- a/src/runtime/entrypoints/main.ts
+++ b/src/runtime/entrypoints/main.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file ban-unknown-rule-code ban-unused-ignore
 import "../polyfills.ts";
 import {
   Component,

--- a/src/runtime/polyfills.ts
+++ b/src/runtime/polyfills.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file ban-unknown-rule-code ban-unused-ignore
 // Polyfill for old safari versions
 if (typeof globalThis === "undefined") {
   // @ts-ignore polyfill

--- a/src/runtime/polyfills.ts
+++ b/src/runtime/polyfills.ts
@@ -1,5 +1,6 @@
 // Polyfill for old safari versions
 if (typeof globalThis === "undefined") {
   // @ts-ignore polyfill
+  // deno-lint-ignore no-window
   window.globalThis = window;
 }

--- a/tests/base_path_test.ts
+++ b/tests/base_path_test.ts
@@ -116,7 +116,7 @@ Deno.test("rewrites root relative URLs in HTML", async () => {
 
     const style = await page.$eval(
       ".foo",
-      (el) => window.getComputedStyle(el).color,
+      (el) => globalThis.getComputedStyle(el).color,
     );
     assertMatch(
       style,

--- a/tests/partials_test.ts
+++ b/tests/partials_test.ts
@@ -1204,7 +1204,7 @@ Deno.test("fragment navigation should not scroll to top", async () => {
       await page.click("a");
       await page.waitForFunction(() => location.hash === "#foo");
 
-      const scroll = await page.evaluate(() => window.scrollY);
+      const scroll = await page.evaluate(() => globalThis.scrollY);
       assert(scroll > 0, `Did not scroll to fragment`);
     },
   );
@@ -1332,12 +1332,12 @@ Deno.test("merges <head> content", async () => {
       assertMetaContent(doc, "og:bar", "og value bar");
 
       const color = await page.$eval("h1", (el) => {
-        return window.getComputedStyle(el).color;
+        return globalThis.getComputedStyle(el).color;
       });
       assertEquals(color, "rgb(255, 0, 0)");
 
       const textColor = await page.$eval("p", (el) => {
-        return window.getComputedStyle(el).color;
+        return globalThis.getComputedStyle(el).color;
       });
       assertEquals(textColor, "rgb(0, 128, 0)");
     },

--- a/tests/server_components_test.ts
+++ b/tests/server_components_test.ts
@@ -157,7 +157,7 @@ Deno.test({
 
         // Check that CSS was applied accordingly
         const color = await page.$eval("h1", (el) => {
-          return window.getComputedStyle(el).color;
+          return globalThis.getComputedStyle(el).color;
         });
         assertEquals(color, "rgb(220, 38, 38)");
       },

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -459,7 +459,7 @@ export async function waitForStyle(
       (s, n, v) => {
         const el = document.querySelector(s);
         if (!el) return false;
-        return window.getComputedStyle(el)[n] === v;
+        return globalThis.getComputedStyle(el)[n] === v;
       },
       selector,
       name,

--- a/www/islands/LemonDrop.tsx
+++ b/www/islands/LemonDrop.tsx
@@ -74,7 +74,9 @@ function LemonDrop() {
   }, [width.value]);
 
   useEffect(() => {
-    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const mediaQuery = globalThis.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    );
     if (mediaQuery.matches) {
       return;
     }


### PR DESCRIPTION
Latest PR runs are failing with linting errors, e.g. https://github.com/denoland/fresh/actions/runs/7625625084/job/20770308634?pr=2266

Maybe this shouldn't be happening like this right now, but we'll still need to clean these up eventually.