### PR TITLE
ci: improve CI perf by adding dependency caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
+          cache: true
           deno-version: ${{ matrix.deno }}
 
       - name: Verify formatting

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: main
+    branches: [main]
 
 jobs:
   deploy:
@@ -21,15 +21,16 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@v2
         with:
+          cache: true
           deno-version: rc
 
       - name: Build step
         working-directory: ./www
-        run: "deno task build" # 📝 Update the build command(s) if necessary
+        run: "deno task build"
 
       - name: Upload to Deno Deploy
         uses: denoland/deployctl@v1
         with:
-          project: "fresh" # 📝 Update the deploy project name if necessary
-          entrypoint: "./www/main.ts" # 📝 Update the entrypoint if necessary
+          project: "fresh"
+          entrypoint: "./www/main.ts"
           root: "."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Install Deno
         uses: denoland/setup-deno@v2
+        with:
+          cache: true
 
       - name: Publish Fresh
         run: deno publish


### PR DESCRIPTION
The `denoland/setup-deno` action recently added built-in caching (https://github.com/denoland/setup-deno/pull/89, https://github.com/denoland/setup-deno/pull/98). This makes it a lot simpler to add caching of the `DENO_DIR` during CI runs, without needing `@actions/cache` manual setup.

This should speed up CI runs by avoiding downloading dependencies between every run.