### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/latest/getting-started/create-a-route.md
+++ b/docs/latest/getting-started/create-a-route.md
@@ -29,10 +29,11 @@ this, one needs to create a new `routes/about.tsx` file. In this file, we can
 declare a component that should be rendered every time a user visits the page.
 This is done with JSX.
 
-> [info]: To learn more about JSX, you can read [this article][jsx] in the React
+> [info]: To learn more about JSX, you can read
+> [this article](https://reactjs.org/docs/introducing-jsx.html) in the React
 > documentation. Beware that Fresh does not use React, but rather
-> [Preact][preact], a lighter weight virtual dom library that works similar to
-> React.
+> [Preact](https://preactjs.com), a lighter weight virtual dom library that
+> works similar to React.
 
 ```tsx routes/about.tsx
 export default function AboutPage() {
@@ -52,7 +53,5 @@ The new page will be visible at `http://localhost:8000/about`.
 pages in the _Getting Started_ guide will also explain more features of routes. -->
 
 [concepts-routing]: /docs/concepts/routing
-[jsx]: https://reactjs.org/docs/introducing-jsx.html
-[preact]: https://preactjs.com/
 
 <!-- [concepts-routes]: /docs/concepts/routes -->

--- a/docs/latest/getting-started/create-a-route.md
+++ b/docs/latest/getting-started/create-a-route.md
@@ -30,7 +30,7 @@ declare a component that should be rendered every time a user visits the page.
 This is done with JSX.
 
 > [info]: To learn more about JSX, you can read
-> [this article](https://reactjs.org/docs/introducing-jsx.html) in the React
+> [this article](https://react.dev/learn/writing-markup-with-jsx) in the React
 > documentation. Beware that Fresh does not use React, but rather
 > [Preact](https://preactjs.com), a lighter weight virtual dom library that
 > works similar to React.


### PR DESCRIPTION
This PR:
1. fixes two broken links in the Getting Started documentation
2. updates the link to React's JSX docs to the lastest documentation; (the existing link leads to documentation that is no longer updated)

Screenshot of the broken links - even though they work correctly when viewing the markdown files, they break when rendered in the browser because they're both inside an info block, which breaks the internal link.
<img width="829" alt="Screenshot 2024-10-19 at 10 37 56 PM" src="https://github.com/user-attachments/assets/896495bf-9a6d-454f-a8fa-4ec8f8b0245a">

Screenshot of the warning seen at the existing JSX link https://react.dev/learn/writing-markup-with-jsx
[
<img width="937" alt="Screenshot 2024-10-19 at 10 41 28 PM" src="https://github.com/user-attachments/assets/ba4e5f40-cd17-43dd-8181-dc4beb09bac0">
](url)
