### PR TITLE
www: remov no build step from marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Some stand-out features:
 - Just-in-time rendering on the edge.
 - Island based client hydration for maximum interactivity.
 - Zero runtime overhead: no JS is shipped to the client by default.
-- No build step.
 - No configuration necessary.
 - TypeScript support out of the box.
 - File-system routing à la Next.js.

--- a/docs/latest/introduction/index.md
+++ b/docs/latest/introduction/index.md
@@ -30,7 +30,6 @@ for the best experience.
 
 Some stand out features:
 
-- No build step
 - Zero config necessary
 - JIT rendering on the edge
 - Tiny & fast (no client JS is required by the framework)

--- a/www/routes/index.tsx
+++ b/www/routes/index.tsx
@@ -126,13 +126,6 @@ function Features() {
       </div>
 
       <div class={item}>
-        <FeatureIcons.NoBuild />
-        <div class={desc}>
-          <b>No build step</b>.
-        </div>
-      </div>
-
-      <div class={item}>
         <FeatureIcons.Garbage />
         <div class={desc}>
           <b>No configuration</b> necessary.


### PR DESCRIPTION
We've been moving away from that for a couple of months now, so featuring the "no build step" prominently in our marketing feels wrong.