### PR TITLE
fix: tests broken on Deno 2.1

### DIFF
--- a/init/src/init_test.ts
+++ b/init/src/init_test.ts
@@ -7,7 +7,7 @@ import { withChildProcessServer } from "../../tests/test_utils.tsx";
 
 async function withTmpDir(fn: (dir: string) => void | Promise<void>) {
   const hash = crypto.randomUUID().replaceAll(/-/g, "");
-  const dir = path.join(import.meta.dirname!, "..", "..", `tmp-${hash}`);
+  const dir = path.join(import.meta.dirname!, "..", "..", `tmp_${hash}`);
   await Deno.mkdir(dir, { recursive: true });
 
   try {


### PR DESCRIPTION
Resolves https://github.com/denoland/fresh/issues/2771

Specifically the `init` test fails:
```
deno test -A ./init
```
Output:
```
error: No target files found.
----- output end -----
init - fmt, lint, and type check project ... FAILED (157ms)
init with tailwind - fmt, lint, and type check project ...
------- output -------
Task check deno fmt --check && deno lint && deno check **/*.ts && deno check **/*.tsx
error: No target files found.
----- output end -----
init with tailwind - fmt, lint, and type check project ... FAILED (136ms)
```

Seems to be a gitignore issue, and _probably_ relates to the new features that ["lint an fmt respect gitignore"](https://github.com/denoland/deno/pull/26897):
- the gitignore file in the fresh project has `tmp-*`
- the tmp directory created by the init test matches that pattern: `tmp-${hash}`
- changing the tmp directory to `tmp_${hash}` resolves the issue 😄 