### PR TITLE
docs: update rendering-markdown.md

### DIFF
--- a/docs/latest/examples/rendering-markdown.md
+++ b/docs/latest/examples/rendering-markdown.md
@@ -93,7 +93,7 @@ description: testFromText
 You'll also need to import the `Github Flavored Markdown` module:
 
 ```bash
-deno add @deno/gfm
+deno add jsr:@deno/gfm
 ```
 
 Andy has a helpful [post](https://deno.com/blog/build-a-blog-with-fresh) on the


### PR DESCRIPTION
When using deno add @deno/gfm outputs the following:
```
error: @deno/gfm is missing a prefix. Did you mean `deno add jsr:@deno/gfm`?
```
Then when jsr is specified:
```
deno add jsr:@deno/gfm
Add jsr:@deno/gfm@0.10.0
```

deno --version: 2.1.4