### PR TITLE
www: docs: fix: Header nav items shouldn't wrap on mobile

### DIFF
--- a/www/components/Footer.tsx
+++ b/www/components/Footer.tsx
@@ -26,7 +26,7 @@ export default function Footer(props: JSX.HTMLAttributes<HTMLElement>) {
           <span>© {new Date().getFullYear()} the Fresh authors</span>
         </div>
 
-        <div class="sm:hidden">
+        <div class="text-foreground-secondary [&_li]:hover:text-green-600 hover:text-green-600 [&_ul]:space-x-5 [&_.github]:hidden">
           <SocialIcons />
         </div>
 

--- a/www/components/Footer.tsx
+++ b/www/components/Footer.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from "preact";
+import * as Icons from "./Icons.tsx";
 
 const LINKS = [
   {
@@ -24,6 +25,27 @@ export default function Footer(props: JSX.HTMLAttributes<HTMLElement>) {
         <div class="text-foreground-secondary text-center">
           <span>© {new Date().getFullYear()} the Fresh authors</span>
         </div>
+
+        <ul class="flex items-center gap-x-2 sm:gap-4 m-2 sm:my-6 flex-wrap lg:mx-8 2xl:mr-0">
+          <li class="sm:hidden items-center">
+            <a
+              href="https://github.com/denoland/fresh"
+              class="hover:text-green-600 inline-block transition"
+              aria-label="GitHub"
+            >
+              <Icons.GitHub />
+            </a>
+          </li>
+          <li class="sm:hidden items-center">
+            <a
+              href="https://discord.com/invite/deno"
+              class="hover:text-green-600 inline-block transition"
+              aria-label="Discord"
+            >
+              <Icons.Discord />
+            </a>
+          </li>
+        </ul>
 
         <div class="flex items-center gap-8">
           {LINKS.map((link) => (

--- a/www/components/Footer.tsx
+++ b/www/components/Footer.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from "preact";
 import * as Icons from "./Icons.tsx";
+import SocialIcons from "./SocialIcons.tsx";
 
 const LINKS = [
   {
@@ -26,26 +27,9 @@ export default function Footer(props: JSX.HTMLAttributes<HTMLElement>) {
           <span>© {new Date().getFullYear()} the Fresh authors</span>
         </div>
 
-        <ul class="flex items-center gap-x-2 sm:gap-4 m-2 sm:my-6 flex-wrap lg:mx-8 2xl:mr-0">
-          <li class="sm:hidden items-center">
-            <a
-              href="https://github.com/denoland/fresh"
-              class="hover:text-green-600 inline-block transition"
-              aria-label="GitHub"
-            >
-              <Icons.GitHub />
-            </a>
-          </li>
-          <li class="sm:hidden items-center">
-            <a
-              href="https://discord.com/invite/deno"
-              class="hover:text-green-600 inline-block transition"
-              aria-label="Discord"
-            >
-              <Icons.Discord />
-            </a>
-          </li>
-        </ul>
+        <div class="sm:hidden">
+          <SocialIcons />
+        </div>
 
         <div class="flex items-center gap-8">
           {LINKS.map((link) => (

--- a/www/components/Footer.tsx
+++ b/www/components/Footer.tsx
@@ -1,5 +1,4 @@
 import type { JSX } from "preact";
-import * as Icons from "./Icons.tsx";
 import SocialIcons from "./SocialIcons.tsx";
 
 const LINKS = [

--- a/www/components/Header.tsx
+++ b/www/components/Header.tsx
@@ -29,7 +29,7 @@ export default function Header(props: { title: string; active: string }) {
         <div class="hidden sm:flex">
           <SocialIcons />
         </div>
-        <div class="flex px-3 sm:px-6">
+        <div class="flex px-3 sm:px-6 fill-foreground-primary hover:fill-fresh transition">
           {isDocs && <ThemeToggle />}
         </div>
       </div>

--- a/www/components/Header.tsx
+++ b/www/components/Header.tsx
@@ -11,7 +11,7 @@ export default function Header(props: { title: string; active: string }) {
         "mx-auto flex gap-3 items-center",
         isHome ? "justify-end h-20 max-w-screen-xl" : "justify-between",
         isDocs
-          ? "h-20 max-w-screen-2xl w-full sticky top-0 bg-background-primary  z-50 backdrop-blur-sm"
+          ? "h-20 max-w-screen-2xl w-full sticky top-0 bg-background-primary/75 z-50 backdrop-blur-sm"
           : "",
         isShowcase ? "max-w-screen-xl w-full" : "",
       ].join(" ")}

--- a/www/components/Header.tsx
+++ b/www/components/Header.tsx
@@ -1,5 +1,6 @@
 import ThemeToggle from "../islands/ThemeToggle.tsx";
 import NavigationBar from "./NavigationBar.tsx";
+import SocialIcons from "./SocialIcons.tsx";
 
 export default function Header(props: { title: string; active: string }) {
   const isHome = props.active == "/";
@@ -25,7 +26,10 @@ export default function Header(props: { title: string; active: string }) {
       )}
       <div class="flex justify-end">
         <NavigationBar class="" active={props.active} />
-        <div class="flex pr-3 pl-3 sm:pl-0 sm:pr-6">
+        <div class="hidden sm:flex">
+          <SocialIcons />
+        </div>
+        <div class="flex px-3 sm:px-6">
           {isDocs && <ThemeToggle />}
         </div>
       </div>

--- a/www/components/Header.tsx
+++ b/www/components/Header.tsx
@@ -1,3 +1,4 @@
+import ThemeToggle from "../islands/ThemeToggle.tsx";
 import NavigationBar from "./NavigationBar.tsx";
 
 export default function Header(props: { title: string; active: string }) {
@@ -22,7 +23,12 @@ export default function Header(props: { title: string; active: string }) {
           <Logo />
         </div>
       )}
-      <NavigationBar class="" active={props.active} />
+      <div class="flex justify-end">
+        <NavigationBar class="" active={props.active} />
+        <div class="flex pr-3 pl-3 sm:pl-0 sm:pr-6">
+          {isDocs && <ThemeToggle />}
+        </div>
+      </div>
     </header>
   );
 }

--- a/www/components/Header.tsx
+++ b/www/components/Header.tsx
@@ -10,7 +10,7 @@ export default function Header(props: { title: string; active: string }) {
   return (
     <header
       class={[
-        "mx-auto flex gap-3 items-center",
+        "mx-auto flex gap-1 sm:gap-3 items-center",
         isHome ? "justify-end h-20 max-w-screen-xl" : "justify-between",
         isDocs
           ? "h-20 max-w-screen-2xl w-full sticky top-0 bg-background-primary/75 z-50 backdrop-blur-sm"
@@ -20,13 +20,13 @@ export default function Header(props: { title: string; active: string }) {
       f-client-nav={false}
     >
       {!isHome && (
-        <div class="p-4 flex items-center">
+        <div class="p-2 md:p-4 flex items-center">
           <Logo />
         </div>
       )}
       <div class="flex justify-end">
         <NavigationBar class="" active={props.active} />
-        <div class="hidden sm:flex">
+        <div class="flex [&_.github]:hidden [&_.github]:sm:flex [&_ul]:space-x-2 [&_ul]:sm:space-x-4 [&_li:hover]:text-green-600">
           <SocialIcons />
         </div>
         <div class="flex px-3 sm:px-6 fill-foreground-primary hover:fill-fresh [&_*]:transition ">
@@ -39,7 +39,11 @@ export default function Header(props: { title: string; active: string }) {
 
 export function Logo() {
   return (
-    <a href="/" class="flex mr-3 items-center shrink-0" aria-label="Top Page">
+    <a
+      href="/"
+      class="flex sm:mr-3 items-center shrink-0"
+      aria-label="Top Page"
+    >
       <img
         src="/logo.svg"
         alt="Fresh logo"

--- a/www/components/Header.tsx
+++ b/www/components/Header.tsx
@@ -29,7 +29,7 @@ export default function Header(props: { title: string; active: string }) {
         <div class="hidden sm:flex">
           <SocialIcons />
         </div>
-        <div class="flex px-3 sm:px-6 fill-foreground-primary hover:fill-fresh transition">
+        <div class="flex px-3 sm:px-6 fill-foreground-primary hover:fill-fresh [&_*]:transition ">
           {isDocs && <ThemeToggle />}
         </div>
       </div>

--- a/www/components/Header.tsx
+++ b/www/components/Header.tsx
@@ -29,7 +29,7 @@ export default function Header(props: { title: string; active: string }) {
         <div class="flex [&_.github]:hidden [&_.github]:sm:flex [&_ul]:space-x-2 [&_ul]:sm:space-x-4 [&_li:hover]:text-green-600">
           <SocialIcons />
         </div>
-        <div class="flex px-3 sm:px-6 fill-foreground-primary hover:fill-fresh [&_*]:transition ">
+        <div class="flex px-3 sm:px-4 sm:sr-6 fill-foreground-primary hover:fill-fresh [&_*]:transition ">
           {isDocs && <ThemeToggle />}
         </div>
       </div>

--- a/www/components/NavigationBar.tsx
+++ b/www/components/NavigationBar.tsx
@@ -1,5 +1,3 @@
-import * as Icons from "./Icons.tsx";
-
 export default function NavigationBar(
   props: { active: string; class?: string },
 ) {
@@ -38,25 +36,6 @@ export default function NavigationBar(
             </a>
           </li>
         ))}
-
-        <li class="hidden sm:flex items-center">
-          <a
-            href="https://github.com/denoland/fresh"
-            class="hover:text-green-600 inline-block transition"
-            aria-label="GitHub"
-          >
-            <Icons.GitHub />
-          </a>
-        </li>
-        <li class="hidden sm:flex items-center">
-          <a
-            href="https://discord.com/invite/deno"
-            class="hover:text-green-600 inline-block transition"
-            aria-label="Discord"
-          >
-            <Icons.Discord />
-          </a>
-        </li>
       </ul>
     </nav>
   );

--- a/www/components/NavigationBar.tsx
+++ b/www/components/NavigationBar.tsx
@@ -22,9 +22,9 @@ export default function NavigationBar(
   const isDocs = props.active == "/docs";
   return (
     <nav class={"flex " + (props.class ?? "")} f-client-nav={false}>
-      <ul class="flex items-center gap-x-2 sm:gap-4 mx-4 my-2 sm:my-6 flex-wrap lg:mx-8 2xl:mr-0">
+      <ul class="flex items-center gap-x-2 sm:gap-4 m-2 sm:my-6 flex-wrap lg:mx-8 2xl:mr-0">
         {items.map((item) => (
-          <li key={item.name}>
+          <li key={item.name} class="mt-[2px]">
             <a
               href={item.href}
               class={`p-1 sm:p-2 ${

--- a/www/components/NavigationBar.tsx
+++ b/www/components/NavigationBar.tsx
@@ -40,7 +40,7 @@ export default function NavigationBar(
           </li>
         ))}
 
-        <li class="flex items-center">
+        <li class="hidden sm:flex items-center">
           <a
             href="https://github.com/denoland/fresh"
             class="hover:text-green-600 inline-block transition"
@@ -49,7 +49,7 @@ export default function NavigationBar(
             <Icons.GitHub />
           </a>
         </li>
-        <li class="flex items-center">
+        <li class="hidden sm:flex items-center">
           <a
             href="https://discord.com/invite/deno"
             class="hover:text-green-600 inline-block transition"

--- a/www/components/NavigationBar.tsx
+++ b/www/components/NavigationBar.tsx
@@ -1,4 +1,3 @@
-import ThemeToggle from "../islands/ThemeToggle.tsx";
 import * as Icons from "./Icons.tsx";
 
 export default function NavigationBar(
@@ -22,7 +21,7 @@ export default function NavigationBar(
   const isDocs = props.active == "/docs";
   return (
     <nav class={"flex " + (props.class ?? "")} f-client-nav={false}>
-      <ul class="flex items-center gap-x-2 sm:gap-4 m-2 sm:my-6 flex-wrap lg:mx-8 2xl:mr-0">
+      <ul class="flex items-center gap-x-2 sm:gap-4 m-2 sm:my-6 flex-wrap sm:mx-8">
         {items.map((item) => (
           <li key={item.name} class="mt-[2px]">
             <a
@@ -58,11 +57,6 @@ export default function NavigationBar(
             <Icons.Discord />
           </a>
         </li>
-        {isDocs && (
-          <li class="flex items-center">
-            <ThemeToggle />
-          </li>
-        )}
       </ul>
     </nav>
   );

--- a/www/components/SocialIcons.tsx
+++ b/www/components/SocialIcons.tsx
@@ -2,20 +2,20 @@ import * as Icons from "./Icons.tsx";
 
 export default function SocialIcons() {
   return (
-    <ul class="flex items-center align-center space-x-5 md:mx-8">
-      <li class="flex">
+    <ul class="flex items-center align-center">
+      <li class="flex github">
         <a
           href="https://github.com/denoland/fresh"
-          class="hover:text-green-600 inline-block transition"
+          class="inline-block transition"
           aria-label="GitHub"
         >
           <Icons.GitHub />
         </a>
       </li>
-      <li class="flex">
+      <li class="flex discord">
         <a
           href="https://discord.com/invite/deno"
-          class="hover:text-green-600 inline-block transition"
+          class="inline-block transition"
           aria-label="Discord"
         >
           <Icons.Discord />

--- a/www/components/SocialIcons.tsx
+++ b/www/components/SocialIcons.tsx
@@ -1,0 +1,26 @@
+import * as Icons from "./Icons.tsx";
+
+export default function SocialIcons() {
+  return (
+    <ul class="flex items-center align-center space-x-5 md:mx-8">
+      <li class="flex">
+        <a
+          href="https://github.com/denoland/fresh"
+          class="hover:text-green-600 inline-block transition"
+          aria-label="GitHub"
+        >
+          <Icons.GitHub />
+        </a>
+      </li>
+      <li class="flex">
+        <a
+          href="https://discord.com/invite/deno"
+          class="hover:text-green-600 inline-block transition"
+          aria-label="Discord"
+        >
+          <Icons.Discord />
+        </a>
+      </li>
+    </ul>
+  );
+}

--- a/www/islands/ThemeToggle.tsx
+++ b/www/islands/ThemeToggle.tsx
@@ -44,7 +44,7 @@ export default function ThemeToggle() {
         )
         : (
           <svg
-            class="fill-foreground-primary hover:fill-fresh w-6 h-6"
+            class="w-6 h-6"
             viewBox="0 0 20 20"
             xmlns="http://www.w3.org/2000/svg"
           >

--- a/www/islands/ThemeToggle.tsx
+++ b/www/islands/ThemeToggle.tsx
@@ -28,7 +28,7 @@ export default function ThemeToggle() {
     <button
       type="button"
       onClick={toggleTheme}
-      class="dark-mode-toggle button p-1 sm:p-2 -m-1"
+      class="dark-mode-toggle button"
       aria-label="Toggle Theme"
     >
       {theme === "light"

--- a/www/islands/ThemeToggle.tsx
+++ b/www/islands/ThemeToggle.tsx
@@ -28,7 +28,7 @@ export default function ThemeToggle() {
     <button
       type="button"
       onClick={toggleTheme}
-      class="dark-mode-toggle button p-1 -m-1"
+      class="dark-mode-toggle button p-1 sm:p-2 -m-1"
       aria-label="Toggle Theme"
     >
       {theme === "light"

--- a/www/islands/ThemeToggle.tsx
+++ b/www/islands/ThemeToggle.tsx
@@ -1,12 +1,23 @@
 import { useEffect, useState } from "preact/hooks";
 import { IS_BROWSER } from "fresh/runtime";
 
+// Use this (e.g. from _app.tsx) in the Head tag like this:
+// import {headScript} from "../islands/ThemeToggle.tsx";
+// <script src={`data:text/javascript, ${headScript}`}>
+export const headScript = `
+  document.documentElement.classList.toggle(
+    "dark",
+    localStorage.theme === "dark" ||
+      (!("theme" in localStorage) &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches),
+);`.replace(/(\n|\t)/g, "").replace(/"/g, "'");
+
 export default function ThemeToggle() {
   const getPreferredTheme = () => {
     if (!IS_BROWSER) return "light";
     const storedTheme = localStorage.getItem("theme");
     if (storedTheme) return storedTheme;
-    return window.matchMedia("(prefers-color-scheme: dark)").matches
+    return globalThis.window.matchMedia("(prefers-color-scheme: dark)").matches
       ? "dark"
       : "light";
   };
@@ -26,38 +37,40 @@ export default function ThemeToggle() {
   };
 
   return (
-    <button
-      type="button"
-      onClick={toggleTheme}
-      class="dark-mode-toggle button"
-      aria-label="Toggle Theme"
-    >
-      {theme === "light"
-        ? (
-          <svg
-            class="fill-foreground-primary hover:fill-fresh w-6 h-6"
-            viewBox="0 0 20 20"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z">
-            </path>
-          </svg>
-        )
-        : (
-          <svg
-            class="w-6 h-6"
-            viewBox="0 0 20 20"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1
-                  0 100-2H3a1 1 0 000 2h1z"
-              fill-rule="evenodd"
-              clip-rule="evenodd"
+    <>
+      <button
+        type="button"
+        onClick={toggleTheme}
+        class="dark-mode-toggle button fill-foreground-primary hover:fill-fresh"
+        aria-label="Toggle Theme"
+      >
+        {theme === "light"
+          ? (
+            <svg
+              class="w-6 h-6"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
             >
-            </path>
-          </svg>
-        )}
-    </button>
+              <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z">
+              </path>
+            </svg>
+          )
+          : (
+            <svg
+              class="w-6 h-6"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1
+                  0 100-2H3a1 1 0 000 2h1z"
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+              >
+              </path>
+            </svg>
+          )}
+      </button>
+    </>
   );
 }

--- a/www/islands/ThemeToggle.tsx
+++ b/www/islands/ThemeToggle.tsx
@@ -1,23 +1,12 @@
 import { useEffect, useState } from "preact/hooks";
 import { IS_BROWSER } from "fresh/runtime";
 
-// Use this (e.g. from _app.tsx) in the Head tag like this:
-// import {headScript} from "../islands/ThemeToggle.tsx";
-// <script src={`data:text/javascript, ${headScript}`}>
-export const headScript = `
-  document.documentElement.classList.toggle(
-    "dark",
-    localStorage.theme === "dark" ||
-      (!("theme" in localStorage) &&
-        window.matchMedia("(prefers-color-scheme: dark)").matches),
-);`.replace(/(\n|\t)/g, "").replace(/"/g, "'");
-
 export default function ThemeToggle() {
   const getPreferredTheme = () => {
     if (!IS_BROWSER) return "light";
     const storedTheme = localStorage.getItem("theme");
     if (storedTheme) return storedTheme;
-    return globalThis.window.matchMedia("(prefers-color-scheme: dark)").matches
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
       ? "dark"
       : "light";
   };
@@ -37,40 +26,38 @@ export default function ThemeToggle() {
   };
 
   return (
-    <>
-      <button
-        type="button"
-        onClick={toggleTheme}
-        class="dark-mode-toggle button fill-foreground-primary hover:fill-fresh"
-        aria-label="Toggle Theme"
-      >
-        {theme === "light"
-          ? (
-            <svg
-              class="w-6 h-6"
-              viewBox="0 0 20 20"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z">
-              </path>
-            </svg>
-          )
-          : (
-            <svg
-              class="w-6 h-6"
-              viewBox="0 0 20 20"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1
+    <button
+      type="button"
+      onClick={toggleTheme}
+      class="dark-mode-toggle button"
+      aria-label="Toggle Theme"
+    >
+      {theme === "light"
+        ? (
+          <svg
+            class="fill-foreground-primary hover:fill-fresh w-6 h-6"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z">
+            </path>
+          </svg>
+        )
+        : (
+          <svg
+            class="w-6 h-6"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1
                   0 100-2H3a1 1 0 000 2h1z"
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-              >
-              </path>
-            </svg>
-          )}
-      </button>
-    </>
+              fill-rule="evenodd"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        )}
+    </button>
   );
 }

--- a/www/islands/ThemeToggle.tsx
+++ b/www/islands/ThemeToggle.tsx
@@ -17,11 +17,12 @@ export default function ThemeToggle() {
     document.documentElement.classList.remove("light", "dark");
     document.documentElement.classList.add(theme);
     document.documentElement.setAttribute("data-theme", theme);
-    localStorage.setItem("theme", theme);
   }, [theme]);
 
   const toggleTheme = () => {
-    setTheme((prev) => (prev === "light" ? "dark" : "light"));
+    const newTheme = theme === "light" ? "dark" : "light";
+    setTheme(newTheme);
+    localStorage.setItem("theme", newTheme);
   };
 
   return (

--- a/www/routes/_app.tsx
+++ b/www/routes/_app.tsx
@@ -1,6 +1,5 @@
 import { asset } from "fresh/runtime";
 import { define } from "../utils/state.ts";
-import { headScript as themeToggleScriptString } from "../islands/ThemeToggle.tsx";
 
 export default define.page(function App({ Component, state, url }) {
   return (
@@ -24,8 +23,6 @@ export default define.page(function App({ Component, state, url }) {
           ? <meta property="og:image" content={state.ogImage} />
           : null}
         {state.noIndex ? <meta name="robots" content="noindex" /> : null}
-        <script src={`data:text/javascript, ${themeToggleScriptString}`}>
-        </script>
         <link
           rel="preload"
           href={asset("/fonts/FixelVariable.woff2")}

--- a/www/routes/_app.tsx
+++ b/www/routes/_app.tsx
@@ -1,5 +1,6 @@
 import { asset } from "fresh/runtime";
 import { define } from "../utils/state.ts";
+import { headScript as themeToggleScriptString } from "../islands/ThemeToggle.tsx";
 
 export default define.page(function App({ Component, state, url }) {
   return (
@@ -23,6 +24,8 @@ export default define.page(function App({ Component, state, url }) {
           ? <meta property="og:image" content={state.ogImage} />
           : null}
         {state.noIndex ? <meta name="robots" content="noindex" /> : null}
+        <script src={`data:text/javascript, ${themeToggleScriptString}`}>
+        </script>
         <link
           rel="preload"
           href={asset("/fonts/FixelVariable.woff2")}


### PR DESCRIPTION
Following up on #2820 

I noticed the addition of the extra icon in the nav bar made the nav items in the Header newline wrap on small screens (mobile smaller than sm).
![image](https://github.com/user-attachments/assets/5020c6b2-1f5e-4ad5-bd24-68376e2af40f)

This pull request fixes that by doing the following:

- On mobile: Hides GitHub social icon in Header

Some other changes I snuck in:

- Reintroduced semi-transparent backgorund on header
- Adjustments to spacing/alignment on Header items
- Refactor ThemeToggle Island to be less Deno Fresh specific (more reusable)
- Refactor social icons into SocialIcons component (removed duplication)
- Added Discord social icon to Footer on all screen sizes