### PR TITLE
fix: allow multiple set-cookie headers to be set before render

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -785,10 +785,10 @@ function sendResponse(
   },
 ) {
   const [body, uuid, csp] = resp;
-  const headers: Record<string, string> = {
+  const headers: Headers = new Headers({
     "content-type": "text/html; charset=utf-8",
     "x-fresh-uuid": uuid,
-  };
+  });
 
   if (csp) {
     if (options.isDev) {
@@ -799,24 +799,25 @@ function sendResponse(
     }
     const directive = serializeCSPDirectives(csp.directives);
     if (csp.reportOnly) {
-      headers["content-security-policy-report-only"] = directive;
+      headers.set("content-security-policy-report-only", directive);
     } else {
-      headers["content-security-policy"] = directive;
+      headers.set("content-security-policy", directive);
     }
   }
 
   if (options.headers) {
     if (Array.isArray(options.headers)) {
-      for (let i = 0; i < options.headers.length; i++) {
-        const item = options.headers[i];
-        headers[item[0]] = item[1];
+      for (const [key, value] of options.headers) {
+        headers.append(key, value);
       }
     } else if (options.headers instanceof Headers) {
       options.headers.forEach((value, key) => {
-        headers[key] = value;
+        headers.append(key, value);
       });
     } else {
-      Object.assign(headers, options.headers);
+      for (const [key, value] of Object.entries(options.headers)) {
+        headers.append(key, value);
+      }
     }
   }
 

--- a/tests/fixture_render/deno.json
+++ b/tests/fixture_render/deno.json
@@ -1,5 +1,8 @@
 {
   "lock": false,
+  "tasks": {
+    "start": "deno run -A --watch=static/,routes/ dev.ts"
+  },
   "imports": {
     "$fresh/": "../../",
     "preact": "https://esm.sh/preact@10.19.6",

--- a/tests/fixture_render/fresh.gen.ts
+++ b/tests/fixture_render/fresh.gen.ts
@@ -2,6 +2,7 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
+import * as $cookiePasser from "./routes/cookiePasser.tsx";
 import * as $head_style from "./routes/head_style.tsx";
 import * as $header_arr from "./routes/header_arr.tsx";
 import * as $header_instance from "./routes/header_instance.tsx";
@@ -12,6 +13,7 @@ import { type Manifest } from "$fresh/server.ts";
 
 const manifest = {
   routes: {
+    "./routes/cookiePasser.tsx": $cookiePasser,
     "./routes/head_style.tsx": $head_style,
     "./routes/header_arr.tsx": $header_arr,
     "./routes/header_instance.tsx": $header_instance,

--- a/tests/fixture_render/routes/cookiePasser.tsx
+++ b/tests/fixture_render/routes/cookiePasser.tsx
@@ -1,0 +1,18 @@
+import { FreshContext, Handlers } from "$fresh/server.ts";
+
+export const handler: Handlers = {
+  async GET(_req: Request, ctx: FreshContext) {
+    const headers = new Headers();
+    headers.append("Set-Cookie", "foo=bar");
+    headers.append("Set-Cookie", "baz=1234");
+    return await ctx.render({}, { headers });
+  },
+};
+
+export default function Home() {
+  return (
+    <div>
+      hello
+    </div>
+  );
+}

--- a/tests/render_test.ts
+++ b/tests/render_test.ts
@@ -32,19 +32,25 @@ Deno.test("doesn't leak data across renderers", async () => {
   await Promise.all(promises);
 });
 
-Deno.test("render headers passed to ctx.render()", async () => {
+Deno.test("render headers passed to ctx.render()", async (t) => {
   await withFakeServe("./tests/fixture_render/main.ts", async (server) => {
-    let res = await server.get("/header_arr");
-    assertEquals(res.headers.get("x-foo"), "Hello world!");
-    await res.body?.cancel();
+    await t.step("header_arr", async () => {
+      const res = await server.get("/header_arr");
+      assertEquals(res.headers.get("x-foo"), "Hello world!");
+      await res.body?.cancel();
+    });
 
-    res = await server.get("/header_obj");
-    assertEquals(res.headers.get("x-foo"), "Hello world!");
-    await res.body?.cancel();
+    await t.step("header_obj", async () => {
+      const res = await server.get("/header_obj");
+      assertEquals(res.headers.get("x-foo"), "Hello world!");
+      await res.body?.cancel();
+    });
 
-    res = await server.get("/header_instance");
-    assertEquals(res.headers.get("x-foo"), "Hello world!");
-    await res.body?.cancel();
+    await t.step("header_instance", async () => {
+      const res = await server.get("/header_instance");
+      assertEquals(res.headers.get("x-foo"), "Hello world!");
+      await res.body?.cancel();
+    });
   });
 });
 
@@ -86,4 +92,13 @@ Deno.test("Ensure manifest has valid specifiers", async () => {
       assertTextMany(doc, "p", ["it works"]);
     },
   );
+});
+
+Deno.test("render multiple set-cookie headers passed to ctx.render()", async () => {
+  await withFakeServe("./tests/fixture_render/dev.ts", async (server) => {
+    const res = await server.get("/cookiePasser");
+    const cookies = res.headers.getSetCookie();
+    assertEquals(cookies, ["foo=bar", "baz=1234"]);
+    await res.body?.cancel();
+  });
 });


### PR DESCRIPTION
closes #2346

The primary issue was the snippet `headers[key] = value`. This caused only one `set-cookie` to make it through. Switching to a `Headers` object allowed me to use `append` when appropriate, allowing for multiple `set-cookie` entries.

I also cleaned up one of the tests to make use of steps, because I originally broke it and couldn't immediately tell which part was failing.