### PR TITLE
fix(partial): form `dialog` method not supported

### DIFF
--- a/src/runtime/client/partials.ts
+++ b/src/runtime/client/partials.ts
@@ -219,10 +219,7 @@ document.addEventListener("submit", async (e) => {
     const lowerMethod =
       e.submitter?.getAttribute("formmethod")?.toLowerCase() ??
         el.method.toLowerCase();
-    if (
-      lowerMethod !== "get" && lowerMethod !== "post" &&
-      lowerMethod !== "dialog"
-    ) {
+    if (lowerMethod !== "get" && lowerMethod !== "post") {
       return;
     }
 

--- a/tests/partials_test.tsx
+++ b/tests/partials_test.tsx
@@ -1834,6 +1834,45 @@ Deno.test({
 });
 
 Deno.test({
+  name: "partials - submit form dialog should do nothing",
+  fn: async () => {
+    const app = testApp()
+      .post("/partial", () => {
+        throw new Error("FAIL");
+      })
+      .get("/", (ctx) => {
+        return ctx.render(
+          <Doc>
+            <div f-client-nav>
+              <dialog open>
+                <p>Greetings, one and all!</p>
+                <form method="dialog">
+                  <Partial name="foo">
+                    <p class="init">init</p>
+                  </Partial>
+                  <SelfCounter />
+                  <button type="submit" class="update">OK</button>
+                </form>
+              </dialog>
+            </div>
+          </Doc>,
+        );
+      });
+
+    await withBrowserApp(app, async (page, address) => {
+      await page.goto(address, { waitUntil: "load" });
+      await page.locator(".ready").wait();
+
+      await page.locator(".increment").click();
+      await waitForText(page, ".output", "1");
+
+      await page.locator(".update").click();
+      await page.locator("dialog:not([open])").wait();
+    });
+  },
+});
+
+Deno.test({
   name: "partials - submit form redirect",
   fn: async () => {
     const app = testApp()


### PR DESCRIPTION
The `<form>` method value `dialog` does no network request, so we should ignore it for partials.

Fixes https://github.com/denoland/fresh/issues/2885