### PR TITLE
fix: make static folders with dot such as `.well-known` allowed

### DIFF
--- a/src/build_cache.ts
+++ b/src/build_cache.ts
@@ -111,7 +111,7 @@ export class ProdBuildCache implements BuildCache {
       : path.join(base, pathname);
 
     // Check if path resolves outside of intended directory.
-    if (path.relative(base, filePath).startsWith(".")) {
+    if (path.relative(base, filePath).startsWith("..")) {
       return null;
     }
 

--- a/src/build_cache_test.ts
+++ b/src/build_cache_test.ts
@@ -1,0 +1,78 @@
+import { expect } from "@std/expect";
+import * as path from "@std/path";
+import { ProdBuildCache, type StaticFile } from "./build_cache.ts";
+import type { ResolvedFreshConfig } from "./mod.ts";
+
+async function getContent(readResult: Promise<StaticFile | null>) {
+  const res = await readResult;
+  if (res === null) return null;
+  if (res.readable instanceof Uint8Array) throw new Error("not implemented");
+  return new Response(res.readable).text();
+}
+
+Deno.test({
+  name: "ProdBuildCache - should error if reading outside of staticDir",
+  fn: async () => {
+    const tmp = await Deno.makeTempDir();
+    const config: ResolvedFreshConfig = {
+      root: tmp,
+      mode: "production",
+      basePath: "/",
+      staticDir: path.join(tmp, "static"),
+      build: {
+        outDir: path.join(tmp, "dist"),
+      },
+    };
+    await Deno.mkdir(path.join(tmp, "static", ".well-known"), {
+      recursive: true,
+    });
+    await Deno.mkdir(path.join(tmp, "dist", "static"), {
+      recursive: true,
+    });
+    await Promise.all([
+      Deno.writeTextFile(
+        path.join(tmp, "dist", "secret-styles.css"),
+        "SECRET!",
+      ),
+      Deno.writeTextFile(path.join(tmp, "SECRETS.txt"), "SECRET!"),
+      Deno.writeTextFile(path.join(tmp, "dist", "static", "styles.css"), "OK"),
+      Deno.writeTextFile(
+        path.join(tmp, "static", ".well-known", "foo.txt"),
+        "OK",
+      ),
+    ]);
+    const buildCache = new ProdBuildCache(
+      config,
+      new Map(),
+      new Map([
+        ["../secret-styles.css", { generated: true, hash: "SECRET!" }],
+        ["../SECRETS.txt", { generated: false, hash: "SECRET!" }],
+        ["./../secret-styles.css", { generated: true, hash: "SECRET!" }],
+        ["./../SECRETS.txt", { generated: false, hash: "SECRET!" }],
+        ["styles.css", { generated: true, hash: "OK" }],
+        [".well-known/foo.txt", { generated: false, hash: "OK" }],
+        ["./styles.css", { generated: true, hash: "OK" }],
+        ["./.well-known/foo.txt", { generated: false, hash: "OK" }],
+      ]),
+      true,
+    );
+
+    const secret1 = getContent(buildCache.readFile("../styles.css"));
+    const secret2 = getContent(buildCache.readFile("../SECRETS.txt"));
+    const secret3 = getContent(buildCache.readFile("./../styles.css"));
+    const secret4 = getContent(buildCache.readFile("./../SECRETS.txt"));
+    const public1 = getContent(buildCache.readFile("styles.css"));
+    const public2 = getContent(buildCache.readFile(".well-known/foo.txt"));
+    const public3 = getContent(buildCache.readFile("./styles.css"));
+    const public4 = getContent(buildCache.readFile("./.well-known/foo.txt"));
+
+    await expect(secret1).resolves.toBe(null);
+    await expect(secret2).resolves.toBe(null);
+    await expect(secret3).resolves.toBe(null);
+    await expect(secret4).resolves.toBe(null);
+    await expect(public1).resolves.toBe("OK");
+    await expect(public2).resolves.toBe("OK");
+    await expect(public3).resolves.toBe("OK");
+    await expect(public4).resolves.toBe("OK");
+  },
+});

--- a/src/dev/dev_build_cache.ts
+++ b/src/dev/dev_build_cache.ts
@@ -77,7 +77,7 @@ export class MemoryBuildCache implements DevBuildCache {
     let entry = pathname.startsWith("/") ? pathname.slice(1) : pathname;
     entry = path.join(this.config.staticDir, entry);
     const relative = path.relative(this.config.staticDir, entry);
-    if (relative.startsWith(".")) {
+    if (relative.startsWith("..")) {
       throw new Error(
         `Processed file resolved outside of static dir ${entry}`,
       );

--- a/src/dev/dev_build_cache_test.ts
+++ b/src/dev/dev_build_cache_test.ts
@@ -1,0 +1,45 @@
+import { expect } from "@std/expect";
+import * as path from "@std/path";
+import { MemoryBuildCache } from "./dev_build_cache.ts";
+import { FreshFileTransformer } from "./file_transformer.ts";
+import { createFakeFs } from "../test_utils.ts";
+import type { ResolvedFreshConfig } from "../mod.ts";
+
+Deno.test({
+  name: "MemoryBuildCache - should error if reading outside of staticDir",
+  fn: async () => {
+    const tmp = await Deno.makeTempDir();
+    const config: ResolvedFreshConfig = {
+      root: tmp,
+      mode: "development",
+      basePath: "/",
+      staticDir: path.join(tmp, "static"),
+      build: {
+        outDir: path.join(tmp, "dist"),
+      },
+    };
+    const fileTransformer = new FreshFileTransformer(createFakeFs({}));
+    const buildCache = new MemoryBuildCache(
+      config,
+      "testing",
+      fileTransformer,
+      "latest",
+    );
+
+    const thrown = buildCache.readFile("../SECRETS.txt");
+    const thrown2 = buildCache.readFile("./../../SECRETS.txt");
+    const noThrown = buildCache.readFile("styles.css");
+    const noThrown2 = buildCache.readFile(".well-known/foo.txt");
+    const noThrown3 = buildCache.readFile("./styles.css");
+    const noThrown4 = buildCache.readFile("./.well-known/foo.txt");
+    await buildCache.flush();
+
+    const err = "Processed file resolved outside of static dir";
+    await expect(thrown).rejects.toThrow(err);
+    await expect(thrown2).rejects.toThrow(err);
+    await expect(noThrown).resolves.toBe(null);
+    await expect(noThrown2).resolves.toBe(null);
+    await expect(noThrown3).resolves.toBe(null);
+    await expect(noThrown4).resolves.toBe(null);
+  },
+});

--- a/src/middlewares/static_files.ts
+++ b/src/middlewares/static_files.ts
@@ -10,7 +10,7 @@ import { trace, tracer } from "../otel.ts";
  * Fresh middleware to enable file-system based routing.
  * ```ts
  * // Enable Fresh static file serving
- * app.use(freshStaticFles());
+ * app.use(staticFiles());
  * ```
  */
 export function staticFiles<T>(): MiddlewareFn<T> {


### PR DESCRIPTION
This PR intends to address an error logged when opening a DevTools in a Chromium based browser while using Fresh in dev mode.

<details>

<summary><strong>See error</strong></summary>

```
Error: Processed file resolved outside of static dir C:\Users\<name>\fresh-site\src\static\.well-known\appspecific\com.chrome.devtools.json
    at MemoryBuildCache.readFile (https://jsr.io/@fresh/core/2.0.0-alpha.29/src/dev/dev_build_cache.ts:81:13)
    at eventLoopTick (ext:core/01_core.js:178:7)
    at async freshStaticFiles (https://jsr.io/@fresh/core/2.0.0-alpha.29/src/middlewares/static_files.ts:30:18)
    at async FreshReqContext.fn (https://jsr.io/@fresh/core/2.0.0-alpha.29/src/middlewares/mod.ts:99:18)
    at async https://jsr.io/@fresh/core/2.0.0-alpha.29/src/dev/middlewares/error_overlay/middleware.tsx:15:14
    at async FreshReqContext.fn (https://jsr.io/@fresh/core/2.0.0-alpha.29/src/middlewares/mod.ts:99:18)
    at async fn (https://jsr.io/@fresh/core/2.0.0-alpha.29/src/middlewares/mod.ts:99:18)
    at async https://jsr.io/@fresh/core/2.0.0-alpha.29/src/app.ts:232:16
    at async mapped (ext:deno_http/00_serve.ts:407:18)
```

</details>

DevTools tries to load a `<root>/static/.well-known/appspecific/com.chrome.devtools.json` file, which incorrectly is flagged as "outside" the static directory, and thus generates errors instead of 404.

Maybe hidden folders (starting with `.`) in `/static` should be opt-in though? I'm not sure if anyone puts folders with `.` prefix inside `static/` without intending them to be accessible?

- `..` throws errors (outside staticDir)
- `.` returns "missing file" (unless `config.allowHiddenFolders` is true)

## Automatic workspace folders

I think a follow-up PR could be for the Dev `Builder` to also implement support for [Automatic workspace folders](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md), by returning JSON content automatically at `.well-known/appspecific/com.chrome.devtools.json`.

I think a good first step is to allow `.<folder-name>`, especially since `.well-known/` has [many valid use-cases](https://en.wikipedia.org/wiki/Well-known_URI), and as such is not unreasonable to want to add static files in.