### PR TITLE
test: use disposable tmp dirs

### DIFF
--- a/init/src/init_test.ts
+++ b/init/src/init_test.ts
@@ -8,6 +8,7 @@ import * as path from "@std/path";
 import { getStdOutput, withBrowser } from "../../tests/test_utils.tsx";
 import { waitForText } from "../../tests/test_utils.tsx";
 import { withChildProcessServer } from "../../tests/test_utils.tsx";
+import { withTmpDir as withTmpDirBase } from "../../src/test_utils.ts";
 import { stub } from "@std/testing/mock";
 
 function stubPrompt(result: string) {
@@ -22,16 +23,11 @@ function stubConfirm(steps: Record<string, boolean> = {}) {
   );
 }
 
-async function withTmpDir(fn: (dir: string) => void | Promise<void>) {
-  const hash = crypto.randomUUID().replaceAll(/-/g, "");
-  const dir = path.join(import.meta.dirname!, "..", "..", `tmp_${hash}`);
-  await Deno.mkdir(dir, { recursive: true });
-
-  try {
-    await fn(dir);
-  } finally {
-    await Deno.remove(dir, { recursive: true });
-  }
+function withTmpDir(): Promise<{ dir: string } & AsyncDisposable> {
+  return withTmpDirBase({
+    dir: path.join(import.meta.dirname!, "..", ".."),
+    prefix: "tmp_",
+  });
 }
 
 async function patchProject(dir: string): Promise<void> {
@@ -64,57 +60,57 @@ async function readProjectFile(dir: string, pathname: string): Promise<string> {
 }
 
 Deno.test("init - new project", async () => {
-  await withTmpDir(async (dir) => {
-    using _promptStub = stubPrompt("fresh-init");
-    using _confirmStub = stubConfirm();
-    await initProject(dir, [], {});
-  });
+  await using tmp = await withTmpDir();
+  using _promptStub = stubPrompt("fresh-init");
+  using _confirmStub = stubConfirm();
+
+  await initProject(tmp.dir, [], {});
 });
 
 Deno.test("init - create project dir", async () => {
-  await withTmpDir(async (dir) => {
-    using _promptStub = stubPrompt("fresh-init");
-    using _confirmStub = stubConfirm();
-    await initProject(dir, [], {});
+  await using tmp = await withTmpDir();
+  const dir = tmp.dir;
+  using _promptStub = stubPrompt("fresh-init");
+  using _confirmStub = stubConfirm();
+  await initProject(dir, [], {});
 
-    const root = path.join(dir, "fresh-init");
-    await expectProjectFile(root, "deno.json");
-    await expectProjectFile(root, "main.ts");
-    await expectProjectFile(root, "dev.ts");
-    await expectProjectFile(root, ".gitignore");
-    await expectProjectFile(root, "static/styles.css");
-  });
+  const root = path.join(dir, "fresh-init");
+  await expectProjectFile(root, "deno.json");
+  await expectProjectFile(root, "main.ts");
+  await expectProjectFile(root, "dev.ts");
+  await expectProjectFile(root, ".gitignore");
+  await expectProjectFile(root, "static/styles.css");
 });
 
 Deno.test("init - with tailwind", async () => {
-  await withTmpDir(async (dir) => {
-    using _promptStub = stubPrompt(".");
-    using _confirmStub = stubConfirm({
-      [CONFIRM_TAILWIND_MESSAGE]: true,
-    });
-    await initProject(dir, [], {});
-
-    const css = await readProjectFile(dir, "static/styles.css");
-    expect(css).toMatch(/@tailwind/);
-
-    const main = await readProjectFile(dir, "main.ts");
-    const dev = await readProjectFile(dir, "dev.ts");
-    expect(main).not.toMatch(/tailwind/);
-    expect(dev).toMatch(/tailwind/);
+  await using tmp = await withTmpDir();
+  const dir = tmp.dir;
+  using _promptStub = stubPrompt(".");
+  using _confirmStub = stubConfirm({
+    [CONFIRM_TAILWIND_MESSAGE]: true,
   });
+  await initProject(dir, [], {});
+
+  const css = await readProjectFile(dir, "static/styles.css");
+  expect(css).toMatch(/@tailwind/);
+
+  const main = await readProjectFile(dir, "main.ts");
+  const dev = await readProjectFile(dir, "dev.ts");
+  expect(main).not.toMatch(/tailwind/);
+  expect(dev).toMatch(/tailwind/);
 });
 
 Deno.test("init - with vscode", async () => {
-  await withTmpDir(async (dir) => {
-    using _promptStub = stubPrompt(".");
-    using _confirmStub = stubConfirm({
-      [CONFIRM_VSCODE_MESSAGE]: true,
-    });
-    await initProject(dir, [], {});
-
-    await expectProjectFile(dir, ".vscode/settings.json");
-    await expectProjectFile(dir, ".vscode/extensions.json");
+  await using tmp = await withTmpDir();
+  const dir = tmp.dir;
+  using _promptStub = stubPrompt(".");
+  using _confirmStub = stubConfirm({
+    [CONFIRM_VSCODE_MESSAGE]: true,
   });
+  await initProject(dir, [], {});
+
+  await expectProjectFile(dir, ".vscode/settings.json");
+  await expectProjectFile(dir, ".vscode/extensions.json");
 });
 
 Deno.test({
@@ -123,33 +119,10 @@ Deno.test({
   // behaviours when the formatter changes.
   ignore: Deno.version.deno.includes("+"),
   fn: async () => {
-    await withTmpDir(async (dir) => {
-      using _promptStub = stubPrompt(".");
-      using _confirmStub = stubConfirm();
-      await initProject(dir, [], {});
-      await expectProjectFile(dir, "main.ts");
-      await expectProjectFile(dir, "dev.ts");
-
-      await patchProject(dir);
-
-      const check = await new Deno.Command(Deno.execPath(), {
-        args: ["task", "check"],
-        cwd: dir,
-        stderr: "inherit",
-        stdout: "inherit",
-      }).output();
-      expect(check.code).toEqual(0);
-    });
-  },
-});
-
-Deno.test("init with tailwind - fmt, lint, and type check project", async () => {
-  await withTmpDir(async (dir) => {
+    await using tmp = await withTmpDir();
+    const dir = tmp.dir;
     using _promptStub = stubPrompt(".");
-    using _confirmStub = stubConfirm({
-      [CONFIRM_TAILWIND_MESSAGE]: true,
-    });
-
+    using _confirmStub = stubConfirm();
     await initProject(dir, [], {});
     await expectProjectFile(dir, "main.ts");
     await expectProjectFile(dir, "dev.ts");
@@ -163,86 +136,109 @@ Deno.test("init with tailwind - fmt, lint, and type check project", async () => 
       stdout: "inherit",
     }).output();
     expect(check.code).toEqual(0);
+  },
+});
+
+Deno.test("init with tailwind - fmt, lint, and type check project", async () => {
+  await using tmp = await withTmpDir();
+  const dir = tmp.dir;
+  using _promptStub = stubPrompt(".");
+  using _confirmStub = stubConfirm({
+    [CONFIRM_TAILWIND_MESSAGE]: true,
   });
+
+  await initProject(dir, [], {});
+  await expectProjectFile(dir, "main.ts");
+  await expectProjectFile(dir, "dev.ts");
+
+  await patchProject(dir);
+
+  const check = await new Deno.Command(Deno.execPath(), {
+    args: ["task", "check"],
+    cwd: dir,
+    stderr: "inherit",
+    stdout: "inherit",
+  }).output();
+  expect(check.code).toEqual(0);
 });
 
 Deno.test("init - can start dev server", async () => {
-  await withTmpDir(async (dir) => {
-    using _promptStub = stubPrompt(".");
-    using _confirmStub = stubConfirm();
-    await initProject(dir, [], {});
-    await expectProjectFile(dir, "main.ts");
-    await expectProjectFile(dir, "dev.ts");
+  await using tmp = await withTmpDir();
+  const dir = tmp.dir;
+  using _promptStub = stubPrompt(".");
+  using _confirmStub = stubConfirm();
+  await initProject(dir, [], {});
+  await expectProjectFile(dir, "main.ts");
+  await expectProjectFile(dir, "dev.ts");
 
-    await patchProject(dir);
-    await withChildProcessServer(
-      dir,
-      "dev",
-      async (address) => {
-        await withBrowser(async (page) => {
-          await page.goto(address);
-          await page.locator("button").click();
-          await waitForText(page, "button + p", "2");
-        });
-      },
-    );
-  });
+  await patchProject(dir);
+  await withChildProcessServer(
+    dir,
+    "dev",
+    async (address) => {
+      await withBrowser(async (page) => {
+        await page.goto(address);
+        await page.locator("button").click();
+        await waitForText(page, "button + p", "2");
+      });
+    },
+  );
 });
 
 Deno.test("init - can start built project", async () => {
-  await withTmpDir(async (dir) => {
-    using _promptStub = stubPrompt(".");
-    using _confirmStub = stubConfirm();
-    await initProject(dir, [], {});
-    await expectProjectFile(dir, "main.ts");
-    await expectProjectFile(dir, "dev.ts");
+  await using tmp = await withTmpDir();
+  const dir = tmp.dir;
+  using _promptStub = stubPrompt(".");
+  using _confirmStub = stubConfirm();
+  await initProject(dir, [], {});
+  await expectProjectFile(dir, "main.ts");
+  await expectProjectFile(dir, "dev.ts");
 
-    await patchProject(dir);
+  await patchProject(dir);
 
-    // Build
-    await new Deno.Command(Deno.execPath(), {
-      args: ["task", "build"],
-      stdin: "null",
-      stdout: "piped",
-      stderr: "piped",
-      cwd: dir,
-    }).output();
+  // Build
+  await new Deno.Command(Deno.execPath(), {
+    args: ["task", "build"],
+    stdin: "null",
+    stdout: "piped",
+    stderr: "piped",
+    cwd: dir,
+  }).output();
 
-    await withChildProcessServer(
-      dir,
-      "start",
-      async (address) => {
-        await withBrowser(async (page) => {
-          await page.goto(address);
-          await page.locator("button").click();
-          await waitForText(page, "button + p", "2");
-        });
-      },
-    );
-  });
+  await withChildProcessServer(
+    dir,
+    "start",
+    async (address) => {
+      await withBrowser(async (page) => {
+        await page.goto(address);
+        await page.locator("button").click();
+        await waitForText(page, "button + p", "2");
+      });
+    },
+  );
 });
 
 Deno.test("init - errors on missing build cache in prod", async () => {
-  await withTmpDir(async (dir) => {
-    using _promptStub = stubPrompt(".");
-    using _confirmStub = stubConfirm();
-    await initProject(dir, [], {});
-    await expectProjectFile(dir, "main.ts");
-    await expectProjectFile(dir, "dev.ts");
+  await using tmp = await withTmpDir();
+  const dir = tmp.dir;
+  using _promptStub = stubPrompt(".");
+  using _confirmStub = stubConfirm();
+  await initProject(dir, [], {});
+  await expectProjectFile(dir, "main.ts");
+  await expectProjectFile(dir, "dev.ts");
 
-    await patchProject(dir);
+  await patchProject(dir);
 
-    const cp = await new Deno.Command(Deno.execPath(), {
-      args: ["task", "start"],
-      stdin: "null",
-      stdout: "piped",
-      stderr: "piped",
-      cwd: dir,
-    }).output();
+  const cp = await new Deno.Command(Deno.execPath(), {
+    args: ["task", "start"],
+    stdin: "null",
+    stdout: "piped",
+    stderr: "piped",
+    cwd: dir,
+  }).output();
 
-    const { stderr } = getStdOutput(cp);
-    expect(cp.code).toEqual(1);
+  const { stderr } = getStdOutput(cp);
+  expect(cp.code).toEqual(1);
 
-    expect(stderr).toMatch(/Found 1 islands, but did not/);
-  });
+  expect(stderr).toMatch(/Found 1 islands, but did not/);
 });

--- a/src/build_cache_test.ts
+++ b/src/build_cache_test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import * as path from "@std/path";
 import { ProdBuildCache, type StaticFile } from "./build_cache.ts";
+import { withTmpDir } from "./test_utils.ts";
 import type { ResolvedFreshConfig } from "./mod.ts";
 
 async function getContent(readResult: Promise<StaticFile | null>) {
@@ -13,7 +14,8 @@ async function getContent(readResult: Promise<StaticFile | null>) {
 Deno.test({
   name: "ProdBuildCache - should error if reading outside of staticDir",
   fn: async () => {
-    const tmp = await Deno.makeTempDir();
+    await using _tmp = await withTmpDir();
+    const tmp = _tmp.dir;
     const config: ResolvedFreshConfig = {
       root: tmp,
       mode: "production",

--- a/src/dev/builder_test.ts
+++ b/src/dev/builder_test.ts
@@ -4,6 +4,7 @@ import { Builder } from "./builder.ts";
 import { App } from "../app.ts";
 import { RemoteIsland } from "@marvinh-test/fresh-island";
 import { BUILD_ID } from "../runtime/build_id.ts";
+import { withTmpDir } from "../test_utils.ts";
 
 Deno.test({
   name: "Builder - chain onTransformStaticFile",
@@ -29,7 +30,8 @@ Deno.test({
       },
     );
 
-    const tmp = await Deno.makeTempDir();
+    await using _tmp = await withTmpDir();
+    const tmp = _tmp.dir;
     await Deno.writeTextFile(path.join(tmp, "foo.css"), "body { color: red; }");
     const app = new App({
       staticDir: tmp,
@@ -49,7 +51,8 @@ Deno.test({
   name: "Builder - handles Windows paths",
   fn: async () => {
     const builder = new Builder();
-    const tmp = await Deno.makeTempDir();
+    await using _tmp = await withTmpDir();
+    const tmp = _tmp.dir;
     await Deno.mkdir(path.join(tmp, "images"));
     await Deno.writeTextFile(
       path.join(tmp, "images", "batman.svg"),
@@ -76,7 +79,8 @@ Deno.test({
   name: "Builder - hashes CSS urls by default",
   fn: async () => {
     const builder = new Builder();
-    const tmp = await Deno.makeTempDir();
+    await using _tmp = await withTmpDir();
+    const tmp = _tmp.dir;
     await Deno.writeTextFile(
       path.join(tmp, "foo.css"),
       "body { background: url('/foo.jpg'); }",
@@ -103,7 +107,8 @@ Deno.test({
   name: "Builder - hashes CSS urls by default",
   fn: async () => {
     const builder = new Builder();
-    const tmp = await Deno.makeTempDir();
+    await using _tmp = await withTmpDir();
+    const tmp = _tmp.dir;
     await Deno.writeTextFile(
       path.join(tmp, "foo.css"),
       `:root { --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgb(76, 154.5, 137.5)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E"); }`,
@@ -131,7 +136,8 @@ Deno.test({
   name: "Builder - can bundle islands from JSR",
   fn: async () => {
     const builder = new Builder();
-    const tmp = await Deno.makeTempDir();
+    await using _tmp = await withTmpDir();
+    const tmp = _tmp.dir;
     const app = new App({
       staticDir: tmp,
       build: {
@@ -190,7 +196,8 @@ Deno.test({
       },
     );
 
-    const tmp = await Deno.makeTempDir();
+    await using _tmp = await withTmpDir();
+    const tmp = _tmp.dir;
     await Deno.writeTextFile(path.join(tmp, "foo.css"), "body { color: red; }");
     await Deno.writeTextFile(
       path.join(tmp, "bar.css"),

--- a/src/dev/dev_build_cache_test.ts
+++ b/src/dev/dev_build_cache_test.ts
@@ -2,13 +2,14 @@ import { expect } from "@std/expect";
 import * as path from "@std/path";
 import { MemoryBuildCache } from "./dev_build_cache.ts";
 import { FreshFileTransformer } from "./file_transformer.ts";
-import { createFakeFs } from "../test_utils.ts";
+import { createFakeFs, withTmpDir } from "../test_utils.ts";
 import type { ResolvedFreshConfig } from "../mod.ts";
 
 Deno.test({
   name: "MemoryBuildCache - should error if reading outside of staticDir",
   fn: async () => {
-    const tmp = await Deno.makeTempDir();
+    await using _tmp = await withTmpDir();
+    const tmp = _tmp.dir;
     const config: ResolvedFreshConfig = {
       root: tmp,
       mode: "development",

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -117,3 +117,15 @@ export function createFakeFs(files: Record<string, unknown>): FsAdapter {
 }
 
 export const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export async function withTmpDir(
+  options?: Deno.MakeTempOptions,
+): Promise<{ dir: string } & AsyncDisposable> {
+  const dir = await Deno.makeTempDir(options);
+  return {
+    dir,
+    async [Symbol.asyncDispose]() {
+      await Deno.remove(dir, { recursive: true });
+    },
+  };
+}


### PR DESCRIPTION
> [!TIP]
> Review without whitespace changes to have an easier time comparing changes

Replaces the patterns below with consistent `AsyncDisposable` and `await using` resource management for automatic cleanup.

- `await withTmpDir(async (dir) => { ... })` with `finally`
  - Makes code a bit flatter, and reduces callback-hell a bit
- `await Deno.makeTempDir()` + `Deno.remove()`
- `await Deno.makeTempDir()`

Helps be more consistent in removing temporary folders. Among others, ensures temp folders are removed in the tests below:

- `src/build_cache_test.ts`
- `src/dev/builder_test.ts`
- `src/dev/dev_build_cache_test.ts`

## TODO's

The `Deno.makeTempDir()` method is still used by `buildProd` as well, but this method is used in the top module scope, where it does not work correctly with `Deno.test` (it runs before the test methods). I removed this part from the PR and leave this for later to avoid making the PR too big.

- https://github.com/csvn/fresh/blob/test%2Fdisposable-tmp-dirs/tests/test_utils.tsx/#L64
- https://github.com/csvn/fresh/blob/test%2Fdisposable-tmp-dirs/www/main_test.ts/#L7