### PR TITLE
fix: do not skip app-wrapper for sibling routes

### DIFF
--- a/src/plugins/fs_routes/mod.ts
+++ b/src/plugins/fs_routes/mod.ts
@@ -221,12 +221,10 @@ export async function fsRoutes<State>(
 
       // _app template
       if (skipApp && mod.path === "/_app") {
-        hasApp = false;
         continue;
       } else if (!skipApp && mod.config?.skipAppWrapper) {
         skipApp = true;
         if (hasApp) {
-          hasApp = false;
           // _app component is always first
           components.shift();
         }

--- a/src/plugins/fs_routes/mod_test.tsx
+++ b/src/plugins/fs_routes/mod_test.tsx
@@ -558,6 +558,56 @@ Deno.test("fsRoutes - route overrides _app", async () => {
   expect(doc.body.firstChild?.textContent).toEqual("route");
 });
 
+Deno.test("fsRoutes - route overrides _app does not affect other routes", async () => {
+  const server = await createServer({
+    "routes/_500.tsx": {
+      config: { skipInheritedLayouts: true },
+      default: () => <>error!</>,
+    },
+    "routes/_app.tsx": {
+      default: (ctx) => (
+        <div>
+          app/<ctx.Component />
+        </div>
+      ),
+    },
+    "routes/_layout.tsx": {
+      default: (ctx) => (
+        <>
+          layout/<ctx.Component />
+        </>
+      ),
+    },
+    // By having "bar" come before "foo", this results in a bug
+    // where the app wrapper is missing from "foo".
+    "routes/bar.tsx": {
+      config: {
+        skipAppWrapper: true,
+        skipInheritedLayouts: true,
+      },
+      default: () => <>bar</>,
+    },
+    "routes/index.tsx": { default: () => <>index</> },
+    "routes/foo.tsx": { default: () => <>foo</> },
+  });
+
+  const [indexRes, fooRes, barRes] = await Promise.all([
+    server.get("/"),
+    server.get("/foo"),
+    server.get("/bar"),
+  ]);
+  const [index, foo, bar] = await Promise.all([
+    indexRes.text(),
+    fooRes.text(),
+    barRes.text(),
+  ]);
+  expect(parseHtml(index).body.firstChild?.textContent).toEqual(
+    "app/layout/index",
+  );
+  expect(parseHtml(foo).body.firstChild?.textContent).toEqual("app/layout/foo");
+  expect(parseHtml(bar).body.firstChild?.textContent).toEqual("bar");
+});
+
 Deno.test("fsRoutes - handler return data", async () => {
   const server = await createServer({
     "routes/index.tsx": {


### PR DESCRIPTION
This PR adds a unit test for the issue in #2910. I have not found a solution yet, since I'm not very familiar with the `fsRoutes` code, and what it is doing. But a thought a unit test with the failing code could help to find a bug fix.

**Edit:** I managed to fix the failing test by removing a couple of lines, but I'm not too familiar with the code so I'm not sure if it's correct. It seems to pass all the tests still...

Closes #2910