### PR TITLE
Update rendering-markdown.md

### DIFF
--- a/docs/latest/examples/rendering-markdown.md
+++ b/docs/latest/examples/rendering-markdown.md
@@ -93,7 +93,7 @@ description: testFromText
 You'll also need to import the `Github Flavored Markdown` module:
 
 ```bash
-deno add @deno/gfm
+deno add jsr:@deno/gfm
 ```
 
 Andy has a helpful [post](https://deno.com/blog/build-a-blog-with-fresh) on the


### PR DESCRIPTION
This pull request includes a small change to the `docs/latest/examples/rendering-markdown.md` file. The change updates the command for adding the `Github Flavored Markdown` module to use the correct package identifier. 

* [`docs/latest/examples/rendering-markdown.md`](diffhunk://#diff-14167f5491528fb9d7a1bdac0dba504bfc819fedb207389e476d17fdad8d4a73L96-R96): Updated the command from `deno add @deno/gfm` to `deno add jsr:@deno/gfm`.