### PR TITLE
chore: get ready for Deno 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         uses: crate-ci/typos@master
         
       - name: Type check project
-        run: deno task check:types
+        run: deno run check:types
 
       - name: Run tests
-        run: deno task test
+        run: deno run test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build step
         working-directory: ./www
-        run: "deno task build" # 📝 Update the build command(s) if necessary
+        run: "deno run build" # 📝 Update the build command(s) if necessary
 
       - name: Upload to Deno Deploy
         uses: denoland/deployctl@v1

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can scaffold a new project by running the Fresh init script. To scaffold a
 project run the following:
 
 ```sh
-deno run -A -r https://fresh.deno.dev
+deno -A -r https://fresh.deno.dev
 ```
 
 Then navigate to the newly created project folder:
@@ -40,10 +40,10 @@ cd deno-fresh-demo
 ```
 
 From within your project folder, start the development server using the
-`deno task` command:
+`deno run` command:
 
 ```
-deno task start
+deno run start
 ```
 
 Now open http://localhost:8000 in your browser to view the page. You make
@@ -77,7 +77,7 @@ promotional purposes may not be listed.
 To take a screenshot, run the following command.
 
 ```sh
-deno task screenshot [url] [your-app-name]
+deno run screenshot [url] [your-app-name]
 ```
 
 Then add your site to

--- a/deno.json
+++ b/deno.json
@@ -9,14 +9,14 @@
   },
   "tasks": {
     "test": "deno test -A --parallel src/ init/ update/ && deno test -A tests/ www/main_test.ts",
-    "fixture": "deno run -A --watch=static/,routes/ tests/fixture/dev.ts",
-    "www": "deno task --cwd=www start",
-    "build-www": "deno task --cwd=www build",
-    "screenshot": "deno run -A www/utils/screenshot.ts",
+    "fixture": "deno -A --watch=static/,routes/ tests/fixture/dev.ts",
+    "www": "deno run --cwd=www start",
+    "build-www": "deno run --cwd=www build",
+    "screenshot": "deno -A www/utils/screenshot.ts",
     "check:types": "deno check src/**/*.ts src/**/*.tsx tests/**/*.ts tests/**/*.tsx update/**/*.ts plugin-tailwindcss/**/*.ts init/**/*.ts",
-    "ok": "deno fmt --check && deno lint && deno task check:types && deno task test",
+    "ok": "deno fmt --check && deno lint && deno run check:types && deno run test",
     "test:www": "deno test -A www/main_test.*",
-    "release": "deno run -A tools/release.ts"
+    "release": "deno -A tools/release.ts"
   },
   "exclude": ["**/_fresh/*", "**/tmp/*", "*/tests_OLD/**"],
   "publish": {

--- a/docs/canary/examples/migration-guide.md
+++ b/docs/canary/examples/migration-guide.md
@@ -16,7 +16,7 @@ Most changes can be applied automatically with the update script. Start the
 update by running it in your project directory:
 
 ```sh
-deno run -Ar jsr:@fresh/update
+deno -Ar jsr:@fresh/update
 ```
 
 This will apply most API changes made in Fresh 2
@@ -62,7 +62,7 @@ const builder = new Builder({ target: "safari12" });
 tailwind(builder, app, {});
 
 // Create optimized assets for the browser when
-// running `deno run -A dev.ts build`
+// running `deno -A dev.ts build`
 if (Deno.args.includes("build")) {
   await builder.build(app);
 } else {
@@ -167,7 +167,7 @@ export default function AppWrapper(ctx: FreshContext) {
 ## Update deployment settings
 
 Fresh 2 requires assets to be build during deployment instead of building them
-on demand. Run the `deno task build` command as part of your deployment process.
+on demand. Run the `deno run build` command as part of your deployment process.
 If you have already set up Fresh's 1.x "Ahead-of-Time Builds", then no changes
 are necessary.
 

--- a/docs/latest/concepts/ahead-of-time-builds.md
+++ b/docs/latest/concepts/ahead-of-time-builds.md
@@ -24,9 +24,9 @@ To have Fresh optimize all the assets, run one of the following commands:
 
 ```sh
 # As a task in newer Fresh projects
