### PR TITLE
docs: update deno version in example Dockerfile for deployment

### DIFF
--- a/docs/latest/concepts/deployment.md
+++ b/docs/latest/concepts/deployment.md
@@ -36,7 +36,7 @@ caching **will** cause your project to not function correctly.
 Here is an example `Dockerfile` for a Fresh project:
 
 ```dockerfile Dockerfile
-FROM denoland/deno:1.38.3
+FROM denoland/deno:2.0.6
 
 ARG GIT_REVISION
 ENV DENO_DEPLOYMENT_ID=${GIT_REVISION}


### PR DESCRIPTION
some context: i developed the Fresh app with Deno 2.0

using the previous version will result in an error log that looks something like this

```
 => ERROR [4/4] RUN deno cache main.ts                                                                                                                                 0.3s 
------
 > [4/4] RUN deno cache main.ts:
0.273 error: invalid type: string "auto", expected a boolean
------
Dockerfile:9
--------------------
   7 |
   8 |     COPY . .
   9 | >>> RUN deno cache main.ts
  10 |
  11 |     EXPOSE 8000
--------------------
ERROR: failed to solve: process "/bin/sh -c deno cache main.ts" did not complete successfully: exit code: 1
```

using the new version fixed the issue