### PR TITLE
fix: allow relative paths for outDir and staticDir

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -49,13 +49,15 @@ export function parseRootPath(root: string, cwd: string): string {
     root = path.dirname(root);
   }
 
+  if (Deno.build.os === "windows") {
+    root = root.replaceAll("\\", "/");
+  }
+
   return root;
 }
 
 export function normalizeConfig(options: FreshConfig): ResolvedFreshConfig {
-  const root = options.root
-    ? parseRootPath(options.root, Deno.cwd())
-    : Deno.cwd();
+  const root = parseRootPath(options.root ?? ".", Deno.cwd());
 
   return {
     root,

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,25 +35,35 @@ export interface ResolvedFreshConfig {
 }
 
 export function parseRootPath(root: string, cwd: string): string {
-  if (root.startsWith("file://")) {
-    root = path.fromFileUrl(root);
-  } else if (!path.isAbsolute(root)) {
-    root = path.join(cwd, root);
+  return parseDirPath(root, cwd, true);
+}
+
+function parseDirPath(
+  dirPath: string,
+  root: string,
+  fileToDir = false,
+): string {
+  if (dirPath.startsWith("file://")) {
+    dirPath = path.fromFileUrl(dirPath);
+  } else if (!path.isAbsolute(dirPath)) {
+    dirPath = path.join(root, dirPath);
   }
 
-  const ext = path.extname(root);
-  if (
-    ext === ".ts" || ext === ".tsx" || ext === ".js" || ext === ".jsx" ||
-    ext === ".mjs"
-  ) {
-    root = path.dirname(root);
+  if (fileToDir) {
+    const ext = path.extname(dirPath);
+    if (
+      ext === ".ts" || ext === ".tsx" || ext === ".js" || ext === ".jsx" ||
+      ext === ".mjs"
+    ) {
+      dirPath = path.dirname(dirPath);
+    }
   }
 
   if (Deno.build.os === "windows") {
-    root = root.replaceAll("\\", "/");
+    dirPath = dirPath.replaceAll("\\", "/");
   }
 
-  return root;
+  return dirPath;
 }
 
 export function normalizeConfig(options: FreshConfig): ResolvedFreshConfig {
@@ -62,10 +72,10 @@ export function normalizeConfig(options: FreshConfig): ResolvedFreshConfig {
   return {
     root,
     build: {
-      outDir: options.build?.outDir ?? path.join(root, "_fresh"),
+      outDir: parseDirPath(options.build?.outDir ?? "_fresh", root),
     },
     basePath: options.basePath ?? "",
-    staticDir: options.staticDir ?? path.join(root, "static"),
+    staticDir: parseDirPath(options.staticDir ?? "static", root),
     mode: "production",
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,20 +1,37 @@
 import * as path from "@std/path";
 
 export interface FreshConfig {
+  /**
+   * The root directory of the Fresh project.
+   *
+   * Other paths, such as `build.outDir`, `staticDir`, and `fsRoutes()`
+   * are resolved relative to this directory.
+   * @default Deno.cwd()
+   */
   root?: string;
   build?: {
     /**
      * The directory to write generated files to when `dev.ts build` is run.
+     *
      * This can be an absolute path, a file URL or a relative path.
+     * Relative paths are resolved against the `root` option.
+     * @default "_fresh"
      */
     outDir?: string;
   };
   /**
    * Serve fresh from a base path instead of from the root.
    *   "/foo/bar" -> http://localhost:8000/foo/bar
-   * @default {undefined}
+   * @default undefined
    */
   basePath?: string;
+  /**
+   * The directory to serve static files from.
+   *
+   * This can be an absolute path, a file URL or a relative path.
+   * Relative paths are resolved against the `root` option.
+   * @default "static"
+   */
   staticDir?: string;
 }
 

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { normalizeConfig, parseRootPath } from "./config.ts";
+import type { FreshConfig } from "./mod.ts";
 
 Deno.test("parseRootPath", () => {
   const cwd = Deno.cwd().replaceAll("\\", "/");
@@ -44,4 +45,64 @@ Deno.test("normalizeConfig - root", () => {
     expect(configRoot("C:/foo/bar.ts")).toEqual("C:/foo");
     expect(configRoot("file:///C:/foo/bar")).toEqual("C:/foo/bar");
   }
+});
+
+Deno.test("normalizeConfig - build.outDir", () => {
+  const cwd = Deno.cwd().replaceAll("\\", "/");
+  const outDir = (options: FreshConfig) =>
+    normalizeConfig(options).build.outDir;
+
+  // Default outDir
+  expect(outDir({ root: "./src" })).toEqual(`${cwd}/src/_fresh`);
+  expect(outDir({ root: "/src" })).toEqual("/src/_fresh");
+  expect(outDir({ root: "file:///src" })).toEqual("/src/_fresh");
+
+  // Relative outDir
+  expect(outDir({ root: "/src", build: { outDir: "dist" } })).toEqual(
+    "/src/dist",
+  );
+  expect(outDir({ root: "/src", build: { outDir: "./dist" } })).toEqual(
+    "/src/dist",
+  );
+
+  // Absolute outDir
+  expect(outDir({ root: "/src", build: { outDir: "/dist" } })).toEqual(
+    "/dist",
+  );
+  expect(outDir({ root: "/src", build: { outDir: "/dist/fresh" } })).toEqual(
+    "/dist/fresh",
+  );
+  expect(outDir({ root: "/src", build: { outDir: "file:///dist" } })).toEqual(
+    "/dist",
+  );
+});
+
+Deno.test("normalizeConfig - staticDir", () => {
+  const cwd = Deno.cwd().replaceAll("\\", "/");
+  const staticDir = (options: FreshConfig) =>
+    normalizeConfig(options).staticDir;
+
+  // Default staticDir
+  expect(staticDir({ root: "./src" })).toEqual(`${cwd}/src/static`);
+  expect(staticDir({ root: "/src" })).toEqual("/src/static");
+  expect(staticDir({ root: "file:///src" })).toEqual("/src/static");
+
+  // Relative staticDir
+  expect(staticDir({ root: "/src", staticDir: "public" })).toEqual(
+    "/src/public",
+  );
+  expect(staticDir({ root: "/src", staticDir: "./public" })).toEqual(
+    "/src/public",
+  );
+
+  // Absolute staticDir
+  expect(staticDir({ root: "/src", staticDir: "/public" })).toEqual(
+    "/public",
+  );
+  expect(staticDir({ root: "/src", staticDir: "/public/assets" })).toEqual(
+    "/public/assets",
+  );
+  expect(staticDir({ root: "/src", staticDir: "file:///public" })).toEqual(
+    "/public",
+  );
 });

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { parseRootPath } from "./config.ts";
+import { normalizeConfig, parseRootPath } from "./config.ts";
 
 Deno.test("parseRootPath", () => {
   const cwd = Deno.cwd().replaceAll("\\", "/");
@@ -26,5 +26,22 @@ Deno.test("parseRootPath", () => {
   if (Deno.build.os === "windows") {
     expect(parseRootPath("C:/foo/bar", cwd)).toEqual("C:/foo/bar");
     expect(parseRootPath("C:/foo/bar.ts", cwd)).toEqual("C:/foo");
+  }
+});
+
+Deno.test("normalizeConfig - root", () => {
+  const cwd = Deno.cwd().replaceAll("\\", "/");
+  const configRoot = (root?: string) => normalizeConfig({ root }).root;
+
+  expect(configRoot()).toEqual(cwd);
+  expect(configRoot("/foo/bar")).toEqual("/foo/bar");
+  expect(configRoot("/foo/bar.ts")).toEqual("/foo");
+  expect(configRoot("file:///foo/bar")).toEqual("/foo/bar");
+  expect(configRoot("./foo/bar")).toEqual(`${cwd}/foo/bar`);
+  expect(configRoot("./foo/bar.ts")).toEqual(`${cwd}/foo`);
+
+  if (Deno.build.os === "windows") {
+    expect(configRoot("C:/foo/bar.ts")).toEqual("C:/foo");
+    expect(configRoot("file:///C:/foo/bar")).toEqual("C:/foo/bar");
   }
 });

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -1,15 +1,30 @@
 import { expect } from "@std/expect";
 import { parseRootPath } from "./config.ts";
 
-// FIXME: Windows
-Deno.test.ignore("parseRootPath", () => {
-  const cwd = Deno.cwd();
+Deno.test("parseRootPath", () => {
+  const cwd = Deno.cwd().replaceAll("\\", "/");
+
+  // File paths
   expect(parseRootPath("file:///foo/bar", cwd)).toEqual("/foo/bar");
   expect(parseRootPath("file:///foo/bar.ts", cwd)).toEqual("/foo");
+  if (Deno.build.os === "windows") {
+    expect(parseRootPath("file:///C:/foo/bar", cwd)).toEqual("C:/foo/bar");
+    expect(parseRootPath("file:///C:/foo/bar.ts", cwd)).toEqual("C:/foo");
+  }
+
+  // Relative paths
+  expect(parseRootPath("./foo/bar", cwd)).toEqual(`${cwd}/foo/bar`);
+  expect(parseRootPath("./foo/bar.ts", cwd)).toEqual(`${cwd}/foo`);
+
+  // Absolute paths
   expect(parseRootPath("/foo/bar", cwd)).toEqual("/foo/bar");
   expect(parseRootPath("/foo/bar.ts", cwd)).toEqual("/foo");
   expect(parseRootPath("/foo/bar.tsx", cwd)).toEqual("/foo");
   expect(parseRootPath("/foo/bar.js", cwd)).toEqual("/foo");
   expect(parseRootPath("/foo/bar.jsx", cwd)).toEqual("/foo");
   expect(parseRootPath("/foo/bar.mjs", cwd)).toEqual("/foo");
+  if (Deno.build.os === "windows") {
+    expect(parseRootPath("C:/foo/bar", cwd)).toEqual("C:/foo/bar");
+    expect(parseRootPath("C:/foo/bar.ts", cwd)).toEqual("C:/foo");
+  }
 });


### PR DESCRIPTION
This PR consists of several commits, where the goal is to re-enable the test (fix for Windows), as well as allow relative paths for config options to address #2913.

1. Re-enables test and normalizes paths for Windows
2. Add unit test for `normalizeConfig` and the `root` option
3. Add unit test for `normalizeConfig` for `build.outDir` and `staticDir`, and allow the properties to be relative
4. Add JSDoc for fields in `FreshConfig`

I can split these into separate PR's if preferred, but all code changes are very in nearly the same places.

Closes #2913