### PR TITLE
www: add back trailing slash handling

### DIFF
--- a/docs/canary/examples/migration-guide.md
+++ b/docs/canary/examples/migration-guide.md
@@ -171,6 +171,21 @@ on demand. Run the `deno task build` command as part of your deployment process.
 If you have already set up Fresh's 1.x "Ahead-of-Time Builds", then no changes
 are necessary.
 
+## Trailing slash handling
+
+The handling trailing slashes has been extracted to an optional middleware that
+you can add if needed. This middleware can be used to ensure that URLs always
+have a trailing slash at the end or that they will never have one.
+
+```diff
+-  import { App, staticFiles } from "@fresh/core";
++  import { App, staticFiles, trailingSlashes } from "@fresh/core";
+
+  export const app = new App({ root: import.meta.url })
+    .use(staticFiles())
++   .use(trailingSlashes("never"));
+```
+
 ## Automatic updates
 
 > [info]: The changes listed here are applied automatically when running the

--- a/www/main.ts
+++ b/www/main.ts
@@ -1,7 +1,8 @@
-import { App, fsRoutes, staticFiles } from "@fresh/core";
+import { App, fsRoutes, staticFiles, trailingSlashes } from "@fresh/core";
 
 export const app = new App({ root: import.meta.url })
-  .use(staticFiles());
+  .use(staticFiles())
+  .use(trailingSlashes("never"));
 
 await fsRoutes(app, {
   loadIsland: (path) => import(`./islands/${path}`),


### PR DESCRIPTION
In Fresh 2 trailing slash handling isn't applied automatically anymore and I forgot to do that when merging the Fresh 2 code base.

While we're at it, I've added a section for that to our migration guide.