### PR TITLE
fix: add proper cache control headers

### DIFF
--- a/src/middlewares/static_files.ts
+++ b/src/middlewares/static_files.ts
@@ -79,6 +79,10 @@ export function staticFiles<T>(): MiddlewareFn<T> {
       }
     }
 
+    if (BUILD_ID === cacheKey) {
+      headers.append("Cache-Control", "public, max-age=31536000, immutable");
+    }
+
     headers.set("Content-Length", String(file.size));
     if (req.method === "HEAD") {
       file.close();

--- a/tests/test_utils.tsx
+++ b/tests/test_utils.tsx
@@ -155,7 +155,7 @@ export async function withChildProcessServer(
   for await (const line of lines.values({ preventCancel: true })) {
     output.push(line);
     const match = line.match(
-      /https?:\/\/localhost:\d+(\/\w+[-\w]*)*/g,
+      /https?:\/\/[^:]+:\d+(\/\w+[-\w]*)*/g,
     );
     if (match) {
       address = match[0];


### PR DESCRIPTION
The whole point of `asset()` is to enable caching. Yet we were not adding cache control headers... :D