### PR TITLE
bugfix: autofocus didn't work in example Input component

### DIFF
--- a/www/components/gallery/Input.tsx
+++ b/www/components/gallery/Input.tsx
@@ -2,10 +2,11 @@ import { JSX } from "preact";
 import { IS_BROWSER } from "$fresh/runtime.ts";
 
 export default function Input(props: JSX.HTMLAttributes<HTMLInputElement>) {
+  const wantFocus = !IS_BROWSER && ("autofocus" in props) || ("autoFocus" in props);
   return (
     <input
       {...props}
-      disabled={!IS_BROWSER || props.disabled}
+      disabled={(!IS_BROWSER && !wantFocus) || props.disabled}
       class={`px-3 py-2 bg-white rounded border(gray-500 2) disabled:(opacity-50 cursor-not-allowed) ${
         props.class ?? ""
       }`}


### PR DESCRIPTION
Disabled elements can't receive focus. If autofocus is requested, we shouldn't disable the input element on startup, or it will have no effect.

The easiest way to fix it is to leave the input element enabled. However, I'm not sure what the other consequences of that are.

(Note: this is how I fixed it in my app, but I haven't tested this patch.)