### PR TITLE
fix(init): must use urls for asset copying

### DIFF
--- a/init/src/init.ts
+++ b/init/src/init.ts
@@ -395,7 +395,7 @@ ${GRADIENT_CSS}`;
   await writeFile(
     "static/favicon.ico",
     await Deno.readFile(
-      path.join(import.meta.dirname!, "assets", "favicon.ico"),
+      new URL(import.meta.resolve("./assets/favicon.ico")),
     ),
   );
 


### PR DESCRIPTION
Second attempt to fix https://github.com/denoland/fresh/pull/2943 . Turns out that `import.meta.dirname` is `undefined` when served from JSR. I'm not able to reproduce that error locally though.

Fixes https://github.com/denoland/fresh/pull/2943