### PR TITLE
fix(init): fix ignore path, restore check task in init script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ vendor/
 node_modules/
 .docs/
 .DS_Store
-tmp_*

--- a/init/src/init.ts
+++ b/init/src/init.ts
@@ -554,8 +554,7 @@ if (Deno.args.includes("build")) {
   const denoJson = {
     tasks: {
       check:
-        // Revert once https://github.com/denoland/deno/issues/28923 is fixed
-        "deno fmt --check . && deno lint . && deno check **/*.ts && deno check **/*.tsx",
+        "deno fmt --check && deno lint && deno check **/*.ts && deno check **/*.tsx",
       dev: "deno run -A --watch=static/,routes/ dev.ts",
       build: "deno run -A dev.ts build",
       start: "deno run -A main.ts",


### PR DESCRIPTION
This PR restores the original `check` task by reverting the change in https://github.com/denoland/fresh/commit/d87e47d15fc7d801f5bd4935503a11e0bd94388b

The 'init' test cases fail when `tmp_*` is included in `.gitignore` because the test case populates the template in `tmp_<random hex number>`, and that causes `deno lint` and `deno fmt --check` fail.