### PR TITLE
fix(update): correct return and argument types for `defineFn()`

### DIFF
--- a/src/compat.ts
+++ b/src/compat.ts
@@ -46,10 +46,10 @@ export type Handler<T = any, State = Record<string, unknown>> = HandlerFn<
 function defineFn<State>(
   fn: (
     ctx: FreshContext<State>,
-  ) => Request | VNode | null | Promise<Request | VNode | null>,
+  ) => Response | VNode | null | Promise<Response | VNode | null>,
 ): (
   ctx: FreshContext<State>,
-) => Request | VNode | null | Promise<Request | VNode | null> {
+) => Response | VNode | null | Promise<Response | VNode | null> {
   return fn;
 }
 


### PR DESCRIPTION
Previously, the return union type of the inner function and the function itself contained a `Request` instead of a `Response`.