### PR TITLE
fix(core): use `PageProps` instead of `FreshContext` in `define*()` compat functions

### DIFF
--- a/src/compat.ts
+++ b/src/compat.ts
@@ -1,5 +1,5 @@
 import type { ComponentChildren } from "preact";
-import type { FreshContext } from "./context.ts";
+import type { FreshContext, PageProps } from "./context.ts";
 import type { HandlerFn, RouteHandler } from "./handlers.ts";
 
 /**
@@ -45,13 +45,13 @@ export type Handler<T = any, State = Record<string, unknown>> = HandlerFn<
 
 function defineFn<State>(
   fn: (
-    ctx: FreshContext<State>,
+    ctx: PageProps<State>,
   ) =>
     | ComponentChildren
     | Response
     | Promise<Response | ComponentChildren>,
 ): (
-  ctx: FreshContext<State>,
+  ctx: PageProps<State>,
 ) =>
   | ComponentChildren
   | Response

--- a/src/compat_test.tsx
+++ b/src/compat_test.tsx
@@ -1,10 +1,10 @@
-import type { FreshContext } from "./context.ts";
+import type { PageProps } from "./context.ts";
 import { assertType, type IsExact } from "@std/testing/types";
 import { expect } from "@std/expect";
 import { type defineApp, type defineLayout, defineRoute } from "./compat.ts";
 
 Deno.test("compat - defineFn works", () => {
-  const ctx = {} as FreshContext<unknown>;
+  const ctx = {} as PageProps<unknown>;
   expect(defineRoute(() => new Response("test"))(ctx)).toBeInstanceOf(Response);
   expect(defineRoute(() => <span>test</span>)(ctx)).toBeInstanceOf(Object);
   expect(defineRoute(() => null)(ctx)).toEqual(null);


### PR DESCRIPTION
In Fresh 1, define apps used `RouteContext`, which align with `PageProps` in Fresh 2, rather than `FreshContext`. E.g. before this PR, one would get a type error if they tried to use `ctx.Component` within `defineApp()` and now they shouldn't.