### PR TITLE
chore: add `coverage/` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .docs/
 .DS_Store
 tmp_*
+coverage/


### PR DESCRIPTION
When running `deno test --coverage` Deno will create a `coverage/` directory by default. We were missing that in our gitignore.