### PR TITLE
fix: open redirect issue with trailing slash detection

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -234,11 +234,10 @@ export class ServerContext {
         !trailingSlashEnabled
       ) {
         // Remove trailing slashes
-        const path = url.pathname.replace(/\/+$/, "");
-        const location = `${path}${url.search}`;
+        url.pathname = url.pathname.replace(/\/+$/, "");
         return new Response(null, {
           status: STATUS_CODE.TemporaryRedirect,
-          headers: { location },
+          headers: { location: url.toString() },
         });
       } else if (trailingSlashEnabled && !url.pathname.endsWith("/")) {
         // If the last element of the path has a "." it's a file

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -187,6 +187,11 @@ export class ServerContext {
       connInfo: ServeHandlerInfo = DEFAULT_CONN_INFO,
     ) {
       const url = new URL(req.url);
+      // Syntactically having double slashes in the pathname is valid per
+      // spec, but there is no behavior defined for that. Practically all
+      // servers normalize the pathname of a URL to not include double
+      // forward slashes.
+      url.pathname = url.pathname.replaceAll(/\/+/g, "/");
 
       const aliveUrl = basePath + ALIVE_URL;
 
@@ -234,10 +239,11 @@ export class ServerContext {
         !trailingSlashEnabled
       ) {
         // Remove trailing slashes
-        url.pathname = url.pathname.replace(/\/+$/, "");
+        const path = url.pathname.replace(/\/+$/, "");
+        const location = `${path}${url.search}`;
         return new Response(null, {
           status: STATUS_CODE.TemporaryRedirect,
-          headers: { location: url.toString() },
+          headers: { location },
         });
       } else if (trailingSlashEnabled && !url.pathname.endsWith("/")) {
         // If the last element of the path has a "." it's a file

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -19,6 +19,7 @@ import {
   startFreshServer,
   waitForText,
   withFakeServe,
+  withFresh,
   withPageName,
 } from "./test_utils.ts";
 
@@ -228,7 +229,7 @@ Deno.test("redirect /pages/fresh/ to /pages/fresh", async () => {
   assertEquals(resp.status, STATUS_CODE.TemporaryRedirect);
   assertEquals(
     resp.headers.get("location"),
-    "/pages/fresh",
+    "https://fresh.deno.dev/pages/fresh",
   );
 });
 
@@ -240,7 +241,7 @@ Deno.test("redirect /pages/////fresh///// to /pages/////fresh", async () => {
   assertEquals(resp.status, STATUS_CODE.TemporaryRedirect);
   assertEquals(
     resp.headers.get("location"),
-    "/pages/////fresh",
+    "https://fresh.deno.dev/pages/////fresh",
   );
 });
 
@@ -252,7 +253,7 @@ Deno.test("redirect /pages/////fresh/ to /pages/////fresh", async () => {
   assertEquals(resp.status, STATUS_CODE.TemporaryRedirect);
   assertEquals(
     resp.headers.get("location"),
-    "/pages/////fresh",
+    "https://fresh.deno.dev/pages/////fresh",
   );
 });
 
@@ -1233,5 +1234,16 @@ Deno.test("should not be able to override __FRSH_STATE", async () => {
     await page.waitForSelector(".raw_ready");
 
     assert(!didError);
+  });
+});
+
+Deno.test("should not be able open redirect", async () => {
+  await withFresh("./tests/fixture/main.ts", async (address) => {
+    const res = await fetch(
+      `${address}//evil.com/`,
+    );
+    await res.body?.cancel();
+    const url = new URL(res.url);
+    assertEquals(url.origin, address);
   });
 });

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -232,20 +232,17 @@ Deno.test("redirect /pages/fresh/ to /pages/fresh", async () => {
   );
 });
 
