### PR TITLE
fix(core): support method handler on _error, _404 and _500 routes

### DIFF
--- a/src/plugins/fs_routes/mod.ts
+++ b/src/plugins/fs_routes/mod.ts
@@ -260,9 +260,11 @@ export async function fsRoutes<State>(
           ? handlers
           : ((ctx) => {
             const { method } = ctx.req;
-            const maybeFn = handlers[method as Method];
-            if (maybeFn !== undefined) {
-              return maybeFn(ctx);
+            if (!Array.isArray(handlers)) {
+              const maybeFn = handlers[method as Method];
+              if (maybeFn !== undefined) {
+                return maybeFn(ctx);
+              }
             }
             return ctx.next();
           }) as HandlerFn<unknown, State>;
@@ -294,9 +296,11 @@ export async function fsRoutes<State>(
           ? handlers
           : ((ctx) => {
             const { method } = ctx.req;
-            const maybeFn = handlers[method as Method];
-            if (maybeFn !== undefined) {
-              return maybeFn(ctx);
+            if (!Array.isArray(handlers)) {
+              const maybeFn = handlers[method as Method];
+              if (maybeFn !== undefined) {
+                return maybeFn(ctx);
+              }
             }
             return ctx.next();
           }) as HandlerFn<unknown, State>;

--- a/src/plugins/fs_routes/mod.ts
+++ b/src/plugins/fs_routes/mod.ts
@@ -258,7 +258,14 @@ export async function fsRoutes<State>(
           ? undefined
           : typeof handlers === "function"
           ? handlers
-          : undefined; // FIXME: Method handler
+          : ((ctx) => {
+            const { method } = ctx.req;
+            const maybeFn = handlers[method as Method];
+            if (maybeFn !== undefined) {
+              return maybeFn(ctx);
+            }
+            return ctx.next();
+          }) as HandlerFn<unknown, State>;
         const errorComponents = components.slice();
         if (mod.component !== null) {
           errorComponents.push(mod.component);
@@ -285,7 +292,14 @@ export async function fsRoutes<State>(
           ? undefined
           : typeof handlers === "function"
           ? handlers
-          : undefined; // FIXME: Method handler
+          : ((ctx) => {
+            const { method } = ctx.req;
+            const maybeFn = handlers[method as Method];
+            if (maybeFn !== undefined) {
+              return maybeFn(ctx);
+            }
+            return ctx.next();
+          }) as HandlerFn<unknown, State>;
         const notFoundComponents = components.slice();
         if (mod.component !== null) {
           notFoundComponents.push(mod.component);

--- a/src/plugins/fs_routes/mod_test.tsx
+++ b/src/plugins/fs_routes/mod_test.tsx
@@ -646,6 +646,28 @@ Deno.test("fsRoutes - _404", async () => {
   expect(content).toContain("Custom 404 - Not Found");
 });
 
+Deno.test("fsRoutes - _404 method handler", async () => {
+  const server = await createServer({
+    "routes/_404.tsx": {
+      handlers: {
+        GET() {
+          return new Response("ok");
+        },
+      },
+    },
+    "routes/index.tsx": {
+      handlers: {
+        GET() {
+          return new Response("fail");
+        },
+      },
+    },
+  });
+
+  const res = await server.get("/invalid");
+  expect(await res.text()).toEqual("ok");
+});
+
 Deno.test("fsRoutes - _500", async () => {
   const server = await createServer({
     "routes/_500.tsx": {
@@ -663,6 +685,26 @@ Deno.test("fsRoutes - _500", async () => {
   const res = await server.get("/");
   const content = await res.text();
   expect(content).toContain("Custom Error Page");
+});
+
+Deno.test("fsRoutes - _500 method handler", async () => {
+  const server = await createServer({
+    "routes/_500.tsx": {
+      handlers: {
+        GET() {
+          return new Response("ok");
+        },
+      },
+    },
+    "routes/index.tsx": {
+      handlers: () => {
+        throw new Error("fail");
+      },
+    },
+  });
+
+  const res = await server.get("/");
+  expect(await res.text()).toEqual("ok");
 });
 
 Deno.test("fsRoutes - _error", async () => {
@@ -727,6 +769,26 @@ Deno.test("fsRoutes - _error nested throw", async () => {
   });
 
   const res = await server.get("/foo");
+  expect(await res.text()).toEqual("ok");
+});
+
+Deno.test("fsRoutes - _error method handler", async () => {
+  const server = await createServer({
+    "routes/_error.tsx": {
+      handlers: {
+        GET() {
+          return new Response("ok");
+        },
+      },
+    },
+    "routes/index.tsx": {
+      handlers: () => {
+        throw new Error("fail");
+      },
+    },
+  });
+
+  const res = await server.get("/");
   expect(await res.text()).toEqual("ok");
 });
 


### PR DESCRIPTION
This PR adds support for using method handlers in `_error`, `_404` and `_500` files.

Fixes https://github.com/denoland/fresh/issues/2953