### PR TITLE
fix: middlewares not being used with default GET handlers

### DIFF
--- a/src/plugins/fs_routes/mod.ts
+++ b/src/plugins/fs_routes/mod.ts
@@ -296,7 +296,10 @@ export async function fsRoutes<State>(
         isHandlerByMethod(handlers) &&
         !Object.keys(handlers).includes("GET");
       if (missingGetHandler) {
-        app.get(routePath, renderMiddleware(components, undefined));
+        const combined = middlewares.concat(
+          renderMiddleware(components, undefined),
+        );
+        app.get(routePath, ...combined);
       }
     }
 


### PR DESCRIPTION
I noticed a small bug with the default GET handlers where middlewares were not being run. This pull requests fixes the bug and adds some unit tests for this behavior.