### PR TITLE
doc: Rename _req used to req

### DIFF
--- a/docs/latest/examples/dealing-with-cors.md
+++ b/docs/latest/examples/dealing-with-cors.md
@@ -47,18 +47,18 @@ deal with "preflight requests". Let's imagine you're trying to support a
 ```ts routes/_middleware.ts
 import { FreshContext } from "$fresh/server.ts";
 
-export async function handler(_req: Request, ctx: FreshContext) {
-  if (_req.method == "OPTIONS") {
+export async function handler(req: Request, ctx: FreshContext) {
+  if (req.method == "OPTIONS") {
     const resp = new Response(null, {
       status: 204,
     });
-    const origin = _req.headers.get("Origin") || "*";
+    const origin = req.headers.get("Origin") || "*";
     const headers = resp.headers;
     headers.set("Access-Control-Allow-Origin", origin);
     headers.set("Access-Control-Allow-Methods", "DELETE");
     return resp;
   }
-  const origin = _req.headers.get("Origin") || "*";
+  const origin = req.headers.get("Origin") || "*";
   const resp = await ctx.next();
   const headers = resp.headers;
 

--- a/tests/fixture/routes/_middleware.ts
+++ b/tests/fixture/routes/_middleware.ts
@@ -1,13 +1,13 @@
 import { FreshContext, MiddlewareHandler } from "$fresh/server.ts";
 
 // cors middleware
-async function corsHandler(_req: Request, ctx: FreshContext) {
-  if (_req.method == "OPTIONS") {
+async function corsHandler(req: Request, ctx: FreshContext) {
+  if (req.method == "OPTIONS") {
     return new Response(null, {
       status: 204,
     });
   }
-  const origin = _req.headers.get("Origin") || "*";
+  const origin = req.headers.get("Origin") || "*";
   const resp = await ctx.next();
   const headers = resp.headers;
 


### PR DESCRIPTION
Where other documents use req, they use the name req instead of _req

https://github.com/denoland/fresh/blob/b7281792a0a5b2674f659514b1e58116fabd6460/docs/latest/concepts/middleware.md?plain=1#L153
