### PR TITLE
feat(tailwindcss): add excludePaths option to skip specific directions #2937

### DIFF
--- a/plugin-tailwindcss/src/mod.ts
+++ b/plugin-tailwindcss/src/mod.ts
@@ -12,7 +12,13 @@ export function tailwind<T>(
 
   builder.onTransformStaticFile(
     { pluginName: "tailwind", filter: /\.css$/ },
+    //a simple function to check if the path is in the excludePaths
+    //showcase: tailwind(builder, app, { excludePaths: ["/x/x"] });
     async (args) => {
+      if (options.excludePaths?.some((path) => args.path.includes(path))) {
+        return { content: args.text, map: undefined };
+      }
+
       if (!processor) processor = initTailwind(app.config, options);
       const instance = await processor;
       const res = await instance.process(args.text, {

--- a/plugin-tailwindcss/src/types.ts
+++ b/plugin-tailwindcss/src/types.ts
@@ -41,4 +41,5 @@ export interface AutoprefixerOptions {
 
 export interface TailwindPluginOptions {
   autoprefixer?: AutoprefixerOptions;
+  excludePaths?: string[];
 }


### PR DESCRIPTION
**What does this PR do?**  
This PR adds an `excludePaths` configuration option to the Fresh Tailwind CSS plugin, allowing users to skip processing specific directories or files. This solves the conflict when hosting pre-built CSS files (e.g., from Vite) that have already been processed by Tailwind and should not be re-compiled by Fresh.


### **Problem Being Solved**  
#2937 Based on the scenario described in this issue, in certain use cases, users may not want Tailwind CSS to automatically process global CSS files. We can add a configuration option to allow skipping specific directories. Add the `excludePaths` option allows users to specify paths like `/static/assets/` to prevent Fresh from processing these files.


### **Changes Made**  
1. **Added Configuration Option**  
   - Extended `TailwindPluginOptions` in `types.ts` with `excludePaths?: string[]`.  
   - Example: `excludePaths: ["/static/assets/"]` skips all CSS files in the `static/assets` directory.  