### PR TITLE
fix(core): silence esbuild jsx comment warning

### DIFF
--- a/src/dev/esbuild.ts
+++ b/src/dev/esbuild.ts
@@ -52,6 +52,7 @@ export async function bundleJs(
     minify: !options.dev,
     logOverride: {
       "suspicious-nullish-coalescing": "silent",
+      "unsupported-jsx-comment": "silent",
     },
 
     jsxDev: options.dev,


### PR DESCRIPTION
JSR is a bit over-eager with inserting JSX comments and inserts both `@jsx classic` and `@jsxImportSource` which are ignored in combination

Fixes https://github.com/denoland/fresh/issues/2942