### PR TITLE
fix: support numeric keys when rendering

### DIFF
--- a/src/plugins/fs_routes/mod_test.tsx
+++ b/src/plugins/fs_routes/mod_test.tsx
@@ -1150,3 +1150,25 @@ Deno.test("fsRoutes - default GET route doesn't override existing handler", asyn
     "<h1>true</h1>",
   );
 });
+
+Deno.test("support numeric keys", async () => {
+  const TestComponent = () => <div>foo</div>;
+
+  const server = await createServer({
+    "routes/index.tsx": {
+      default: () => {
+        return (
+          <>
+            <TestComponent key={0} />
+            <TestComponent key={1} />
+            ok
+          </>
+        );
+      },
+    },
+  });
+
+  const res = await server.get("/");
+  const text = await res.text();
+  expect(text).toContain("ok");
+});

--- a/src/runtime/server/preact_hooks.tsx
+++ b/src/runtime/server/preact_hooks.tsx
@@ -165,8 +165,11 @@ options[OptionsType.ATTR] = (name, value) => {
 
 const PATCHED = new WeakSet<VNode>();
 
-function normalizeKey(str: string) {
-  return str.replaceAll(":", "_");
+function normalizeKey(key: string | number) {
+  if (typeof key === "number") {
+    key = key.toString();
+  }
+  return key.replaceAll(":", "_");
 }
 
 const oldDiff = options[OptionsType.DIFF];


### PR DESCRIPTION
I'm trying to migrate one of my projects which publishes a plugin, and this was blocking me.

Looks like key is typed as `export type Key = string | number | any;`, so we might need to make more changes here in the future.