### PR TITLE
chore: fix type error

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -14,7 +14,7 @@
     "www": "deno task --cwd=www start",
     "build-www": "deno task --cwd=www build",
     "screenshot": "deno run -A www/utils/screenshot.ts",
-    "check:types": "deno check src/**/*.ts src/**/*.tsx tests/**/*.ts tests/**/*.tsx",
+    "check:types": "deno check src/**/*.ts src/**/*.tsx tests/**/*.ts tests/**/*.tsx update/**/*.ts plugin-tailwindcss/**/*.ts init/**/*.ts",
     "ok": "deno fmt --check && deno lint && deno task check:types && deno task test",
     "test:www": "deno test -A tests/www/",
     "manifests": "deno run -A genAllManifest.ts"

--- a/plugin-tailwindcss/src/compiler.ts
+++ b/plugin-tailwindcss/src/compiler.ts
@@ -71,7 +71,7 @@ export async function initTailwind(
     autoprefixer(options.autoprefixer) as any,
   ];
 
-  if (config.mode === "build") {
+  if (config.mode === "production") {
     plugins.push(cssnano());
   }
 


### PR DESCRIPTION
We only checking types in CI in `src/` + `tests/`. This PR adds the other folders.