-deno task build
+deno run build
 # or invoke it manually
-deno run -A dev.ts build
+deno -A dev.ts build
 ```
 
 This will create a `_fresh` folder in the project directory. That folder
@@ -63,7 +63,7 @@ builds to optimize the assets before deploying them. This will make your
 application load quicker.
 
 Open the Deno Deploy dashboard for your project and head to the "Git
-Integration" section in the project settings. Enter `deno task build` in the
+Integration" section in the project settings. Enter `deno run build` in the
 "Build command" field and save. This will switch your Deno Deploy project to use
 ahead-of-time builds.
 

--- a/docs/latest/concepts/middleware.md
+++ b/docs/latest/concepts/middleware.md
@@ -144,7 +144,7 @@ for a `route`, as opposed to something like `http://localhost:8001/favicon.ico`.
 
 ### Example
 
-Initiate a new Fresh project (`deno run -A -r https://fresh.deno.dev/`) and then
+Initiate a new Fresh project (`deno -A -r https://fresh.deno.dev/`) and then
 create a `_middleware.ts` file in the `routes` folder like this:
 
 ```ts routes/_middleware.ts
@@ -158,10 +158,10 @@ export async function handler(req: Request, ctx: FreshContext) {
 }
 ```
 
-If you start up your server (`deno task start`) you'll see the following:
+If you start up your server (`deno run start`) you'll see the following:
 
 ```sh Terminal
-Task start deno run -A --watch=static/,routes/ dev.ts
+Task start deno -A --watch=static/,routes/ dev.ts
 Watcher Process started.
 The manifest has been generated for 4 routes and 1 islands.
 

--- a/docs/latest/concepts/updating.md
+++ b/docs/latest/concepts/updating.md
@@ -42,7 +42,7 @@ To run the auto updater, run the following command from the root of your
 project:
 
 ```sh Terminal
-$ deno run -A -r https://fresh.deno.dev/update
+$ deno -A -r https://fresh.deno.dev/update
 ```
 
 You will be prompted to confirm the changes that will be made to your project.

--- a/docs/latest/examples/authentication-with-supabase.md
+++ b/docs/latest/examples/authentication-with-supabase.md
@@ -51,10 +51,10 @@ Update the imports section of your `deno.json` file to include the following:
 ```
 
 Since Deno 1.38, we reading .env files is built-in and can be enabled with the
-`--env` flag. Here's the complete command to run our app:
+`--env-file` flag. Here's the complete command to run our app:
 
 ```shell
-deno run --unstable-kv --allow-env --allow-read --allow-write --allow-run --allow-net --watch=static/,routes/ dev.ts
+deno --unstable-kv --allow-env --allow-read --allow-write --allow-run --allow-net --watch=static/,routes/ dev.ts
 ```
 
 ### `@supabase/ssr`

--- a/docs/latest/examples/changing-the-src-dir.md
+++ b/docs/latest/examples/changing-the-src-dir.md
@@ -3,8 +3,8 @@ description: |
   Change the source directory to effectively manage your project.
 ---
 
-When you initialize a project with `deno run -A -r https://fresh.deno.dev`,
-you'll end up with a project like the following:
+When you initialize a project with `deno -A -r https://fresh.deno.dev`, you'll
+end up with a project like the following:
 
 ```txt Project Structure
 .
@@ -44,8 +44,8 @@ Here's what the diff of `deno.json` looks like:
  {
    "lock": false,
    "tasks": {
--    "start": "deno run -A --watch=static/,routes/ dev.ts"
-+    "start": "deno run -A --watch=src/static/,src/routes/ src/dev.ts"
+-    "start": "deno -A --watch=static/,routes/ dev.ts"
++    "start": "deno -A --watch=src/static/,src/routes/ src/dev.ts"
    },
    "imports": {
      "$fresh/": "file:///Users/reed/code/fresh/",

--- a/docs/latest/examples/init-the-server.md
+++ b/docs/latest/examples/init-the-server.md
@@ -84,10 +84,10 @@ have access to the complicated initialization step by calling
 
 ### Dev
 
-When you run `deno task start` you should see the following output:
+When you run `deno run start` you should see the following output:
 
 ```
