### PR TITLE
fix: remove unnecessary config property in init script

### DIFF
--- a/init/src/init.ts
+++ b/init/src/init.ts
@@ -403,6 +403,7 @@ ${GRADIENT_CSS}`;
 import { define, type State } from "./utils.ts";
 
 export const app = new App<State>();
+
 app.use(staticFiles());
 
 // this is the same as the /api/:name route defined via a file. feel free to delete this!
@@ -421,7 +422,6 @@ const exampleLoggerMiddleware = define.middleware((ctx) => {
 app.use(exampleLoggerMiddleware);
 
 await fsRoutes(app, {
-  dir: "./",
   loadIsland: (path) => import(\`./islands/\${path}\`),
   loadRoute: (path) => import(\`./routes/\${path}\`),
 });

--- a/src/plugins/fs_routes/mod.ts
+++ b/src/plugins/fs_routes/mod.ts
@@ -47,6 +47,12 @@ function isFreshFile<State>(mod: any): mod is FreshFsItem<State> {
 }
 
 export interface FsRoutesOptions {
+  /**
+   * Parent directory for the `/routes` and `/islands` folders.
+   *
+   * By default, the `root` config option of the provided app is used.
+   * @default app.config.root
+   */
   dir?: string;
   ignoreFilePattern?: RegExp[];
   loadRoute: (path: string) => Promise<unknown>;


### PR DESCRIPTION
From what I can see, `fsRoutes` uses the `FreshConfig.root` option by default, so this property does not need to be specified. I also added some JSDoc for the `dir` option in `fsRoutes()` as I understood it's purpose.