### PR TITLE
startServer onListen logs https when key & cert specified

### DIFF
--- a/src/server/boot.ts
+++ b/src/server/boot.ts
@@ -9,8 +9,10 @@ export async function startServer(
   if (!opts.onListen) {
     opts.onListen = (params) => {
       const pathname = opts.basePath + "/";
+      const https = !!(opts.key && opts.cert);
+      const protocol = https ? "https:" : "http:";
       const address = colors.cyan(
-        `http://localhost:${params.port}${pathname}`,
+        `${protocol}//localhost:${params.port}${pathname}`,
       );
       const localLabel = colors.bold("Local:");
 


### PR DESCRIPTION
Some team members of mine were confused by the default output 

```
 🍋 Fresh ready
    Local: http://localhost:8000/
```

when the server is actually running HTTPS. This should now print

```
 🍋 Fresh ready
    Local: https://localhost:8000/
```

when a key and cert are specified.