### PR TITLE
docs(plugins): twind link example renderAsync

### DIFF
--- a/docs/latest/concepts/plugins.md
+++ b/docs/latest/concepts/plugins.md
@@ -99,7 +99,7 @@ the state defined in the `scripts` entry. The state can be any arbitrary JSON
 serializable JavaScript value.
 
 For an example of a plugin that uses the `render` hook, see the first-party
-[Twind plugin](https://github.com/denoland/fresh/blob/twind-ssr/plugins/twind.ts).
+[Twind plugin](https://github.com/denoland/fresh/blob/1.x/plugins/twind.ts).
 
 ### Hook: `renderAsync`
 

--- a/docs/latest/concepts/plugins.md
+++ b/docs/latest/concepts/plugins.md
@@ -99,7 +99,7 @@ the state defined in the `scripts` entry. The state can be any arbitrary JSON
 serializable JavaScript value.
 
 For an example of a plugin that uses the `render` hook, see the first-party
-[Twind plugin](https://github.com/denoland/fresh/blob/main/plugins/twind.ts).
+[Twind plugin](https://github.com/denoland/fresh/blob/twind-ssr/plugins/twind.ts).
 
 ### Hook: `renderAsync`
 


### PR DESCRIPTION
Provide by navigating intended link from main branch to twind-ssr.