### PR TITLE
fix: improve styling of "Edit on GitHub" link for better visibility in Dark mode

### DIFF
--- a/www/routes/docs/[...slug].tsx
+++ b/www/routes/docs/[...slug].tsx
@@ -221,7 +221,7 @@ export default define.page<typeof handler>(function DocsPage(props) {
                   <div class="px-4 md:px-0 flex justify-between my-6">
                     <a
                       href={`https://github.com/denoland/fresh/edit/main/${page.file}`}
-                      class="dark:text-white text-md flex items-center bg-[#ebedf0] dark:bg-[#2b2d3c] px-4 py-2 rounded"
+                      class="text-gray-700 dark:text-gray-200 text-md flex items-center bg-[#ebedf0] dark:bg-[#1e1f2a] px-4 py-2 rounded hover:bg-gray-200 dark:hover:bg-[#36394c] transition-colors"
                       target="_blank"
                       rel="noopener noreferrer"
                     >


### PR DESCRIPTION
change style for dark mode
last:
![image](https://github.com/user-attachments/assets/52ee66b2-4779-406b-b220-ede6a9100c77)
now:
![image](https://github.com/user-attachments/assets/3c822f3b-4e41-4f30-a5e5-dd1a8cf66d2b)

