### PR TITLE
fix: specify array for `on.pull_request.branches`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: main
+    branches: [main]
 
 jobs:
   deploy:

--- a/docs/latest/concepts/ahead-of-time-builds.md
+++ b/docs/latest/concepts/ahead-of-time-builds.md
@@ -68,7 +68,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: main
+    branches: [main]
 
 jobs:
   deploy:

--- a/src/dev/imports.ts
+++ b/src/dev/imports.ts
@@ -43,7 +43,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: main
+    branches: [main]
 
 jobs:
   deploy:


### PR DESCRIPTION
Currently, the `on.pull_request.branches` in deploy.yml, which is created during project initialization, specifies `main` as a string value. However, according to the [GitHub Actions documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore), it should be an array. I have corrected this inconsistency.