### PR TITLE
fix: GH actions warning by upgrading actions/checkout to v4 #2285

### DIFF
--- a/docs/latest/concepts/ahead-of-time-builds.md
+++ b/docs/latest/concepts/ahead-of-time-builds.md
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Deno
         uses: denoland/setup-deno@v1

--- a/src/dev/imports.ts
+++ b/src/dev/imports.ts
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Deno
         uses: denoland/setup-deno@v1


### PR DESCRIPTION
I tested the change in my own repo, the warning on github disapears for the "actions/checkout" action. 
It is still there for the denoland/setup-deno action, but an upgrade PR is already ongoing for this action, see: 
https://github.com/denoland/setup-deno/pull/56