### PR TITLE
Docs: Correct the /docs/introduction French loanwords in it into Engl…

### DIFF
--- a/docs/latest/introduction/index.md
+++ b/docs/latest/introduction/index.md
@@ -37,7 +37,7 @@ Some stand out features:
 - Highly resilient because of progressive enhancement and use of native browser
   features
 - TypeScript out of the box
-- File-system routing à la Next.js
+- File-system routing inspired by Next.js
 
 [preact]: https://preactjs.com
 [deno]: https://deno.com


### PR DESCRIPTION
…ish.

Correct the French loanwords in the "/docs/introduction" document. In this document, I've found French loanwords and I will replace them with their corresponding English words to improve the language consistency of the document.