-Task start deno run -A --watch=static/,routes/ dev.ts
+Task start deno -A --watch=static/,routes/ dev.ts
 Watcher Process started.
 i'm logged during initialization, and not during handling!
 The manifest has been generated for 6 routes and 1 islands.
@@ -105,10 +105,10 @@ Context { complicatedStartupValue: 42 }
 
 ### Build
 
-When you run `deno task build` you should see:
+When you run `deno run build` you should see:
 
 ```
-Task build deno run -A dev.ts build
+Task build deno -A dev.ts build
 i'm logged during initialization, and not during handling!
 The manifest has been generated for 6 routes and 1 islands.
 Assets written to: /path/to/my/project/_fresh
@@ -119,10 +119,10 @@ initialization occurred.
 
 ### Preview
 
-Finally when you run `deno task preview` you should see:
+Finally when you run `deno run preview` you should see:
 
 ```
-Task preview deno run -A main.ts
+Task preview deno -A main.ts
 i'm logged during initialization, and not during handling!
 Using snapshot found at /Users/reed/code/temp/1763/_fresh
 

--- a/docs/latest/examples/setting-the-language.md
+++ b/docs/latest/examples/setting-the-language.md
@@ -3,8 +3,8 @@ description: |
   Set the lang attribute in the <html> tag.
 ---
 
-When you initialize a project with `deno run -A -r https://fresh.deno.dev`,
-you'll end up with a `main.ts` like the following:
+When you initialize a project with `deno -A -r https://fresh.deno.dev`, you'll
+end up with a `main.ts` like the following:
 
 ```ts main.ts
 /// <reference no-default-lib="true" />

--- a/docs/latest/examples/using-fresh-canary-version.md
+++ b/docs/latest/examples/using-fresh-canary-version.md
@@ -17,7 +17,7 @@ instead this one particular commit? Just make the following changes to your
 `deno.json`:
 
 ```diff deno.json
