### PR TITLE
fix: add `.js` + `.jsx` extension to tailwind content glob

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -330,7 +330,7 @@ const TAILWIND_CONFIG_TS = `import { type Config } from "tailwindcss";
 
 export default {
   content: [
-    "{routes,islands,components}/**/*.{ts,tsx}",
+    "{routes,islands,components}/**/*.{ts,tsx,js,jsx}",
   ],
 } satisfies Config;
 `;


### PR DESCRIPTION
Whilst Deno supports Typescript by default, not everyone necessarily will want to write every file in Typescript. If using TailwindCSS, at the moment the files Tailwind searches for classes does not include `.js` and `.jsx` endings. Whilst you can manually add them via the `tailwind.config.ts`, it might be nice to have these added in by default for a better onboarding experience.

Closes #2291 