### PR TITLE
docs: Fix build command in deployment documentation

### DIFF
--- a/docs/latest/concepts/deployment.md
+++ b/docs/latest/concepts/deployment.md
@@ -76,7 +76,7 @@ that includes all assets and dependencies. This executable can run on any
 platform without requiring Deno to be installed.
 
 ```sh Terminal
-$ deno build
+$ deno task build
 $ deno compile --include static --include _fresh --include deno.json -A main.ts
 ```
 


### PR DESCRIPTION
The `Self Contained Executable` instructions in the `Deployment` documentation contains an error in the sample code.

```sh Terminal
$ deno build
$ deno compile --include static --include _fresh --include deno.json -A main.ts
```

should be:

```sh Terminal
$ deno task build
$ deno compile --include static --include _fresh --include deno.json -A main.ts
```

This PR fixes that.