### PR TITLE
docs: update markdown tutorial to use JSR

### DIFF
--- a/docs/latest/examples/rendering-markdown.md
+++ b/docs/latest/examples/rendering-markdown.md
@@ -92,8 +92,8 @@ description: testFromText
 
 You'll also need to import the `Github Flavored Markdown` module:
 
-```json
-"$gfm": "https://deno.land/x/gfm@0.2.3/mod.ts",
+```bash
+deno add @deno/gfm
 ```
 
 Andy has a helpful [post](https://deno.com/blog/build-a-blog-with-fresh) on the


### PR DESCRIPTION
Small cleanup of how we recommend importing the gfm package (moved to jsr, old post still works but could be confusing to new users)