### PR TITLE
Fix: Prevent input value leakage by generating unique keys for Partia…

### DIFF
--- a/src/runtime/client/partials.ts
+++ b/src/runtime/client/partials.ts
@@ -457,8 +457,11 @@ function revivePartials(
           sib as Comment,
         );
 
+        // Always generate a unique key for PartialComp to avoid vnode reuse when switching partials, which fixes input value leakage issues.
+        const uniqueKey = (partialKey !== "" ? partialKey : "partial") + "-" +
+          Date.now();
         const root = h(PartialComp, {
-          key: partialKey !== "" ? partialKey : undefined,
+          key: uniqueKey,
           name: partialName,
           mode: partialMode,
           children: null,


### PR DESCRIPTION
…lComp([2.0 bug] different/incorrect behaviour due to bump fresh@1.7.3 up to @fresh/core@^2.0.0-alpha.29 #2850)