### PR TITLE
Add new partials mode “upsert”

### DIFF
--- a/docs/latest/concepts/partials.md
+++ b/docs/latest/concepts/partials.md
@@ -176,6 +176,8 @@ achieved by adding the `mode` prop to a `Partial` component.
 - `replace` - Swap out the content of the existing partial (default)
 - `prepend` - Insert the new content before the existing content
 - `append` - Insert the new content after the existing content
+- `upsert` - Will swap out direct child nodes with matching `key` prop. If no
+  match is found, then append the new content.
 
 Personally, we’ve found that the `append` mode is really useful when you have an
 UI which displays log messages or similar list-like data.
@@ -194,8 +196,8 @@ export default function LogView() {
 }
 ```
 
-> [info]: When picking the `prepend` or `append` mode, make sure to add keys to
-> the elements.
+> [info]: When picking the `prepend`, `upsert` or `append` mode, make sure to
+> add keys to the elements.
 
 ## Bypassing or disabling Partials
 

--- a/src/runtime/client/partials.ts
+++ b/src/runtime/client/partials.ts
@@ -1,4 +1,4 @@
-import { type ComponentChildren, h } from "preact";
+import { type ComponentChildren, h, toChildArray } from "preact";
 import {
   CLIENT_NAV_ATTR,
   DATA_ANCESTOR,
@@ -497,6 +497,50 @@ function revivePartials(
 
               (instance.props.children as ComponentChildren[]).unshift(
                 root.props.children,
+              );
+            } else {
+              instance.props.children = root.props.children;
+            }
+          } else if (partialMode === PartialMode.Upsert) {
+            const active = ACTIVE_PARTIALS.get(partialName);
+            if (active !== undefined) {
+              copyOldChildren(
+                instance.props,
+                toChildArray(active.props.children),
+              );
+
+              toChildArray(root.props.children).forEach(
+                (newChild) => {
+                  if (
+                    newChild && typeof newChild === "object" &&
+                    "key" in newChild
+                  ) {
+                    const replaceAtIndex =
+                      (instance.props.children as ComponentChildren[])
+                        .findIndex(
+                          (oldChild) => {
+                            if (
+                              oldChild && typeof oldChild === "object" &&
+                              "key" in oldChild
+                            ) {
+                              return newChild.key === oldChild.key;
+                            }
+                            return false;
+                          },
+                        );
+                    if (replaceAtIndex === -1) {
+                      (instance.props.children as ComponentChildren[]).push(
+                        newChild,
+                      );
+                    } else {
+                      (instance.props.children as ComponentChildren[]).splice(
+                        replaceAtIndex,
+                        1,
+                        newChild,
+                      );
+                    }
+                  }
+                },
               );
             } else {
               instance.props.children = root.props.children;

--- a/src/runtime/server/preact_hooks.tsx
+++ b/src/runtime/server/preact_hooks.tsx
@@ -126,7 +126,9 @@ options[OptionsType.VNODE] = (vnode) => {
         ? PartialMode.Replace
         : props.mode === "append"
         ? PartialMode.Append
-        : PartialMode.Prepend;
+        : props.mode === "prepend"
+        ? PartialMode.Prepend
+        : PartialMode.Upsert;
       props.children = wrapWithMarker(
         props.children,
         "partial",

--- a/src/runtime/shared.ts
+++ b/src/runtime/shared.ts
@@ -44,7 +44,7 @@ export interface PartialProps {
    * Define how the new HTML should be applied.
    * @default {"replace"}
    */
-  mode?: "replace" | "prepend" | "append";
+  mode?: "replace" | "prepend" | "append" | "upsert";
 }
 
 export function Partial(props: PartialProps): VNode {

--- a/src/runtime/shared_internal.tsx
+++ b/src/runtime/shared_internal.tsx
@@ -54,6 +54,7 @@ export const enum PartialMode {
   Replace,
   Append,
   Prepend,
+  Upsert,
 }
 
 /**


### PR DESCRIPTION
Forgive me, this is my first ever pull request. I only have experience as a solo web developer, so this is outside my comfort zone.

I propose adding an additional mode for partials to complement `replace`, `append`, and `prepend`. At this stage I have called it `upsert`.

It functions similar to append, however each direct child node in the Partial update with a ‘key’ prop is compared to the direct children of the corresponding Partial already in the document. If a match is found, it will swap out that element, otherwise it will append the new node to the existing content.

I believe this has several use cases, the simplest I can think would be a todo list, where individual todo items can be sent to the client to populate a list, or update as they are modified, without using islands or any additional client side JavaScript. Another example, which is my specific use case, is that I need to update a list of recent chats in a messaging app as new messages arrive. Rather than send another copy of the entire list on each update, I can send just the individual item, which would feature an unread message badge. My current work around is using global state to maintain an array of the DOM nodes, and sending that list to the server with every request, in order to determine whether a message is coming from someone already in the recent list or not, so I don’t end up with duplicates. 

If adding this additional `mode` is considered adding unnecessary complexity, then an alternative solution might be that both `append` and `prepend` would automatically substitute child nodes if a matching key is detected. Preact warns about having duplicate keys in component children already, but Fresh will currently not check this.

I am happy to take on feedback, both for this feature, as well as the correct etiquette for pull requests. Once I submit this I will create an issue and link it, because I think that’s what I supposed to do.