### PR TITLE
update instructions to run project from a fresh scaffold

### DIFF
--- a/init/src/init.ts
+++ b/init/src/init.ts
@@ -684,7 +684,7 @@ This will watch the project directory and restart as necessary.`;
     );
   }
   console.log(
-    "Run %cdeno task start%c to start the project. %cCTRL-C%c to stop.",
+    "Run %cdeno task dev%c to start the project. %cCTRL-C%c to stop.",
     "color: cyan",
     "",
     "color: cyan",


### PR DESCRIPTION
After scaffolding the project with 
```
deno run -Ar jsr:@fresh/init@2.0.0-alpha.34
```
Instruction show up to run the project:
```
Enter your project directory using cd fresh-project.
Run deno task start to start the project. CTRL-C to stop.

Stuck? Join our Discord https://discord.gg/deno
```
these instructions seem to be outdated since running `deno task start` on this project throws an error.

While this error also hints that you might want to run the dev server, I think it gives a bad impression that a newly scaffolded project is throwing an error after running the command that it has specified. Also, not many people, especially beginners, read the error messages completely.