### PR TITLE
fix: convert island filePath to valid variable name

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,3 @@
-import * as path from "@std/path";
 import { type ComponentType, h } from "preact";
 import { renderToString } from "preact-render-to-string";
 import { trace } from "@opentelemetry/api";
@@ -17,7 +16,7 @@ import { type BuildCache, ProdBuildCache } from "./build_cache.ts";
 import type { ServerIslandRegistry } from "./context.ts";
 import { FinishSetup, ForgotBuild } from "./finish_setup.tsx";
 import { HttpError } from "./error.ts";
-import { mergePaths } from "./utils.ts";
+import { mergePaths, pathToExportName } from "./utils.ts";
 
 // TODO: Completed type clashes in older Deno versions
 // deno-lint-ignore no-explicit-any
@@ -159,7 +158,7 @@ export class App<State> {
 
     // Create unique island name
     let name = exportName === "default"
-      ? path.basename(filePath, path.extname(filePath))
+      ? pathToExportName(filePath)
       : exportName;
     if (this.#islandNames.has(name)) {
       let i = 0;

--- a/src/app_test.tsx
+++ b/src/app_test.tsx
@@ -501,3 +501,34 @@ Deno.test("FreshApp - throw when middleware returns no response", async () => {
   expect(res.status).toEqual(500);
   expect(text).toContain("Internal server error");
 });
+
+Deno.test("FreshApp - adding Island should convert to valid export names", () => {
+  const app = new App();
+  const islands = getIslandRegistry(app);
+
+  const component1 = () => <>OK</>;
+  const component2 = () => <>OK</>;
+  const component3 = () => <>OK</>;
+  app.island("/islands/foo.v2.tsx", "default", component1);
+  app.island("/islands/_bar-baz-...-$.tsx", "default", component2);
+  app.island("/islands/1_hello.tsx", "default", component3);
+
+  expect(islands.get(component1)!).toEqual({
+    file: "/islands/foo.v2.tsx",
+    name: "foo_v2",
+    exportName: "default",
+    fn: component1,
+  });
+  expect(islands.get(component2)!).toEqual({
+    file: "/islands/_bar-baz-...-$.tsx",
+    name: "_bar_baz_$",
+    exportName: "default",
+    fn: component2,
+  });
+  expect(islands.get(component3)!).toEqual({
+    file: "/islands/1_hello.tsx",
+    name: "_hello",
+    exportName: "default",
+    fn: component3,
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,6 +43,8 @@ export function mergePaths(a: string, b: string) {
  * pathToExportName("/islands/nav-bar.tsx"); // "nav_bar"
  * pathToExportName("/islands/_.$bar.tsx");  // "_$bar"
  * pathToExportName("/islands/1.hello.tsx"); // "_hello"
+ * pathToExportName("/islands/collapse...repeat_-dash.tsx");
+ * // "collapse_repeat_dash"
  * ```
  */
 export function pathToExportName(filePath: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,3 +32,22 @@ export function mergePaths(a: string, b: string) {
   if (!b.startsWith("/")) return a + "/" + b;
   return a + b;
 }
+
+/**
+ * Converts a file path to a valid JS export name.
+ *
+ * @example
+ * ```ts
+ * pathToExportName("/islands/foo.tsx");     // "foo"
+ * pathToExportName("/islands/foo.v2.tsx");  // "foo_v2"
+ * pathToExportName("/islands/nav-bar.tsx"); // "nav_bar"
+ * pathToExportName("/islands/_.$bar.tsx");  // "_$bar"
+ * pathToExportName("/islands/1.hello.tsx"); // "_hello"
+ * ```
+ */
+export function pathToExportName(filePath: string): string {
+  const name = path.basename(filePath, path.extname(filePath));
+  // Regex for valid JS identifier characters
+  const regex = /^[^a-z_$]|[^a-z0-9_$]/gi;
+  return name.replaceAll(regex, "_").replaceAll(/_{2,}/g, "_");
+}

--- a/src/utils_test.ts
+++ b/src/utils_test.ts
@@ -16,4 +16,7 @@ Deno.test("filenameToExportName", () => {
   expect(pathToExportName("/islands/nav-bar.tsx")).toBe("nav_bar");
   expect(pathToExportName("/islands/_.$bar.tsx")).toBe("_$bar");
   expect(pathToExportName("/islands/1.hello.tsx")).toBe("_hello");
+  expect(pathToExportName("/islands/collapse...repeat_-dash.tsx")).toBe(
+    "collapse_repeat_dash",
+  );
 });

--- a/src/utils_test.ts
+++ b/src/utils_test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { mergePaths } from "./utils.ts";
+import { mergePaths, pathToExportName } from "./utils.ts";
 
 Deno.test("mergePaths", () => {
   expect(mergePaths("", "")).toEqual("");
@@ -8,4 +8,12 @@ Deno.test("mergePaths", () => {
   expect(mergePaths("/foo/bar", "/baz")).toEqual("/foo/bar/baz");
   expect(mergePaths("/foo/bar/", "/baz")).toEqual("/foo/bar/baz");
   expect(mergePaths("/foo/bar", "baz")).toEqual("/foo/bar/baz");
+});
+
+Deno.test("filenameToExportName", () => {
+  expect(pathToExportName("/islands/foo.tsx")).toBe("foo");
+  expect(pathToExportName("/islands/foo.v2.tsx")).toBe("foo_v2");
+  expect(pathToExportName("/islands/nav-bar.tsx")).toBe("nav_bar");
+  expect(pathToExportName("/islands/_.$bar.tsx")).toBe("_$bar");
+  expect(pathToExportName("/islands/1.hello.tsx")).toBe("_hello");
 });


### PR DESCRIPTION
I only added a unit test, but maybe it's testing internals too much? Should I add a more E2E test in `tests/` with real files?


Closes #2971