### PR TITLE
refactor(src): remove redundant coloring from `createCodeFrame()`

### DIFF
--- a/src/dev/middlewares/error_overlay/code_frame.tsx
+++ b/src/dev/middlewares/error_overlay/code_frame.tsx
@@ -1,5 +1,4 @@
 import * as path from "@std/path";
-import * as colors from "@std/fmt/colors";
 
 function tabs2Spaces(str: string) {
   return str.replace(/^\t+/, (tabs) => "  ".repeat(tabs.length));
@@ -55,21 +54,18 @@ export function createCodeFrame(
     activeLine.length - lines[lineNum].length + columnNum,
   );
 
-  const sep = colors.dim("|");
+  const sep = "|";
   let out = "";
 
   for (let i = 0; i < spaceLines.length; i++) {
     const line = spaceLines[i];
-    const currentLine = colors.dim(
-      (padding + (i + start + 1)).slice(-maxLineNum),
-    );
+    const currentLine = (padding + (i + start + 1)).slice(-maxLineNum);
 
     // Line where the error occurred
     if (i === lineNum - start) {
-      out += colors.red(">") +
-        ` ${currentLine} ${sep} ${line}\n`;
+      out += ">" + ` ${currentLine} ${sep} ${line}\n`;
 
-      const columnMarker = colors.bold(colors.red("^"));
+      const columnMarker = "^";
       out += `  ${padding} ${sep} ${" ".repeat(count)}${columnMarker}\n`;
     } else {
       out += `  ${currentLine} ${sep} ${line}\n`;

--- a/src/runtime/server/preact_hooks.tsx
+++ b/src/runtime/server/preact_hooks.tsx
@@ -29,7 +29,6 @@ import {
   DEV_ERROR_OVERLAY_URL,
   PARTIAL_SEARCH_PARAM,
 } from "../../constants.ts";
-import * as colors from "@std/fmt/colors";
 import { escape as escapeHtml } from "@std/html";
 import { HttpError } from "../../error.ts";
 import { getCodeFrame } from "../../dev/middlewares/error_overlay/code_frame.tsx";
@@ -527,7 +526,7 @@ export function ShowErrorOverlay() {
       searchParams.append("stack", error.stack);
       const codeFrame = getCodeFrame(error.stack, ctx.config.root);
       if (codeFrame !== undefined) {
-        searchParams.append("code-frame", colors.stripAnsiCode(codeFrame));
+        searchParams.append("code-frame", codeFrame);
       }
     }
   } else {


### PR DESCRIPTION
`src/runtime/server/preact_hooks.tsx` is the only place that `createCodeFrame()` is used which stripped the ANSI codes anyway.