### PR TITLE
Add localhost help text to server address output

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -76,8 +76,11 @@ function createOnListen(
     const address = colors.cyan(
       `${protocol}//${hostname}:${params.port}${pathname}`,
     );
+    const helper = hostname === "0.0.0.0" || hostname === "::"
+      ? colors.cyan(` (${protocol}//localhost:${params.port}${pathname})`)
+      : "";
     // deno-lint-ignore no-console
-    console.log(`    ${localLabel}  ${space}${address}${sep}`);
+    console.log(`    ${localLabel}  ${space}${address}${helper}${sep}`);
     if (options.remoteAddress) {
       const remoteLabel = colors.bold("Remote:");
       const remoteAddress = colors.cyan(options.remoteAddress);


### PR DESCRIPTION
When binding to `0.0.0.0` or `::`, show localhost equivalent URL for convenience

Closes #3076

output from fresh www

```
deno task start
Task start deno run -A --watch=static/,routes/,../src,../docs dev.ts
Watcher Process started.

 🍋 Fresh ready
    Local:  http://0.0.0.0:8000/ (http://localhost:8000/)

GA4_MEASUREMENT_ID environment variable not set. Google Analytics reporting disabled.
```