-Deno.test(
-  "redirect /pages/////fresh///// to /pages/fresh",
-  async () => {
-    const resp = await handler(
-      new Request("https://fresh.deno.dev/pages/////fresh/////"),
-    );
-    assert(resp);
-    assertEquals(resp.status, STATUS_CODE.TemporaryRedirect);
-    assertEquals(
-      resp.headers.get("location"),
-      "/pages/fresh",
-    );
-  },
-);
+Deno.test("redirect /pages/////fresh///// to /pages/fresh", async () => {
+  const resp = await handler(
+    new Request("https://fresh.deno.dev/pages/////fresh/////"),
+  );
+  assert(resp);
+  assertEquals(resp.status, STATUS_CODE.TemporaryRedirect);
+  assertEquals(
+    resp.headers.get("location"),
+    "/pages/fresh",
+  );
+});
 
 Deno.test("redirect /pages/////fresh/ to /pages/fresh", async () => {
   const resp = await handler(

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -229,23 +229,26 @@ Deno.test("redirect /pages/fresh/ to /pages/fresh", async () => {
   assertEquals(resp.status, STATUS_CODE.TemporaryRedirect);
   assertEquals(
     resp.headers.get("location"),
-    "https://fresh.deno.dev/pages/fresh",
+    "/pages/fresh",
   );
 });
 
-Deno.test("redirect /pages/////fresh///// to /pages/////fresh", async () => {
-  const resp = await handler(
-    new Request("https://fresh.deno.dev/pages/////fresh/////"),
-  );
-  assert(resp);
-  assertEquals(resp.status, STATUS_CODE.TemporaryRedirect);
-  assertEquals(
-    resp.headers.get("location"),
-    "https://fresh.deno.dev/pages/////fresh",
-  );
-});
+Deno.test(
+  "redirect /pages/////fresh///// to /pages/fresh",
+  async () => {
+    const resp = await handler(
+      new Request("https://fresh.deno.dev/pages/////fresh/////"),
+    );
+    assert(resp);
+    assertEquals(resp.status, STATUS_CODE.TemporaryRedirect);
+    assertEquals(
+      resp.headers.get("location"),
+      "/pages/fresh",
+    );
+  },
+);
 
-Deno.test("redirect /pages/////fresh/ to /pages/////fresh", async () => {
+Deno.test("redirect /pages/////fresh/ to /pages/fresh", async () => {
   const resp = await handler(
     new Request("https://fresh.deno.dev/pages/////fresh/"),
   );
@@ -253,7 +256,7 @@ Deno.test("redirect /pages/////fresh/ to /pages/////fresh", async () => {
   assertEquals(resp.status, STATUS_CODE.TemporaryRedirect);
   assertEquals(
     resp.headers.get("location"),
-    "https://fresh.deno.dev/pages/////fresh",
+    "/pages/fresh",
   );
 });
 
@@ -263,6 +266,15 @@ Deno.test("no redirect for /pages/////fresh", async () => {
   );
   assert(resp);
   assertEquals(resp.status, STATUS_CODE.NotFound);
+});
+
+Deno.test("no redirect for /pages/////fresh", async () => {
+  const resp = await handler(
+    new Request("https://fresh.deno.dev//evil.com/"),
+  );
+  assert(resp);
+  assertEquals(resp.status, STATUS_CODE.TemporaryRedirect);
+  assertEquals(resp.headers.get("location"), "/evil.com");
 });
 
 Deno.test("/failure", async () => {

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -19,7 +19,6 @@ import {
   startFreshServer,
   waitForText,
   withFakeServe,
-  withFresh,
   withPageName,
 } from "./test_utils.ts";
 
@@ -1246,16 +1245,5 @@ Deno.test("should not be able to override __FRSH_STATE", async () => {
     await page.waitForSelector(".raw_ready");
 
     assert(!didError);
-  });
-});
-
-Deno.test("should not be able open redirect", async () => {
-  await withFresh("./tests/fixture/main.ts", async (address) => {
-    const res = await fetch(
-      `${address}//evil.com/`,
-    );
-    await res.body?.cancel();
-    const url = new URL(res.url);
-    assertEquals(url.origin, address);
   });
 });

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -264,7 +264,7 @@ Deno.test("no redirect for /pages/////fresh", async () => {
   assertEquals(resp.status, STATUS_CODE.NotFound);
 });
 
-Deno.test("no redirect for /pages/////fresh", async () => {
+Deno.test("no open redirect when passing double slashes", async () => {
   const resp = await handler(
     new Request("https://fresh.deno.dev//evil.com/"),
   );


### PR DESCRIPTION
Passing a path like `/foo/bar` as the location header is interpreted as a relative path. But when it contains two leading slashes like `//evil.com/` it is interpreted as a port relative url. This has the consequence that the origin of a URL can essentially be replaced:

```ts
new URL("//evil.com", "https://example.com/");
// -> 'https://evil.com/'
```

Our trailing slash detection logic didn't guard against this case. By normalizing the pathname of the URL and stripping sibling forward slashes we sidestep this problem.

