### PR TITLE
chore: satisfy use-import-type lint (biomejs)

### DIFF
--- a/src/dev/manifest.ts
+++ b/src/dev/manifest.ts
@@ -82,7 +82,7 @@ ${
     )
       .join("\n")
   }
-import { type Manifest } from "$fresh/server.ts";
+import type { Manifest } from "$fresh/server.ts";
 
 const manifest = {
   routes: {


### PR DESCRIPTION
https://biomejs.dev/linter/rules/use-import-type/

From that page the argument is 

>The rule ensures that all imports used only as a type use a type-only import. It also groups inline type imports into a grouped import type.