### PR TITLE
BREAKING(core): remove `Mode` type

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,4 @@
 import * as path from "@std/path";
-import type { Mode } from "./runtime/server/mod.ts";
 
 export interface FreshConfig {
   root?: string;
@@ -30,9 +29,9 @@ export interface ResolvedFreshConfig {
   basePath: string;
   staticDir: string;
   /**
-   * Tells you in which mode Fresh is currently running in.
+   * The mode Fresh can run in.
    */
-  mode: Mode;
+  mode: "development" | "production";
 }
 
 export function parseRootPath(root: string, cwd: string): string {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -12,7 +12,6 @@ export {
 export type { RouteConfig } from "./types.ts";
 export type { Middleware, MiddlewareFn } from "./middlewares/mod.ts";
 export { staticFiles } from "./middlewares/static_files.ts";
-export type { Mode } from "./runtime/server/mod.ts";
 export type { FreshConfig, ResolvedFreshConfig } from "./config.ts";
 export type { FreshContext, Island, PageProps } from "./context.ts";
 export { createDefine, type Define } from "./define.ts";

--- a/src/runtime/server/mod.ts
+++ b/src/runtime/server/mod.ts
@@ -1,4 +1,0 @@
-/**
- * The mode Fresh can run in.
- */
-export type Mode = "development" | "production";


### PR DESCRIPTION
It doesn't seem like it deserves to be it's own type. It can just be an interface property.