### PR TITLE
doc: fix the link to sever configuration

### DIFF
--- a/docs/latest/examples/writing-tests.md
+++ b/docs/latest/examples/writing-tests.md
@@ -122,4 +122,4 @@ export interface FreshConfig {
 ```
 
 For more on how these work, see the page about
-[server configuration](/docs/examples/server-configuration).
+[server configuration](/docs/concepts/server-configuration).


### PR DESCRIPTION
I found a dead link on the "Writing tests" page.