### PR TITLE
feat(core): support `exclude` option for transformers

### DIFF
--- a/plugin-tailwindcss/src/mod.ts
+++ b/plugin-tailwindcss/src/mod.ts
@@ -1,17 +1,17 @@
 import type { TailwindPluginOptions } from "./types.ts";
 import { initTailwind } from "./compiler.ts";
-import type { Builder } from "fresh/dev";
+import type { FreshBuilder } from "fresh/dev";
 import type { App } from "fresh";
 
 export function tailwind<T>(
-  builder: Builder,
+  builder: FreshBuilder,
   app: App<T>,
   options: TailwindPluginOptions = {},
 ): void {
   let processor: ReturnType<typeof initTailwind> | null;
 
   builder.onTransformStaticFile(
-    { pluginName: "tailwind", filter: /\.css$/ },
+    { pluginName: "tailwind", filter: /\.css$/, exclude: options.exclude },
     async (args) => {
       if (!processor) processor = initTailwind(app.config, options);
       const instance = await processor;

--- a/plugin-tailwindcss/src/types.ts
+++ b/plugin-tailwindcss/src/types.ts
@@ -1,3 +1,5 @@
+import type { OnTransformOptions } from "@fresh/core/dev";
+
 export interface AutoprefixerOptions {
   /** environment for `Browserslist` */
   env?: string;
@@ -41,4 +43,6 @@ export interface AutoprefixerOptions {
 
 export interface TailwindPluginOptions {
   autoprefixer?: AutoprefixerOptions;
+  /** Exclude paths or globs that should not be processed */
+  exclude?: OnTransformOptions["exclude"];
 }

--- a/src/dev/file_transformer.ts
+++ b/src/dev/file_transformer.ts
@@ -1,3 +1,4 @@
+import { globToRegExp, isGlob } from "@std/path";
 import type { FsAdapter } from "../fs.ts";
 import { BUILD_ID } from "../runtime/build_id.ts";
 import { assetInternal } from "../runtime/shared_internal.tsx";
@@ -7,6 +8,7 @@ export type TransformMode = "development" | "production";
 export interface OnTransformOptions {
   pluginName: string;
   filter: RegExp;
+  exclude?: Array<string | RegExp>;
 }
 
 export interface OnTransformResult {
@@ -112,13 +114,32 @@ export class FreshFileTransformer {
       seen.add(req.filePath);
 
       let transformed = false;
-      for (let i = 0; i < this.#transformers.length; i++) {
+      outer: for (let i = 0; i < this.#transformers.length; i++) {
         const transformer = this.#transformers[i];
 
         const { options, fn } = transformer;
         options.filter.lastIndex = 0;
         if (!options.filter.test(req.filePath)) {
           continue;
+        }
+
+        // Check if file is excluded
+        if (options.exclude !== undefined) {
+          for (let j = 0; j < options.exclude.length; j++) {
+            const exclude = options.exclude[j];
+            if (exclude instanceof RegExp) {
+              if (exclude.test(filePath)) {
+                continue outer;
+              }
+            } else if (isGlob(exclude)) {
+              const regex = globToRegExp(exclude);
+              if (regex.test(filePath)) {
+                continue outer;
+              }
+            } else if (filePath.includes(exclude)) {
+              continue outer;
+            }
+          }
         }
 
         const result = await fn({


### PR DESCRIPTION
This PR adds general support for an `exclude` option to file transformers. This allows plugin to skip processing excluded files. The exclude array can be a `string`, a `RegExp` or a glob pattern.

Fixes https://github.com/denoland/fresh/issues/2937