### PR TITLE
fix: ensure file paths in snapshot.json uses /

### DIFF
--- a/src/dev/builder_test.ts
+++ b/src/dev/builder_test.ts
@@ -45,6 +45,33 @@ Deno.test({
 });
 
 Deno.test({
+  name: "Builder - handles Windows paths",
+  fn: async () => {
+    const builder = new Builder();
+    const tmp = await Deno.makeTempDir();
+    await Deno.mkdir(path.join(tmp, "images"));
+    await Deno.writeTextFile(
+      path.join(tmp, "images", "batman.svg"),
+      "<svg></svg>",
+    );
+    const app = new App({
+      staticDir: tmp,
+      build: {
+        outDir: path.join(tmp, "dist"),
+      },
+    });
+    await builder.build(app);
+
+    const snapshotJson = await Deno.readTextFile(
+      path.join(tmp, "dist", "snapshot.json"),
+    );
+    expect(snapshotJson).toContain("/images/batman.svg");
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});
+
+Deno.test({
   name: "Builder - hashes CSS urls by default",
   fn: async () => {
     const builder = new Builder();

--- a/src/dev/dev_build_cache.ts
+++ b/src/dev/dev_build_cache.ts
@@ -1,5 +1,6 @@
 import type { BuildCache, StaticFile } from "../build_cache.ts";
 import * as path from "@std/path";
+import { SEPARATOR as WINDOWS_SEPARATOR } from "@std/path/windows/constants";
 import type { ResolvedFreshConfig } from "../config.ts";
 import type { BuildSnapshot } from "../build_cache.ts";
 import { encodeHex } from "@std/encoding/hex";
@@ -174,7 +175,7 @@ export class DiskBuildCache implements DevBuildCache {
 
   addUnprocessedFile(pathname: string): void {
     this.#unprocessedFiles.set(
-      pathname,
+      pathname.replaceAll(WINDOWS_SEPARATOR, "/"),
       path.join(this.config.staticDir, pathname),
     );
   }


### PR DESCRIPTION
Avoids `\\\\` paths ending up in `snapshot.json` when using `deno task build` on Windows. Backslashes do not which pathnames in URLs, so these assets are not returned.

Closes #2703