### PR TITLE
test(www): use `@std/expect` instead of `@std/assert`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -55,7 +55,6 @@
     "@preact/signals": "npm:@preact/signals@^2.0.4",
     "esbuild": "npm:esbuild@0.25.4",
     "esbuild-wasm": "npm:esbuild-wasm@0.25.4",
-    "@std/assert": "jsr:@std/assert@^1.0.16",
     "@std/crypto": "jsr:@std/crypto@1",
     "@std/datetime": "jsr:@std/datetime@^0.225.2",
     "@std/encoding": "jsr:@std/encoding@1",

--- a/deno.lock
+++ b/deno.lock
@@ -1916,7 +1916,6 @@
       "jsr:@fresh/plugin-tailwind@^0.0.1-alpha.7",
       "jsr:@luca/esbuild-deno-loader@0.11",
       "jsr:@marvinh-test/fresh-island@^0.0.1",
-      "jsr:@std/assert@^1.0.16",
       "jsr:@std/async@^1.0.13",
       "jsr:@std/cli@^1.0.19",
       "jsr:@std/collections@^1.0.11",

--- a/www/utils/screenshot_test.ts
+++ b/www/utils/screenshot_test.ts
@@ -1,49 +1,47 @@
-import { assertEquals, assertThrows } from "jsr:@std/assert";
+import { expect } from "@std/expect/expect";
 import { generateFilePaths, validateArgs, validateUrl } from "./screenshot.ts";
 
 Deno.test("validateArgs - accepts 2 arguments", () => {
   const result = validateArgs(["https://example.com", "test-id"]);
-  assertEquals(result, ["https://example.com", "test-id"]);
+  expect(result).toEqual(["https://example.com", "test-id"]);
 });
 
 Deno.test("validateArgs - should throw error for incorrect number of arguments", () => {
-  assertThrows(
-    () => validateArgs(["only-one"]),
-    Error,
+  expect(() => validateArgs(["only-one"])).toThrow(
     "Usage: screenshot <url> <id>",
   );
-  assertThrows(
-    () => validateArgs(["one", "two", "three"]),
-    Error,
+  expect(() => validateArgs(["one", "two", "three"])).toThrow(
     "Usage: screenshot <url> <id>",
   );
 });
 
 Deno.test("validateUrl - should accept valid HTTP URLs", () => {
   const url = validateUrl("http://example.com");
-  assertEquals(url.protocol, "http:");
-  assertEquals(url.hostname, "example.com");
+  expect(url).toEqual(new URL("http://example.com"));
 });
 
 Deno.test("validateUrl - should accept valid HTTPS URLs", () => {
   const url = validateUrl("https://example.com");
-  assertEquals(url.protocol, "https:");
-  assertEquals(url.hostname, "example.com");
+  expect(url).toEqual(new URL("https://example.com"));
 });
 
 Deno.test("validateUrl - should reject invalid protocols", () => {
-  assertThrows(() => validateUrl("ftp://example.com"), Error, "Invalid URL");
-  assertThrows(() => validateUrl("file:///path/to/file"), Error, "Invalid URL");
+  expect(() => validateUrl("ftp://example.com")).toThrow("Invalid URL");
+  expect(() => validateUrl("file:///path/to/file")).toThrow("Invalid URL");
 });
 
 Deno.test("generateFilePaths - should generate correct file paths", () => {
   const paths = generateFilePaths("test-id");
-  assertEquals(paths.image2x, "./www/static/showcase/test-id2x.jpg");
-  assertEquals(paths.image1x, "./www/static/showcase/test-id1x.jpg");
+  expect(paths).toEqual({
+    image2x: "./www/static/showcase/test-id2x.jpg",
+    image1x: "./www/static/showcase/test-id1x.jpg",
+  });
 });
 
 Deno.test("generateFilePaths - should handle special characters in ID", () => {
   const paths = generateFilePaths("test-id_123");
-  assertEquals(paths.image2x, "./www/static/showcase/test-id_1232x.jpg");
-  assertEquals(paths.image1x, "./www/static/showcase/test-id_1231x.jpg");
+  expect(paths).toEqual({
+    image2x: "./www/static/showcase/test-id_1232x.jpg",
+    image1x: "./www/static/showcase/test-id_1231x.jpg",
+  });
 });


### PR DESCRIPTION
Aligns screenshot tests to the rest of the codebase by using `@std/expect` instead of `@std/assert`.