### PR TITLE
fix: add back `LayoutConfig`

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -9,7 +9,7 @@ export {
   type RouteData,
   type RouteHandler,
 } from "./handlers.ts";
-export type { RouteConfig } from "./types.ts";
+export type { LayoutConfig, RouteConfig } from "./types.ts";
 export type { Middleware, MiddlewareFn } from "./middlewares/mod.ts";
 export { staticFiles } from "./middlewares/static_files.ts";
 export type { FreshConfig, ResolvedFreshConfig } from "./config.ts";

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,20 @@ export interface RouteConfig {
   skipAppWrapper?: boolean;
 }
 
+export interface LayoutConfig {
+  /**
+   * Skip already inherited layouts
+   * Default: `false`
+   */
+  skipInheritedLayouts?: boolean;
+
+  /**
+   * Skip rendering the `routes/_app` template
+   * Default: `false`
+   */
+  skipAppWrapper?: boolean;
+}
+
 // TODO: Uncomment once JSR supports global types
 // declare global {
 //   namespace preact.createElement.JSX {


### PR DESCRIPTION
~~Makes it easier to upgrade from 1.x .~~

Initially, I assumed it would be just an alias to `RouteConfig`, but upon closer inspection that has some additional properties that make no sense for a layout.