### PR TITLE
docs: simplify introduction content

### DIFF
--- a/docs/latest/getting-started/index.md
+++ b/docs/latest/getting-started/index.md
@@ -8,17 +8,9 @@ description: |
 In this chapter of the Fresh documentation, you'll be introduced to the
 framework. You'll learn how to create a new project, run it locally, edit and
 create pages, fetch data, handle user interactions, and how to then deploy the
-project to [Deno Deploy][deno-deploy].
+project to [Deno Deploy](https://deno.com/deploy).
 
-The documentation assumes you have Deno 1.45.2 or later installed.
-
-To install Deno, follow the
-[installation instructions in the Deno manual][manual-installation].
-
-For the best user experience, you should also set up your editor or IDE to play
-nice with Deno. Documentation for this can also be found
-[in the manual][manual-editors].
-
-[deno-deploy]: https://deno.com/deploy
-[manual-installation]: https://docs.deno.com/runtime/getting_started/installation
-[manual-editors]: https://docs.deno.com/runtime/getting_started/setup_your_environment
+The documentation assumes you have the latest version
+[Deno](https://docs.deno.com/runtime/#install-deno) installed on your system and
+set up your
+[Editor to work with Deno](https://docs.deno.com/runtime/getting_started/setup_your_environment/).

--- a/docs/latest/introduction/index.md
+++ b/docs/latest/introduction/index.md
@@ -1,28 +1,20 @@
 ---
 description: |
   Fresh is a full stack modern web framework for JavaScript and TypeScript
-  developers, designed to make it trivial to create high-quality, performant,
+  developers, designed to build high-quality, performant,
   and personalized web applications.
 ---
 
 Fresh is a full stack modern web framework for JavaScript and TypeScript
-developers, designed to make it trivial to create high-quality, performant, and
+developers. It's designed for building high-quality, performant, and
 personalized web applications. You can use it to create your home page, a blog,
-a large web application like GitHub or Twitter, or anything else you can think
-of.
+an e-commerce shop, a large web application like GitHub or Twitter and more.
 
 At its core, Fresh is a combination of a routing framework and templating engine
-that renders pages on demand, on the server. In addition to this just-in-time
-(JIT) rendering on the server, Fresh also provides an interface for seamlessly
-rendering some components on the client for maximum interactivity. The framework
-uses [Preact][preact] and JSX for rendering and templating on both the server
-and the client.
-
-Fresh also does not have a build step. The code you write is also directly the
-code that is run on the server, and the code that is executed on the client. Any
-necessary transpilation of TypeScript or JSX to plain JavaScript is done on the
-fly, just when it is needed. This allows for insanely fast iteration loops and
-very very fast deployments.
+that renders pages on demand on the server. These server rendered pages can
+contain areas that are made interactive on the client (also known as the
+[Island Architecture](https://jasonformat.com/islands-architecture)). Fresh uses
+[Preact][preact] as the JSX rendering engine.
 
 Fresh projects can be deployed manually to any platform with [Deno][deno], but
 it is intended to be deployed to an edge runtime like [Deno Deploy][deno-deploy]
@@ -31,7 +23,6 @@ for the best experience.
 Some stand out features:
 
 - Zero config necessary
-- JIT rendering on the edge
 - Tiny & fast (no client JS is required by the framework)
 - Optional client side hydration of individual components
 - Highly resilient because of progressive enhancement and use of native browser


### PR DESCRIPTION
The original text is a bit wordy. This shortens the introduction content a bit in our docs.