### PR TITLE
fix: `ServerhandlerInfo` type for newer Deno versions

### DIFF
--- a/src/server/boot.ts
+++ b/src/server/boot.ts
@@ -79,15 +79,19 @@ async function bootServer(
     // @ts-ignore Ignore type error when type checking with Deno versions
     await Deno.serve(
       opts,
-      (r, { remoteAddr }) =>
-        handler(r, {
-          remoteAddr,
-          localAddr: {
-            transport: "tcp",
-            hostname: opts.hostname ?? "localhost",
-            port: opts.port,
-          } as Deno.NetAddr,
-        }),
+      (r, info) =>
+        handler(
+          r,
+          {
+            ...info,
+            remoteAddr: info.remoteAddr,
+            localAddr: {
+              transport: "tcp",
+              hostname: opts.hostname ?? "localhost",
+              port: opts.port,
+            } as Deno.NetAddr,
+          },
+        ),
     ).finished;
   } else {
     // @ts-ignore Deprecated std serve way

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -46,7 +46,9 @@ import { withBase } from "./router.ts";
 import { PARTIAL_SEARCH_PARAM } from "../constants.ts";
 import TailwindErrorPage from "./tailwind_aot_error_page.tsx";
 
-const DEFAULT_CONN_INFO: ServeHandlerInfo = {
+// TODO: Completed type clashes in older Deno versions
+// deno-lint-ignore no-explicit-any
+const DEFAULT_CONN_INFO: any = {
   localAddr: { transport: "tcp", hostname: "localhost", port: 8080 },
   remoteAddr: { transport: "tcp", hostname: "localhost", port: 1234 },
 };

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -251,13 +251,12 @@ export interface RouteConfig {
 
 export interface RenderOptions extends ResponseInit {}
 
-export type ServeHandlerInfo = {
+export type ServeHandlerInfo = Deno.ServeHandlerInfo & {
   /**
    * Backwards compatible with std/server
    * @deprecated
    */
   localAddr?: Deno.NetAddr;
-  remoteAddr: Deno.NetAddr;
 };
 
 export type ServeHandler = (

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -305,7 +305,8 @@ Deno.test("static files in custom directory", async () => {
         hostname: "127.0.0.1",
         port: 80,
       },
-    });
+      // deno-lint-ignore no-explicit-any
+    } as any);
   };
 
   const resp = await newRouter(

--- a/tests/plugin_test.ts
+++ b/tests/plugin_test.ts
@@ -29,7 +29,8 @@ const router = (req: Request) => {
       hostname: "127.0.0.1",
       port: 80,
     },
-  });
+    // deno-lint-ignore no-explicit-any
+  } as any);
 };
 
 Deno.test("/static page prerender", async () => {
@@ -98,7 +99,8 @@ Deno.test("plugin routes and middleware -- async _app", async () => {
         hostname: "127.0.0.1",
         port: 80,
       },
-    });
+      // deno-lint-ignore no-explicit-any
+    } as any);
   };
 
   const resp = await router(new Request("https://fresh.deno.dev/test"));

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -289,7 +289,8 @@ export async function fakeServe(
   const ctx = await ServerContext.fromManifest(manifest, config);
   const handler = ctx.handler();
 
-  const conn: ServeHandlerInfo = {
+  // deno-lint-ignore no-explicit-any
+  const conn: any = {
     remoteAddr: {
       transport: "tcp",
       hostname: "127.0.0.1",

--- a/tests/trailing_slash_test.ts
+++ b/tests/trailing_slash_test.ts
@@ -15,7 +15,8 @@ const router = (req: Request) => {
       hostname: "127.0.0.1",
       port: 80,
     },
-  });
+    // deno-lint-ignore no-explicit-any
+  } as any);
 };
 
 Deno.test("forwards slash placed at the end of url", async () => {


### PR DESCRIPTION
Newer Deno versions have an additional `completed` property in there. This PR allows Fresh to be used with both old and newer Deno versions without getting type errors.