### PR TITLE
fix: enhanced config.ts->{parseRootPath}

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -40,18 +40,22 @@ export interface ResolvedFreshConfig {
 }
 
 export function parseRootPath(root: string, cwd: string): string {
-  if (root.startsWith("file://")) {
+  if (root === "\\" || root === "/") {
+    return cwd;
+  } else if (root.startsWith("file://")) {
     root = path.fromFileUrl(root);
   } else if (!path.isAbsolute(root)) {
     root = path.join(cwd, root);
   }
 
   const ext = path.extname(root);
-  if (
-    ext === ".ts" || ext === ".tsx" || ext === ".js" || ext === ".jsx" ||
-    ext === ".mjs"
-  ) {
+
+  if (ext) {
     root = path.dirname(root);
+  }
+
+  if (root.endsWith("/") || root.endsWith("\\")) {
+    root = root.slice(0, -1);
   }
 
   return root;

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -1,15 +1,42 @@
 import { expect } from "@std/expect";
 import { parseRootPath } from "./config.ts";
+import { osType } from "$std/path/_os.ts";
 
-// FIXME: Windows
-Deno.test.ignore("parseRootPath", () => {
+Deno.test("parseRootPath", () => {
   const cwd = Deno.cwd();
-  expect(parseRootPath("file:///foo/bar", cwd)).toEqual("/foo/bar");
-  expect(parseRootPath("file:///foo/bar.ts", cwd)).toEqual("/foo");
+  const isWindows = osType === "windows";
+  const slash = isWindows ? "\\" : "/";
+  /** ../ */
+  const currentPathMinusOneDir = cwd.split(slash).slice(0, -1).join(slash);
+
+  expect(parseRootPath("file:///foo/bar", cwd)).toEqual(
+    slash + "foo" + slash + "bar",
+  );
   expect(parseRootPath("/foo/bar", cwd)).toEqual("/foo/bar");
   expect(parseRootPath("/foo/bar.ts", cwd)).toEqual("/foo");
   expect(parseRootPath("/foo/bar.tsx", cwd)).toEqual("/foo");
   expect(parseRootPath("/foo/bar.js", cwd)).toEqual("/foo");
   expect(parseRootPath("/foo/bar.jsx", cwd)).toEqual("/foo");
   expect(parseRootPath("/foo/bar.mjs", cwd)).toEqual("/foo");
+  expect(
+    parseRootPath("./foo/bar.ts", cwd).endsWith(slash + "foo"),
+  ).toBeTruthy();
+  expect(parseRootPath("../foo/bar.ts", cwd)).toEqual(
+    currentPathMinusOneDir + slash + "foo",
+  );
+
+  if (isWindows) {
+    expect(parseRootPath("C:\\foo\\bar.ts", cwd)).toEqual("C:\\foo");
+    expect(parseRootPath("C:/foo/bar.ts", cwd)).toEqual("C:/foo");
+  }
+
+  expect(parseRootPath("/foo/bar.baz", cwd)).toEqual("/foo");
+  expect(parseRootPath("/foo/bar.tar.gz", cwd)).toEqual("/foo");
+  expect(parseRootPath("foo/bar.ts", cwd)).toEqual(cwd + slash + "foo");
+  expect(parseRootPath("foo/bar.js", cwd)).toEqual(cwd + slash + "foo");
+  expect(parseRootPath("/foo/bar/baz.js", cwd)).toEqual("/foo/bar");
+  expect(parseRootPath("/foo/bar/baz/", cwd)).toEqual("/foo/bar/baz");
+  expect(parseRootPath("/foo/", cwd)).toEqual("/foo");
+  expect(parseRootPath("/foo", cwd)).toEqual("/foo");
+  expect(parseRootPath("/", cwd)).toEqual(cwd);
 });


### PR DESCRIPTION
* Added tests for Windows.
* Enhanced `parseRootPath` function to work with any extension and better windows compatibility.

Tested on Windows 11 and WSL.