### PR TITLE
fix(esbuild): disable spammy warning for monaco editor

### DIFF
--- a/src/dev/esbuild.ts
+++ b/src/dev/esbuild.ts
@@ -50,6 +50,9 @@ export async function bundleJs(
     treeShaking: true,
     sourcemap: options.dev ? "linked" : false,
     minify: !options.dev,
+    logOverride: {
+      "suspicious-nullish-coalescing": "silent",
+    },
 
     jsxDev: options.dev,
     jsx: "automatic",


### PR DESCRIPTION
It's a super spammy warning message when you're using the monaco editor. They have code like that as the result of minifcation.

Fixes https://github.com/denoland/fresh/issues/2775