### PR TITLE
chore: upgrade to esbuild 0.20.0

### DIFF
--- a/src/build/deps.ts
+++ b/src/build/deps.ts
@@ -6,5 +6,5 @@ export {
   toFileUrl,
 } from "https://deno.land/std@0.211.0/path/mod.ts";
 export { escape as regexpEscape } from "https://deno.land/std@0.211.0/regexp/escape.ts";
-export { denoPlugins } from "https://raw.githubusercontent.com/lucacasonato/esbuild_deno_loader/5bd8975c1abcc222024b2b10d902b60377a3b908/mod.ts";
+export { denoPlugins } from "https://deno.land/x/esbuild_deno_loader@0.9.0/mod.ts";
 export { assertEquals } from "https://deno.land/std@0.211.0/assert/mod.ts";

--- a/src/build/deps.ts
+++ b/src/build/deps.ts
@@ -6,5 +6,5 @@ export {
   toFileUrl,
 } from "https://deno.land/std@0.211.0/path/mod.ts";
 export { escape as regexpEscape } from "https://deno.land/std@0.211.0/regexp/escape.ts";
-export { denoPlugins } from "https://deno.land/x/esbuild_deno_loader@0.8.5/mod.ts";
+export { denoPlugins } from "https://raw.githubusercontent.com/lucacasonato/esbuild_deno_loader/5bd8975c1abcc222024b2b10d902b60377a3b908/mod.ts";
 export { assertEquals } from "https://deno.land/std@0.211.0/assert/mod.ts";

--- a/src/build/esbuild.ts
+++ b/src/build/esbuild.ts
@@ -2,7 +2,7 @@ import {
   type BuildOptions,
   type OnLoadOptions,
   type Plugin,
-} from "https://deno.land/x/esbuild@v0.19.11/mod.js";
+} from "https://deno.land/x/esbuild@v0.20.0/mod.js";
 import { denoPlugins, fromFileUrl, regexpEscape, relative } from "./deps.ts";
 import { Builder, BuildSnapshot } from "./mod.ts";
 
@@ -39,10 +39,10 @@ export class EsbuildBuilder implements Builder {
       // deno-lint-ignore no-deprecated-deno-api
       Deno.run === undefined ||
         Deno.env.get("FRESH_ESBUILD_LOADER") === "portable"
-        ? await import("https://deno.land/x/esbuild@v0.19.11/wasm.js")
-        : await import("https://deno.land/x/esbuild@v0.19.11/mod.js");
+        ? await import("https://deno.land/x/esbuild@v0.20.0/wasm.js")
+        : await import("https://deno.land/x/esbuild@v0.20.0/mod.js");
     const esbuildWasmURL =
-      new URL("./esbuild_v0.19.11.wasm", import.meta.url).href;
+      new URL("./esbuild_v0.20.0.wasm", import.meta.url).href;
 
     // deno-lint-ignore no-deprecated-deno-api
     if (Deno.run === undefined) {
@@ -129,7 +129,7 @@ export class EsbuildBuilder implements Builder {
 
       return new EsbuildSnapshot(files, dependencies);
     } finally {
-      esbuild.stop();
+      await esbuild.stop();
     }
   }
 }

--- a/src/build/esbuild.ts
+++ b/src/build/esbuild.ts
@@ -34,7 +34,7 @@ export class EsbuildBuilder implements Builder {
     const opts = this.#options;
 
     // Lazily initialize esbuild
-    // @deno-types="https://deno.land/x/esbuild@v0.19.4/mod.d.ts"
+    // @deno-types="https://deno.land/x/esbuild@v0.20.0/mod.d.ts"
     const esbuild =
       // deno-lint-ignore no-deprecated-deno-api
       Deno.run === undefined ||


### PR DESCRIPTION
Sadly this isn't working due to failures like this:
```
deno test -A src/build/esbuild_test.ts
running 1 test from ./src/build/esbuild_test.ts
esbuild ...
  esbuild snapshot with cwd=Deno.cwd() ...
ok | 0 passed | 0 failed (88ms)

error: Promise resolution is still pending but the event loop has already resolved.
```
I'm not sure what I'm doing wrong, but I thought I would open this as a draft PR so others can see what I've started.
Note the esbuild_deno_loader import is coming from https://github.com/lucacasonato/esbuild_deno_loader/pull/108.