-     "update": "deno run -A -r https://fresh.deno.dev/update ."
+     "update": "deno -A -r https://fresh.deno.dev/update ."
    },
    "imports": {
 -    "$fresh/": "https://deno.land/x/fresh@1.2.0/",
@@ -34,7 +34,7 @@ Here's an example of referencing a feature in a forked repository that hasn't
 been merged yet (at the time of writing this):
 
 ```diff deno.json
-     "update": "deno run -A -r https://fresh.deno.dev/update ."
+     "update": "deno -A -r https://fresh.deno.dev/update ."
    },
    "imports": {
 -    "$fresh/": "https://deno.land/x/fresh@1.2.0/",
@@ -54,13 +54,13 @@ create a test project based on your local changes.
 Instead of doing it like this:
 
 ```sh Terminal
-deno run -A -r https://fresh.deno.dev/
+deno -A -r https://fresh.deno.dev/
 ```
 
 do it like this:
 
 ```sh Terminal
-deno run -A -r path/to/fresh/init.ts
+deno -A -r path/to/fresh/init.ts
 ```
 
 (or wherever your local code lives)
@@ -72,5 +72,5 @@ create a project from the latest commit by combining the techniques on this page
 like this:
 
 ```sh Terminal
-deno run -A -r https://raw.githubusercontent.com/denoland/fresh/main/init.ts
+deno -A -r https://raw.githubusercontent.com/denoland/fresh/main/init.ts
 ```

--- a/docs/latest/examples/using-twind-v1.md
+++ b/docs/latest/examples/using-twind-v1.md
@@ -3,8 +3,8 @@ description: |
   With a few tweaks one can use twind v1
 ---
 
-When you initialize a project with `deno run -A -r https://fresh.deno.dev`,
-you'll end up with a `main.ts` like the following:
+When you initialize a project with `deno -A -r https://fresh.deno.dev`, you'll
+end up with a `main.ts` like the following:
 
 ```ts main.ts
 /// <reference no-default-lib="true" />

--- a/docs/latest/getting-started/create-a-project.md
+++ b/docs/latest/getting-started/create-a-project.md
@@ -10,9 +10,9 @@ will scaffold out a new project with some example files to get you started.
 To create a new project, run:
 
 ```sh Terminal
-deno run -A -r https://fresh.deno.dev
+deno -A -r https://fresh.deno.dev
 cd fresh-project
-deno task start
+deno run start
 ```
 
 This will scaffold out the new project, then switch into the newly created
@@ -38,7 +38,7 @@ two things:
   used to manage dependencies for the project. This allows for easy importing
   and updating of dependencies.
 - It registers a "start" [task][task-runner] to run the project without having
-  to type a long `deno run` command.
+  to type a long `deno` command.
 
 Two important folders are also created that contain your routes and islands
 respectively:

--- a/docs/latest/getting-started/deploy-to-production.md
+++ b/docs/latest/getting-started/deploy-to-production.md
@@ -19,7 +19,7 @@ new project.
 
 Click on the "New Project" button and select the GitHub repository that contains
 the Fresh project. Select the "Fresh" framework preset, and click on "Advanced
-options". Enter `deno task build` in the "Build command" field. Press "Create
+options". Enter `deno run build` in the "Build command" field. Press "Create
 project".
 
 The project will now deploy to Deno Deploy. After this is done, the project will

--- a/docs/latest/getting-started/running-locally.md
+++ b/docs/latest/getting-started/running-locally.md
@@ -1,22 +1,22 @@
 ---
 description: |
-  To start a Fresh project, just run `deno task start`. This will start the
+  To start a Fresh project, just run `deno run start`. This will start the
   project with default permission flags, in watch mode.
 ---
 
 The next step after scaffolding out a new project, is to actually start it. To
-do this you can just `deno task start`. Environment variables will be
+do this you can just `deno run start`. Environment variables will be
 automatically read from `.env`.
 
 ```sh Terminal
-$ deno task start
+$ deno run start
 Watcher Process started.
  🍋 Fresh ready
      Local: http://localhost:8000
 ```
 
-If you want to start manually without Deno task, `deno run` the `main.ts` with
-the appropriate flags. You will need to provide permission flags for:
+If you want to start manually without Deno task, `deno` the `main.ts` with the
+appropriate flags. You will need to provide permission flags for:
 
 - **`--allow-net`**: This is required to start the HTTP server.
 - **`--allow-read`**: This is required to read (static) files from disk.
@@ -45,13 +45,13 @@ await start(manifest, { server: { port: 3000 } });
 You can also change the port by setting the `PORT` environment variable:
 
 ```sh Terminal
-$ PORT=3000 deno task start
+$ PORT=3000 deno run start
 ```
 
-Combining all of this we get the following `deno run` command:
+Combining all of this we get the following `deno` command:
 
 ```sh Terminal
-$ deno run --allow-net --allow-read --allow-env --allow-run --watch=static/,routes/ main.ts
+$ deno --allow-net --allow-read --allow-env --allow-run --watch=static/,routes/ main.ts
 Watcher Process started.
  🍋 Fresh ready
      Local: http://localhost:8000

--- a/init/README.md
+++ b/init/README.md
@@ -3,7 +3,7 @@
 This is a CLI tool to bootstrap a new Fresh project. To do so, run this command:
 
 ```sh
-deno run -Ar jsr:@fresh/init
+deno -Ar jsr:@fresh/init
 ```
 
 Go to [https://fresh.deno.dev/](https://fresh.deno.dev/) for more information

--- a/init/src/init.ts
+++ b/init/src/init.ts
@@ -28,13 +28,13 @@ Initialize a new Fresh project. This will create all the necessary files for a
 new project.
 
 To generate a project in the './foobar' subdirectory:
-  deno run -Ar jsr:@fresh/init ./foobar
+  deno -Ar jsr:@fresh/init ./foobar
 
 To generate a project in the current directory:
-  deno run -Ar jsr:@fresh/init .
+  deno -Ar jsr:@fresh/init .
 
 USAGE:
-    deno run -Ar jsr:@fresh/init [DIRECTORY]
+    deno -Ar jsr:@fresh/init [DIRECTORY]
 
 OPTIONS:
     --force      Overwrite existing files
@@ -506,7 +506,7 @@ export default function Counter(props: CounterProps) {
 }`;
   await writeFile("islands/Counter.tsx", ISLANDS_COUNTER_TSX);
 
-  const DEV_TS = `#!/usr/bin/env -S deno run -A --watch=static/,routes/
+  const DEV_TS = `#!/usr/bin/env -S deno -A --watch=static/,routes/
 ${useTailwind ? `import { tailwind } from "@fresh/plugin-tailwind";\n` : ""}
 import { Builder } from "fresh/dev";
 import { app } from "./main.ts";
@@ -524,10 +524,10 @@ if (Deno.args.includes("build")) {
     tasks: {
       check:
         "deno fmt --check && deno lint && deno check **/*.ts && deno check **/*.tsx",
-      dev: "deno run -A --watch=static/,routes/ dev.ts",
-      build: "deno run -A dev.ts build",
-      start: "deno run -A main.ts",
-      update: "deno run -A -r jsr:@fresh/update .",
+      dev: "deno -A --watch=static/,routes/ dev.ts",
+      build: "deno -A dev.ts build",
+      start: "deno -A main.ts",
+      update: "deno -A -r jsr:@fresh/update .",
     },
     lint: {
       rules: {
@@ -576,7 +576,7 @@ Make sure to install Deno: https://deno.land/manual/getting_started/installation
 Then start the project in development mode:
 
 \`\`\`
-deno task dev
+deno run dev
 \`\`\`
 
 This will watch the project directory and restart as necessary.`;
@@ -691,7 +691,7 @@ This will watch the project directory and restart as necessary.`;
     );
   }
   tty.log(
-    "Run %cdeno task start%c to start the project. %cCTRL-C%c to stop.",
+    "Run %cdeno run start%c to start the project. %cCTRL-C%c to stop.",
     "color: cyan",
     "",
     "color: cyan",

--- a/src/build_cache.ts
+++ b/src/build_cache.ts
@@ -70,9 +70,9 @@ export class ProdBuildCache implements BuildCache {
             }, but did not find build snapshot at:\n${
               colors.red(snapshotPath)
             }.\n\nMaybe your forgot to run ${
-              colors.cyan("deno task build")
+              colors.cyan("deno run build")
             } before starting the production server\nor maybe you wanted to run ${
-              colors.cyan("deno task dev")
+              colors.cyan("deno run dev")
             } to spin up a development server instead?\n`,
           );
         }

