### PR TITLE
fix[core] path checking and recursive call issues in MemoryBuildCache.readFile method

### DIFF
--- a/src/dev/dev_build_cache.ts
+++ b/src/dev/dev_build_cache.ts
@@ -99,12 +99,16 @@ export class MemoryBuildCache implements DevBuildCache {
             `Processed file resolved outside of static dir ${file.path}`,
           );
         }
-        const pathname = `/${relative}`;
+        const transformedPathname = `/${relative}`;
 
-        this.addProcessedFile(pathname, file.content, null);
-      }
-      if (this.#processedFiles.has(pathname)) {
-        return this.readFile(pathname);
+        this.addProcessedFile(transformedPathname, file.content, null);
+
+        if (
+          transformedPathname === pathname &&
+          this.#processedFiles.has(transformedPathname)
+        ) {
+          return this.readFile(transformedPathname);
+        }
       }
     } else {
       try {


### PR DESCRIPTION
## Problem Description
When processing transformed files, the pathname variable is redefined inside the for loop. After the loop ends, the check uses the last pathname value from the loop, rather than the originally requested file pathname. 

This may result 

1. in the file content not being returned correctly even if the originally requested file has been properly processed and added to #processedFiles.
2. potential infinite recursion problem

## Solution
Use a new variable transformedPathname to store the pathname of the currently processed file, and check in each loop whether the pathname of the currently processed file is the same as the originally requested file pathname.