### PR TITLE
fix(init): fetch favicon from network like  before

### DIFF
--- a/init/src/init.ts
+++ b/init/src/init.ts
@@ -392,12 +392,14 @@ ${GRADIENT_CSS}`;
   <path d="M14.297 16.49c.985-.747 1.644-1.01 2.099-2.526.566.121.841-.08 1.29-.701.324.466 1.657.608 2.453.701-.715.451-1.057.852-1.452 2.106-1.464-.611-3.167-.302-4.39.42Z" fill="#fff"/>
 </svg>`;
   await writeFile("static/logo.svg", STATIC_LOGO);
-  await writeFile(
-    "static/favicon.ico",
-    await Deno.readFile(
-      new URL(import.meta.resolve("./assets/favicon.ico")),
-    ),
-  );
+
+  try {
+    const res = await fetch("https://fresh.deno.dev/favicon.ico");
+    const buf = await res.arrayBuffer();
+    await writeFile("static/favicon.ico", new Uint8Array(buf));
+  } catch {
+    // Skip this and be silent if there is a network issue.
+  }
 
   const MAIN_TS = `import { App, fsRoutes, staticFiles } from "fresh";
 import { define, type State } from "./utils.ts";


### PR DESCRIPTION
Reverts back to fetching the favicon from the network. Copying assets from JSR turns out to be difficult.

Fixes https://github.com/denoland/fresh/issues/2941