### PR TITLE
feat(plugins/fs-routes): allow to customize fresh app tree and exts

### DIFF
--- a/src/plugins/fs_routes/mod.ts
+++ b/src/plugins/fs_routes/mod.ts
@@ -51,6 +51,9 @@ export interface FsRoutesOptions {
   ignoreFilePattern?: RegExp[];
   loadRoute: (path: string) => Promise<unknown>;
   loadIsland: (path: string) => Promise<unknown>;
+  islandDir?: string;
+  routesDir?: string;
+  fileExts?: string[];
 }
 
 export interface TESTING_ONLY__FsRoutesOptions {
@@ -68,8 +71,8 @@ export async function fsRoutes<State>(
   const dir = options.dir
     ? parseRootPath(options.dir, fs.cwd())
     : app.config.root;
-  const islandDir = path.join(dir, "islands");
-  const routesDir = path.join(dir, "routes");
+  const islandDir = path.join(dir, options.islandDir ?? "islands");
+  const routesDir = path.join(dir, options.routesDir ?? "routes");
 
   const islandPaths: string[] = [];
   const relRoutePaths: string[] = [];
@@ -83,6 +86,7 @@ export async function fsRoutes<State>(
       },
       ignore,
       fs,
+      options.fileExts ?? [],
     ),
     walkDir(
       routesDir,
@@ -105,6 +109,7 @@ export async function fsRoutes<State>(
       },
       ignore,
       fs,
+      options.fileExts ?? [],
     ),
   ]);
 
@@ -364,13 +369,14 @@ async function walkDir(
   callback: (entry: WalkEntry) => void,
   ignore: RegExp[],
   fs: FsAdapter,
+  exts: string[],
 ) {
   if (!await fs.isDirectory(dir)) return;
 
   const entries = fs.walk(dir, {
     includeDirs: false,
     includeFiles: true,
-    exts: ["tsx", "jsx", "ts", "js"],
+    exts: ["tsx", "jsx", "ts", "js", ...exts],
     skip: ignore,
   });
 


### PR DESCRIPTION
Currently __fresh__ enforce usage of `routes` and `islands` as respectively "routes" and "islands" directory.
Also __fresh__ only support `js(x)` and `ts(x)` files extensions to registers routes.

I currently facing a problem using __fresh__ to build project to render `mdx` files with a custom semantic.
Despite options to overload "island" and "route" loading there is no options to define other roots.
This PR allow to customize the default behavior of routes and islands registrations.

For example:
```ts
await fsRoutes(app, {
    dir: './',
    loadIsland: (path) => import(`./islands/${path}`),
    loadRoute: async (path) => {
        const { default: Page, frontmatter } = path.endsWith('.mdx')
            ? await compileMdx(`./pages/${path}`)
            : await import(`./pages/${path}`)
    
        // Define Page component
        // Pass PageProps and allow custom props
	const Component =
            (pageProps: PageProps) => (props: Record<string, unknown>) =>
            Page({ ...pageProps, ...props })

        // Define App Wrapper
        const Wrapper = (props: PageProps) =>
            Template({ ...props, Component: Component(props), frontmatter })

        // Load wrapped route
        return { default: Wrapper }
    },
    routesDir: 'pages',
    fileExts: ['mdx'],
})
``` 

This allow the following directory structure:

```
Mode  Size Name
d----    -   .
d----    -  ├──  components
-a---  146  │   ├──  Authors.tsx
-----  232  │   ├──  Button.tsx
-----  492  │   ├──  Katex.tsx
-----  182  │   ├──  PapexBadge.tsx
-a---  653  │   └──  Raw.tsx
-a---  153  ├──  config.ts
-a--- 1.2k  ├──  deno.json
d----    -  ├──  islands
-----  361  │   ├──  Counter.tsx
-a---  769  │   └──  Plotly.tsx
----- 1.9k  ├──  main.ts
d----    -  ├──  pages
----- 1.1k  │   └──  main.mdx
-a---  381  └──  README.md
```