### PR TITLE
feat: add `ctx.redirect()` helper

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -127,6 +127,7 @@ function redirectTo(pathOrUrl: string = "/", status = 302): Response {
     const pathname = idx > -1 ? pathOrUrl.slice(0, idx) : pathOrUrl;
     const search = idx > -1 ? pathOrUrl.slice(idx) : "";
 
+    // Remove double slashes to prevent open redirect vulnerability.
     location = `${pathname.replaceAll(/\/+/g, "/")}${search}`;
   }
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -157,7 +157,7 @@ export type PageProps<T = any, S = Record<string, unknown>> = Omit<
     S,
     T
   >,
-  "render" | "next" | "renderNotFound"
+  "render" | "next" | "renderNotFound" | "redirect"
 >;
 
 export interface StaticFile {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -206,6 +206,7 @@ export interface FreshContext<
   ) => Response | Promise<Response>;
   Component: ComponentType<unknown>;
   next: () => Promise<Response>;
+  redirect: (path: string, statusCode?: number) => Response;
 }
 /**
  * Context passed to async route components.

--- a/tests/fixture/fresh.gen.ts
+++ b/tests/fixture/fresh.gen.ts
@@ -65,6 +65,7 @@ import * as $not_found from "./routes/not_found.ts";
 import * as $params from "./routes/params.tsx";
 import * as $preact_boolean_attrs from "./routes/preact/boolean_attrs.tsx";
 import * as $props_id_ from "./routes/props/[id].tsx";
+import * as $redirect from "./routes/redirect.tsx";
 import * as $route_groups_islands_index from "./routes/route-groups-islands/index.tsx";
 import * as $route_groups_bar_baz_layout from "./routes/route-groups/(bar)/(baz)/_layout.tsx";
 import * as $route_groups_bar_baz_baz from "./routes/route-groups/(bar)/(baz)/baz.tsx";
@@ -186,6 +187,7 @@ const manifest = {
     "./routes/params.tsx": $params,
     "./routes/preact/boolean_attrs.tsx": $preact_boolean_attrs,
     "./routes/props/[id].tsx": $props_id_,
+    "./routes/redirect.tsx": $redirect,
     "./routes/route-groups-islands/index.tsx": $route_groups_islands_index,
     "./routes/route-groups/(bar)/(baz)/_layout.tsx":
       $route_groups_bar_baz_layout,

--- a/tests/fixture/routes/redirect.tsx
+++ b/tests/fixture/routes/redirect.tsx
@@ -1,0 +1,10 @@
+import { FreshContext } from "$fresh/server.ts";
+
+export const handler = {
+  GET(_req: Request, ctx: FreshContext) {
+    const rawStatus = ctx.url.searchParams.get("status");
+    const status = rawStatus !== null ? Number(rawStatus) : undefined;
+    const location = ctx.url.searchParams.get("path") ?? "/";
+    return ctx.redirect(location, status);
+  },
+};

--- a/tests/fixture_base_path/routes/api/rewrite.ts
+++ b/tests/fixture_base_path/routes/api/rewrite.ts
@@ -1,13 +1,7 @@
 import { Handlers } from "$fresh/server.ts";
 
 export const handler: Handlers<unknown, { data: string }> = {
-  GET(req) {
-    const url = new URL(req.url);
-    return new Response(null, {
-      status: 302,
-      headers: {
-        "Location": url.origin,
-      },
-    });
+  GET(_req, ctx) {
+    return ctx.redirect(ctx.url.origin, 302);
   },
 };

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -1205,6 +1205,7 @@ Deno.test("Expose config in ctx", async () => {
       next: "Function",
       render: "AsyncFunction",
       renderNotFound: "AsyncFunction",
+      redirect: "Function",
       localAddr: "<undefined>",
       pattern: "/ctx_config",
       data: "<undefined>",

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -294,7 +294,7 @@ Deno.test("ctx.redirect() - absolute urls", async () => {
     new Request("https://fresh.deno.dev/redirect?path=https://example.com/"),
   );
   assertEquals(resp.status, 302);
-  assertEquals(resp.headers.get("location"), "https://example.com");
+  assertEquals(resp.headers.get("location"), "https://example.com/");
 });
 
 Deno.test("ctx.redirect() - with search and hash", async () => {

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -297,6 +297,18 @@ Deno.test("ctx.redirect() - absolute urls", async () => {
   assertEquals(resp.headers.get("location"), "https://example.com");
 });
 
+Deno.test("ctx.redirect() - with search and hash", async () => {
+  const resp = await handler(
+    new Request(
+      `https://fresh.deno.dev/redirect?path=${
+        encodeURIComponent("/foo/bar?baz=123#foo")
+      }`,
+    ),
+  );
+  assertEquals(resp.status, 302);
+  assertEquals(resp.headers.get("location"), "/foo/bar?baz=123#foo");
+});
+
 Deno.test("/failure", async () => {
   const resp = await handler(new Request("https://fresh.deno.dev/failure"));
   assert(resp);

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -273,6 +273,30 @@ Deno.test("no open redirect when passing double slashes", async () => {
   assertEquals(resp.headers.get("location"), "/evil.com");
 });
 
+Deno.test("ctx.redirect() - relative urls", async () => {
+  let resp = await handler(
+    new Request("https://fresh.deno.dev/redirect?path=//evil.com/"),
+  );
+  assertEquals(resp.status, 302);
+  assertEquals(resp.headers.get("location"), "/evil.com/");
+
+  resp = await handler(
+    new Request(
+      "https://fresh.deno.dev/redirect?path=//evil.com//foo&status=307",
+    ),
+  );
+  assertEquals(resp.status, 307);
+  assertEquals(resp.headers.get("location"), "/evil.com/foo");
+});
+
+Deno.test("ctx.redirect() - absolute urls", async () => {
+  const resp = await handler(
+    new Request("https://fresh.deno.dev/redirect?path=https://example.com/"),
+  );
+  assertEquals(resp.status, 302);
+  assertEquals(resp.headers.get("location"), "https://example.com");
+});
+
 Deno.test("/failure", async () => {
   const resp = await handler(new Request("https://fresh.deno.dev/failure"));
   assert(resp);

--- a/tests/server_components_test.ts
+++ b/tests/server_components_test.ts
@@ -117,6 +117,7 @@ Deno.test("passes context to server component", async () => {
           params: {
             id: "foo",
           },
+          redirect: "Function",
           state: {},
           isPartial: false,
         },

--- a/www/routes/docs/_middleware.ts
+++ b/www/routes/docs/_middleware.ts
@@ -12,11 +12,7 @@ export async function handler(
   // Redirect from old doc URLs to new ones
   const redirect = REDIRECTS[ctx.url.pathname];
   if (redirect) {
-    const url = new URL(redirect, ctx.url.origin);
-    return new Response("", {
-      status: 307,
-      headers: { location: url.href },
-    });
+    return ctx.redirect(redirect, 307);
   }
 
   return await ctx.next();


### PR DESCRIPTION
This PR adds a `ctx.redirect(path, status)` helper that aims to reduce the verbosity of having to manually create a `Response` obejct for a mere redirect.

```ts
// Before
new Response(null, {
  status: 307,
  headers: {
    Location: "/foo/bar"
  },
})

// After
ctx.redirect("/foo/bar", 307)
```

If the second parameter is not passed, it will default to `302`.