### PR TITLE
fix: route middleware order with groups

### DIFF
--- a/src/plugins/fs_routes/mod.ts
+++ b/src/plugins/fs_routes/mod.ts
@@ -400,37 +400,18 @@ export function sortRoutePaths(a: string, b: string) {
   let aIdx = 0;
   let bIdx = 0;
   for (; aIdx < aLen && bIdx < bLen; aIdx++, bIdx++) {
-    let charA = a.charAt(aIdx);
-    let charB = b.charAt(bIdx);
+    const charA = a.charAt(aIdx);
+    const charB = b.charAt(bIdx);
 
     // When comparing a grouped route with a non-grouped one, we
     // need to skip over the group name to effectively compare the
     // actual route.
     if (charA === "(" && charB !== "(") {
-      aIdx++;
-
-      while (aIdx < aLen) {
-        charA = a.charAt(aIdx);
-        if (charA === ")") {
-          aIdx += 2;
-          charA = a.charAt(aIdx);
-          break;
-        }
-
-        aIdx++;
-      }
+      if (charB == "[") return -1;
+      return 1;
     } else if (charB === "(" && charA !== "(") {
-      bIdx++;
-      while (bIdx < bLen) {
-        charB = b.charAt(bIdx);
-        if (charB === ")") {
-          bIdx += 2;
-          charB = b.charAt(bIdx);
-          break;
-        }
-
-        bIdx++;
-      }
+      if (charA == "[") return 1;
+      return -1;
     }
 
     if (charA === "/" || charB === "/") {

--- a/src/plugins/fs_routes/mod_test.tsx
+++ b/src/plugins/fs_routes/mod_test.tsx
@@ -1164,6 +1164,54 @@ Deno.test("fsRoutes - sortRoutePaths", () => {
   expect(routes).toEqual(sorted);
 });
 
+Deno.test("fsRoutes - sortRoutePaths with groups", () => {
+  let routes = [
+    "/(authed)/_middleware.ts",
+    "/(authed)/index.ts",
+    "/about.tsx",
+  ];
+  routes.sort(sortRoutePaths);
+  let sorted = [
+    "/about.tsx",
+    "/(authed)/_middleware.ts",
+    "/(authed)/index.ts",
+  ];
+  expect(routes).toEqual(sorted);
+
+  routes = [
+    "/_app",
+    "/(authed)/_middleware",
+    "/(authed)/_layout",
+    "/_error",
+    "/(authed)/index",
+    "/login",
+    "/auth/login",
+    "/auth/logout",
+    "/(authed)/(account)/account",
+    "/(authed)/api/slug",
+    "/hooks/github",
+    "/(authed)/[org]/_middleware",
+    "/(authed)/[org]/index",
+  ];
+  routes.sort(sortRoutePaths);
+  sorted = [
+    "/_app",
+    "/_error",
+    "/login",
+    "/auth/login",
+    "/auth/logout",
+    "/hooks/github",
+    "/(authed)/_middleware",
+    "/(authed)/_layout",
+    "/(authed)/index",
+    "/(authed)/api/slug",
+    "/(authed)/(account)/account",
+    "/(authed)/[org]/_middleware",
+    "/(authed)/[org]/index",
+  ];
+  expect(routes).toEqual(sorted);
+});
+
 Deno.test("fsRoutes - registers default GET route for component without GET handler", async () => {
   const server = await createServer<{ value: boolean }>({
     "routes/noGetHandler.tsx": {


### PR DESCRIPTION
This is a follow-up fix to https://github.com/denoland/fresh/pull/2792

The original fix skipped over route groups which lead to them being mixed with non-grouped routes. This in turn confused the middleware processing part when building the final routes.