### PR TITLE
refactor(core): remove `FsAdapter.readFile()`

### DIFF
--- a/src/dev/builder.ts
+++ b/src/dev/builder.ts
@@ -5,7 +5,6 @@ import {
   type ListenOptions,
   setBuildCache,
 } from "../app.ts";
-import { fsAdapter } from "../fs.ts";
 import * as path from "@std/path";
 import * as colors from "@std/fmt/colors";
 import { bundleJs } from "./esbuild.ts";
@@ -44,7 +43,7 @@ export interface FreshBuilder {
 }
 
 export class Builder implements FreshBuilder {
-  #transformer = new FreshFileTransformer(fsAdapter);
+  #transformer = new FreshFileTransformer();
   #addedInternalTransforms = false;
   #options: { target: string | string[] };
 

--- a/src/dev/file_transformer.ts
+++ b/src/dev/file_transformer.ts
@@ -1,4 +1,3 @@
-import type { FsAdapter } from "../fs.ts";
 import { BUILD_ID } from "../runtime/build_id.ts";
 import { assetInternal } from "../runtime/shared_internal.tsx";
 
@@ -56,11 +55,6 @@ interface TransformReq {
 
 export class FreshFileTransformer {
   #transformers: Transformer[] = [];
-  #fs: FsAdapter;
-
-  constructor(fs: FsAdapter) {
-    this.#fs = fs;
-  }
 
   onTransform(options: OnTransformOptions, callback: TransformFn): void {
     this.#transformers.push({ options, fn: callback });
@@ -86,7 +80,7 @@ export class FreshFileTransformer {
 
     let content: Uint8Array;
     try {
-      content = await this.#fs.readFile(filePath);
+      content = await Deno.readFile(filePath);
     } catch (err) {
       if (err instanceof Deno.errors.NotFound) {
         return null;

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -8,7 +8,6 @@ export interface FsAdapter {
   ): AsyncIterableIterator<WalkEntry>;
   isDirectory(path: string | URL): Promise<boolean>;
   mkdirp(dir: string): Promise<void>;
-  readFile(path: string | URL): Promise<Uint8Array>;
 }
 
 export const fsAdapter: FsAdapter = {
@@ -32,5 +31,4 @@ export const fsAdapter: FsAdapter = {
       }
     }
   },
-  readFile: Deno.readFile,
 };

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -112,7 +112,6 @@ export function createFakeFs(files: Record<string, unknown>): FsAdapter {
     },
     async mkdirp(_dir: string) {
     },
-    readFile: Deno.readFile,
   };
 }
 


### PR DESCRIPTION
I realise we complicate a lot of objects, classes and interfaces for testing purposes. By stubbing (and possibly) spying only where we need to, we can simplify these symbols and jump through far fewer mental hoops to reason about things.

Pre-requisite for #2934