### PR TITLE
fix(update): `fresh/runtime` import specifier updated incorrectly

### DIFF
--- a/update/src/update.ts
+++ b/update/src/update.ts
@@ -313,7 +313,7 @@ async function updateFile(sourceFile: tsmorph.SourceFile): Promise<void> {
   if (!hasRuntimeImport && newImports.runtime.size > 0) {
     sourceFile.addImportDeclaration({
       moduleSpecifier: "fresh/runtime",
-      namedImports: Array.from(newImports.core),
+      namedImports: Array.from(newImports.runtime),
     });
   }
   if (newImports.compat.size > 0) {


### PR DESCRIPTION
…ports

The original code is shown in the following figure, and there is an incorrect usage in it.

![1749021630760](https://github.com/user-attachments/assets/2d603bdd-6dd7-4ddf-9dae-8d62b8bdaedf)