--- a/src/dev/update_check.ts
+++ b/src/dev/update_check.ts
@@ -132,7 +132,7 @@ export async function updateCheck(
     );
     // deno-lint-ignore no-console
     console.log(
-      `    To upgrade, run: deno run -A -r https://fresh.deno.dev/update`,
+      `    To upgrade, run: deno -A -r https://fresh.deno.dev/update`,
     );
     // deno-lint-ignore no-console
     console.log();

--- a/src/finish_setup.tsx
+++ b/src/finish_setup.tsx
@@ -12,7 +12,7 @@ export function FinishSetup() {
               <code>Settings</code> tab.
             </li>
             <li>
-              In the Git Integration section, enter <code>deno task build</code>
+              In the Git Integration section, enter <code>deno run build</code>
               {" "}
               in the <code>Build Command</code> input.
             </li>
@@ -33,7 +33,7 @@ export function ForgotBuild() {
         <div style="max-width: 48rem; padding: 2rem 1rem; margin: 0 auto; font-family: sans-serif">
           <h1>Missing build directory</h1>
           <p>
-            Did you forget to run <code>deno task build</code>?
+            Did you forget to run <code>deno run build</code>?
           </p>
         </div>
       </div>

--- a/src/server/tailwind_aot_error_page.tsx
+++ b/src/server/tailwind_aot_error_page.tsx
@@ -16,7 +16,7 @@ export default function TailwindErrorPage() {
             <code>Settings</code> tab.
           </li>
           <li>
-            In the Git Integration section, enter <code>deno task build</code>
+            In the Git Integration section, enter <code>deno run build</code>
             {" "}
             in the <code>Build Command</code> input.
           </li>

--- a/tools/release.ts
+++ b/tools/release.ts
@@ -6,7 +6,7 @@ import * as semver from "@std/semver";
 function showHelp() {
   // deno-lint-ignore no-console
   console.log(`
-  Usage: deno run -A release.ts <major|minor|patch|...>
+  Usage: deno -A release.ts <major|minor|patch|...>
 `);
 }
 

--- a/update/README.md
+++ b/update/README.md
@@ -4,7 +4,7 @@ This is a CLI tool can be used to upgrade an existing Fresh project. To do so,
 run this command:
 
 ```sh
-deno run -Ar jsr:@fresh/update
+deno -Ar jsr:@fresh/update
 ```
 
 Go to [https://fresh.deno.dev/](https://fresh.deno.dev/) for more information

--- a/update/src/mod.ts
+++ b/update/src/mod.ts
@@ -12,7 +12,7 @@ Update a Fresh project. This updates dependencies and optionally performs code
 mods to update a project's source code to the latest recommended patterns.
 
 To upgrade a project in the current directory, run:
-  deno run -A jsr:@fresh/update .
+  deno -A jsr:@fresh/update .
 
 USAGE:
     @fresh/update [DIRECTORY]

--- a/www/README.md
+++ b/www/README.md
@@ -10,7 +10,7 @@ This is the Fresh website source. The Fresh website contains:
 Start the project:
 
 ```
-deno task start
+deno run start
 ```
 
 This will watch the project directory and restart as necessary.

--- a/www/components/homepage/Hero.tsx
+++ b/www/components/homepage/Hero.tsx
@@ -14,7 +14,7 @@ export function Hero(props: { origin: string }) {
             </h2>
             <div class="mt-12 flex flex-wrap justify-center items-stretch md:justify-start gap-4">
               <FancyLink href="/docs/getting-started">Get started</FancyLink>
-              <CopyArea code={`deno run -A -r ${props.origin}`} />
+              <CopyArea code={`deno -A -r ${props.origin}`} />
             </div>
           </div>
           <div class="md:col-span-2 flex justify-center items-end">

--- a/www/deno.json
+++ b/www/deno.json
@@ -1,9 +1,9 @@
 {
   "nodeModulesDir": true,
   "tasks": {
-    "start": "deno run -A --watch=static/,routes/,../src,../docs dev.ts",
-    "build": "deno run -A dev.ts build",
-    "preview": "deno run -A main.ts"
+    "start": "deno -A --watch=static/,routes/,../src,../docs dev.ts",
+    "build": "deno -A dev.ts build",
+    "preview": "deno -A main.ts"
   },
   "imports": {
     "$ga4": "https://raw.githubusercontent.com/denoland/ga4/main/mod.ts",

--- a/www/dev.ts
+++ b/www/dev.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run -A --watch=static/,routes/
+#!/usr/bin/env -S deno -A --watch=static/,routes/
 
 import { Builder } from "fresh/dev";
 import { app } from "./main.ts";


### PR DESCRIPTION
According to https://deno.com/blog/v1.46, we can use a simpler CLI for `deno run` and `deno task`.

### Changes

- Update all `deno run` to `deno`
- Update all `deno task` to `deno run`