### PR TITLE
fix: properly prefix all scripts with base path

### DIFF
--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -358,6 +358,7 @@ export async function render<Data>(
     dependenciesFn: opts.dependenciesFn,
     styles: ctx.styles,
     pluginRenderResults: renderResults,
+    basePath,
   });
 
   // Append error overlay in dev mode

--- a/src/server/rendering/fresh_tags.tsx
+++ b/src/server/rendering/fresh_tags.tsx
@@ -23,6 +23,7 @@ export function renderFreshTags(
     dependenciesFn: (path: string) => string[];
     styles: string[];
     pluginRenderResults: [Plugin, PluginRenderResult][];
+    basePath: string;
   },
 ) {
   const { isPartial } = renderState;
@@ -41,7 +42,7 @@ export function renderFreshTags(
 
   const preloadSet = new Set<string>();
   function addImport(path: string): string {
-    const url = bundleAssetUrl(`/${path}`);
+    const url = opts.basePath + bundleAssetUrl(`/${path}`);
     if (!isPartial) {
       preloadSet.add(url);
       for (const depPath of opts.dependenciesFn(path)) {

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -49,3 +49,4 @@ export * as JSONC from "https://deno.land/std@0.216.0/jsonc/mod.ts";
 export * as colors from "https://deno.land/std@0.216.0/fmt/colors.ts";
 export { STATUS_CODE } from "https://deno.land/std@0.216.0/http/status.ts";
 export { stripAnsiCode } from "https://deno.land/std@0.216.0/fmt/colors.ts";
+export { Project } from "https://deno.land/x/ts_morph@21.0.1/mod.ts";


### PR DESCRIPTION
closes https://github.com/denoland/fresh/issues/2326

There was a big misunderstanding on my part -- in particular that a different server might be listening at the root, so the redirect built into `context.ts` will never happen. The existing test (as mentioned in the issue) passes, but only because no one else is listening, and fresh is able to perform the redirect.

I briefly considered writing a docker container to orchestrate this properly, but then I didn't want to have docker running in order to run these tests. (My laptop is old and bad.) So instead the two new tests very thoroughly assert that scripts included in the html are properly prefixed with the base path. And yes, they fail if the fix is reverted.

As for the fix itself: I just needed to prepend the asset URL with the base path.