### PR TITLE
chore: cleanup cors middleware

### DIFF
--- a/src/middlewares/cors.ts
+++ b/src/middlewares/cors.ts
@@ -1,11 +1,14 @@
 import type { FreshContext } from "../context.ts";
 import type { MiddlewareFn } from "./mod.ts";
 
-export type CORSOptions = {
+export type CORSOptions<State> = {
   origin:
     | string
     | string[]
-    | ((requestOrigin: string, ctx: FreshContext) => string | undefined | null);
+    | ((
+      requestOrigin: string,
+      ctx: FreshContext<State>,
+    ) => string | undefined | null);
   allowMethods?: string[];
   allowHeaders?: string[];
   maxAge?: number;
@@ -51,8 +54,8 @@ export type CORSOptions = {
  * // ];
  * ```
  */
-export function cors<T>(options?: CORSOptions): MiddlewareFn<T> {
-  const opts: CORSOptions = {
+export function cors<State>(options?: CORSOptions<State>): MiddlewareFn<State> {
+  const opts: CORSOptions<State> = {
     origin: "*",
     allowMethods: ["GET", "HEAD", "PUT", "POST", "DELETE", "PATCH"],
     allowHeaders: [],
@@ -60,27 +63,10 @@ export function cors<T>(options?: CORSOptions): MiddlewareFn<T> {
     ...options,
   };
 
-  const findAllowOrigin = ((optsOrigin: CORSOptions["origin"]) => {
-    if (typeof optsOrigin === "string") {
-      if (optsOrigin === "*") {
-        return (_requestOrigin: string, _ctx: FreshContext) => optsOrigin;
-      } else {
-        return (requestOrigin: string, _ctx: FreshContext) =>
-          optsOrigin === requestOrigin ? requestOrigin : null;
-      }
-    } else if (typeof optsOrigin === "function") {
-      return (requestOrigin: string, ctx: FreshContext) =>
-        optsOrigin(requestOrigin, ctx);
-    } else {
-      return (requestOrigin: string, _ctx: FreshContext) =>
-        optsOrigin.includes(requestOrigin) ? requestOrigin : null;
-    }
-  })(opts.origin);
-
   const addHeaderProperties = (
     headers: Headers,
     allowOrigin: string | null | undefined,
-    opts: CORSOptions,
+    opts: CORSOptions<State>,
   ) => {
     if (allowOrigin) {
       headers.set("Access-Control-Allow-Origin", allowOrigin);
@@ -98,77 +84,82 @@ export function cors<T>(options?: CORSOptions): MiddlewareFn<T> {
     }
   };
 
-  const OptionsResponse = (
-    ctx: FreshContext,
-    allowOrigin: string | null | undefined,
-    opts: CORSOptions,
-    varyValues: Set<string>,
-  ) => {
-    const headers = new Headers();
+  const optsOrigin = opts.origin;
 
-    addHeaderProperties(
-      headers,
-      allowOrigin,
-      opts,
-    );
-
-    if (opts.maxAge != null) {
-      headers.set("Access-Control-Max-Age", opts.maxAge.toString());
-    }
-
-    if (opts.allowMethods?.length) {
-      headers.set(
-        "Access-Control-Allow-Methods",
-        opts.allowMethods.join(","),
-      );
-    }
-
-    let effectiveAllowHeaders = opts.allowHeaders;
-    if (!effectiveAllowHeaders?.length) {
-      const reqHeaders = ctx.req.headers.get(
-        "Access-Control-Request-Headers",
-      );
-      if (reqHeaders) {
-        effectiveAllowHeaders = reqHeaders.split(/\s*,\s*/);
-      }
-    }
-
-    if (effectiveAllowHeaders?.length) {
-      headers.set(
-        "Access-Control-Allow-Headers",
-        effectiveAllowHeaders.join(","),
-      );
-      varyValues.add("Access-Control-Request-Headers");
-    }
-
-    if (varyValues.size > 0) {
-      headers.set("Vary", Array.from(varyValues).join(", "));
-    } else {
-      headers.delete("Vary"); // Ensure Vary is not set if no conditions met
-    }
-
-    headers.delete("Content-Length");
-    headers.delete("Content-Type");
-
-    return new Response(null, {
-      status: 204,
-      statusText: "No Content",
-      headers,
-    });
-  };
-
-  return async (ctx: FreshContext): Promise<Response> => {
+  return async (ctx) => {
     const requestOrigin = ctx.req.headers.get("origin") || "";
-    const allowOrigin = findAllowOrigin(requestOrigin, ctx);
 
-    const varyValues = new Set<string>();
+    let allowOrigin: string | null = null;
+    if (typeof optsOrigin === "string") {
+      if (optsOrigin === "*") {
+        allowOrigin = optsOrigin;
+      } else {
+        allowOrigin = optsOrigin === requestOrigin ? requestOrigin : null;
+      }
+    } else if (typeof optsOrigin === "function") {
+      allowOrigin = optsOrigin(requestOrigin, ctx) ?? null;
+    } else {
+      allowOrigin = optsOrigin.includes(requestOrigin) ? requestOrigin : null;
+    }
+
+    const vary = new Set<string>();
     // Add 'Origin' to Vary if a specific origin is allowed, not '*'
     if (opts.origin !== "*" && allowOrigin && allowOrigin !== "*") {
-      varyValues.add("Origin");
+      vary.add("Origin");
     }
 
     if (ctx.req.method === "OPTIONS") {
-      return OptionsResponse(ctx, allowOrigin, opts, varyValues);
+      const headers = new Headers();
+
+      addHeaderProperties(
+        headers,
+        allowOrigin,
+        opts,
+      );
+
+      if (opts.maxAge != null) {
+        headers.set("Access-Control-Max-Age", opts.maxAge.toString());
+      }
+
+      if (opts.allowMethods?.length) {
+        headers.set(
+          "Access-Control-Allow-Methods",
+          opts.allowMethods.join(","),
+        );
+      }
+
+      let allowHeaders = opts.allowHeaders;
+      if (!allowHeaders?.length) {
+        const reqHeaders = ctx.req.headers.get(
+          "Access-Control-Request-Headers",
+        );
+        if (reqHeaders) {
+          allowHeaders = reqHeaders.split(/\s*,\s*/);
+        }
+      }
+
+      if (allowHeaders?.length) {
+        headers.set(
+          "Access-Control-Allow-Headers",
+          allowHeaders.join(","),
+        );
+        vary.add("Access-Control-Request-Headers");
+      }
+
+      if (vary.size > 0) {
+        headers.set("Vary", Array.from(vary).join(", "));
+      } else {
+        headers.delete("Vary"); // Ensure Vary is not set if no conditions met
+      }
+
+      headers.delete("Content-Length");
+      headers.delete("Content-Type");
+
+      return new Response(null, {
+        status: 204,
+        statusText: "No Content",
+        headers,
+      });
     }
 
     // For non-OPTIONS requests
@@ -181,13 +172,13 @@ export function cors<T>(options?: CORSOptions): MiddlewareFn<T> {
     );
 
     // Merge our calculated varyValues with any existing Vary from downstream response
-    if (varyValues.size > 0) {
-      const existingVary = res.headers.get("Vary");
-      if (existingVary) {
-        existingVary.split(/\s*,\s*/).forEach((v) => varyValues.add(v));
+    if (vary.size > 0) {
+      const existing = res.headers.get("Vary");
+      if (existing) {
+        existing.split(/\s*,\s*/).forEach((v) => vary.add(v));
       }
 
-      res.headers.set("Vary", Array.from(varyValues).join(", "));
+      res.headers.set("Vary", Array.from(vary).join(", "));
     }
 
     return res;

--- a/src/middlewares/cors_test.ts
+++ b/src/middlewares/cors_test.ts
@@ -1,249 +1,255 @@
 import { App } from "../app.ts";
-import type { FreshContext } from "../context.ts";
 import { cors } from "./cors.ts";
-import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-describe("CORS by Middleware", () => {
-  const app = new App();
+Deno.test("CORS - GET default", async () => {
+  const handler = new App()
+    .use(cors())
+    .get("/", () => new Response("ok"))
+    .handler();
 
-  app.all("/api/*", cors());
+  const res = await handler(new Request("https://localhost/"));
 
-  app.all(
-    "/api2/*",
-    cors({
-      origin: "http://example.com",
-      allowHeaders: ["X-Custom-Header", "Upgrade-Insecure-Requests"],
-      allowMethods: ["POST", "GET", "OPTIONS"],
-      exposeHeaders: ["Content-Length", "X-Kuma-Revision"],
-      maxAge: 600,
-      credentials: true,
+  expect(res.status).toBe(200);
+  expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  expect(res.headers.get("Vary")).toBeNull();
+});
+
+Deno.test("CORS - Preflight default", async () => {
+  const handler = new App()
+    .use(cors())
+    .get("/", () => new Response("ok"))
+    .handler();
+
+  const req = new Request("https://localhost/", { method: "OPTIONS" });
+  req.headers.append(
+    "Access-Control-Request-Headers",
+    "X-PINGOTHER, Content-Type",
+  );
+
+  const res = await handler(req);
+
+  expect(res.status).toBe(204);
+  expect(res.statusText).toBe("No Content");
+  expect(res.headers.get("Access-Control-Allow-Methods")?.split(",")[0]).toBe(
+    "GET",
+  );
+  expect(res.headers.get("Access-Control-Allow-Headers")?.split(",")).toEqual(
+    [
+      "X-PINGOTHER",
+      "Content-Type",
+    ],
+  );
+});
+
+Deno.test("CORS - Preflight with options", async () => {
+  const handler = new App()
+    .use(
+      cors({
+        origin: "http://example.com",
+        allowHeaders: ["X-Custom-Header", "Upgrade-Insecure-Requests"],
+        allowMethods: ["POST", "GET", "OPTIONS"],
+        exposeHeaders: ["Content-Length", "X-Kuma-Revision"],
+        maxAge: 600,
+        credentials: true,
+      }),
+    )
+    .get("/", () => new Response("ok"))
+    .handler();
+
+  const res = await handler(
+    new Request("https://localhost/", {
+      method: "OPTIONS",
+      headers: { origin: "http://example.com" },
     }),
   );
 
-  app.all(
-    "/api3/*",
-    cors({
+  expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+    "http://example.com",
+  );
+  expect(res.headers.get("Vary")?.split(/\s*,\s*/)).toEqual(
+    expect.arrayContaining(["Origin"]),
+  );
+  expect(res.headers.get("Access-Control-Allow-Headers")?.split(/\s*,\s*/))
+    .toEqual([
+      "X-Custom-Header",
+      "Upgrade-Insecure-Requests",
+    ]);
+  expect(res.headers.get("Access-Control-Allow-Methods")?.split(/\s*,\s*/))
+    .toEqual([
+      "POST",
+      "GET",
+      "OPTIONS",
+    ]);
+  expect(res.headers.get("Access-Control-Expose-Headers")?.split(/\s*,\s*/))
+    .toEqual([
+      "Content-Length",
+      "X-Kuma-Revision",
+    ]);
+  expect(res.headers.get("Access-Control-Max-Age")).toBe("600");
+  expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+});
+
+Deno.test("CORS - Disallow an unmatched origin", async () => {
+  const handler = new App()
+    .use(
+      cors({
+        origin: "http://example.com",
+        allowHeaders: ["X-Custom-Header", "Upgrade-Insecure-Requests"],
+        allowMethods: ["POST", "GET", "OPTIONS"],
+        exposeHeaders: ["Content-Length", "X-Kuma-Revision"],
+        maxAge: 600,
+        credentials: true,
+      }),
+    )
+    .get("/", () => new Response("ok"))
+    .handler();
+
+  const res = await handler(
+    new Request("https://localhost/", {
+      method: "OPTIONS",
+      headers: { origin: "http://example.net" },
+    }),
+  );
+
+  expect(res.headers.has("Access-Control-Allow-Origin")).toBeFalsy();
+});
+
+Deno.test("CORS - Allow multiple origins", async () => {
+  const handler = new App()
+    .use(cors({
       origin: [
         "http://example.com",
         "http://example.org",
         "http://example.dev",
       ],
-    }),
-  );
+    }))
+    .get("/", () => new Response("ok"))
+    .handler();
 
-  app.all(
-    "/api4/*",
-    cors({
-      origin: (
-        origin,
-      ) => (origin.endsWith(".example.com") ? origin : "http://example.com"),
-    }),
-  );
-
-  app.all("/api5/*", cors());
-
-  app.all(
-    "/api6/*",
-    cors({
-      origin: "http://example.com",
-    }),
-  );
-  //
-  app.get("/api/abc", (_ctx: FreshContext) => {
-    return Response.json({ success: true });
-  });
-
-  app.get("/api2/abc", (_ctx: FreshContext) => {
-    return Response.json({ success: true });
-  });
-
-  app.get("/api3/abc", (_ctx: FreshContext) => {
-    return Response.json({ success: true });
-  });
-
-  app.get("/api4/abc", (_ctx: FreshContext) => {
-    return Response.json({ success: true });
-  });
-
-  app.get("/api5/abc", () => {
-    return new Response(JSON.stringify({ success: true }));
-  });
-
-  app.get("/api6/abc", (_ctx: FreshContext) => {
-    return Response.json({ success: true });
-  });
-
-  const handler = app.handler();
-
-  it("GET default", async () => {
-    const res = await handler(
-      new Request("https://localhost/api/abc"),
-    );
-
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
-    expect(res.headers.get("Vary")).toBeNull();
-  });
-
-  it("Preflight default", async () => {
-    const req = new Request("https://localhost/api/abc", { method: "OPTIONS" });
-    req.headers.append(
-      "Access-Control-Request-Headers",
-      "X-PINGOTHER, Content-Type",
-    );
-
-    const res = await handler(req);
-
-    expect(res.status).toBe(204);
-    expect(res.statusText).toBe("No Content");
-    expect(res.headers.get("Access-Control-Allow-Methods")?.split(",")[0]).toBe(
-      "GET",
-    );
-    expect(res.headers.get("Access-Control-Allow-Headers")?.split(",")).toEqual(
-      [
-        "X-PINGOTHER",
-        "Content-Type",
-      ],
-    );
-  });
-
-  it("Preflight with options", async () => {
-    const req = new Request("https://localhost/api2/abc", {
-      method: "OPTIONS",
-      headers: { origin: "http://example.com" },
-    });
-
-    const res = await handler(req);
-
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
-      "http://example.com",
-    );
-    expect(res.headers.get("Vary")?.split(/\s*,\s*/)).toEqual(
-      expect.arrayContaining(["Origin"]),
-    );
-    expect(res.headers.get("Access-Control-Allow-Headers")?.split(/\s*,\s*/))
-      .toEqual([
-        "X-Custom-Header",
-        "Upgrade-Insecure-Requests",
-      ]);
-    expect(res.headers.get("Access-Control-Allow-Methods")?.split(/\s*,\s*/))
-      .toEqual([
-        "POST",
-        "GET",
-        "OPTIONS",
-      ]);
-    expect(res.headers.get("Access-Control-Expose-Headers")?.split(/\s*,\s*/))
-      .toEqual([
-        "Content-Length",
-        "X-Kuma-Revision",
-      ]);
-    expect(res.headers.get("Access-Control-Max-Age")).toBe("600");
-    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
-  });
-
-  it("Disallow an unmatched origin", async () => {
-    const req = new Request("https://localhost/api2/abc", {
-      method: "OPTIONS",
-      headers: { origin: "http://example.net" },
-    });
-
-    const res = await handler(req);
-    expect(res.headers.has("Access-Control-Allow-Origin")).toBeFalsy();
-  });
-
-  it("Allow multiple origins", async () => {
-    let req = new Request("http://localhost/api3/abc", {
+  let res = await handler(
+    new Request("http://localhost/", {
       headers: {
         Origin: "http://example.org",
       },
-    });
-    let res = await handler(req);
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
-      "http://example.org",
-    );
+    }),
+  );
+  expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+    "http://example.org",
+  );
 
-    req = new Request("http://localhost/api3/abc");
-    res = await handler(req);
-    expect(
-      res.headers.has("Access-Control-Allow-Origin"),
-      "An unmatched origin should be disallowed",
-    ).toBeFalsy();
+  res = await handler(new Request("http://localhost/"));
+  expect(
+    res.headers.has("Access-Control-Allow-Origin"),
+    "An unmatched origin should be disallowed",
+  ).toBeFalsy();
 
-    req = new Request("http://localhost/api3/abc", {
+  res = await handler(
+    new Request("http://localhost/api3/abc", {
       headers: {
         Referer: "http://example.net/",
       },
-    });
-    res = await handler(req);
-    expect(
-      res.headers.has("Access-Control-Allow-Origin"),
-      "An unmatched origin should be disallowed",
-    ).toBeFalsy();
-  });
+    }),
+  );
+  expect(
+    res.headers.has("Access-Control-Allow-Origin"),
+    "An unmatched origin should be disallowed",
+  ).toBeFalsy();
+});
 
-  it("Allow different Vary header value", async () => {
-    const req = new Request("http://localhost/api3/abc", {
+Deno.test("CORS - Allow different Vary header value", async () => {
+  const handler = new App()
+    .use(cors({
+      origin: [
+        "http://example.com",
+        "http://example.org",
+        "http://example.dev",
+      ],
+    }))
+    .get("/", () => new Response("ok"))
+    .handler();
+
+  const res = await handler(
+    new Request("http://localhost/", {
       headers: {
         Vary: "accept-encoding",
         Origin: "http://example.com",
       },
-    });
-    const res = await handler(req);
+    }),
+  );
 
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
-      "http://example.com",
-    );
-    expect(res.headers.get("Vary")).toBe("Origin");
-  });
+  expect(res.status).toBe(200);
+  expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+    "http://example.com",
+  );
+  expect(res.headers.get("Vary")).toBe("Origin");
+});
 
-  it("Allow origins by function", async () => {
-    let req = new Request("http://localhost/api4/abc", {
+Deno.test("CORS - Allow origins by function", async () => {
+  const handler = new App()
+    .use(cors({
+      origin: (
+        origin,
+      ) => (origin.endsWith(".example.com") ? origin : "http://example.com"),
+    }))
+    .get("/", () => new Response("ok"))
+    .handler();
+
+  let res = await handler(
+    new Request("http://localhost/", {
       headers: {
         Origin: "http://subdomain.example.com",
       },
-    });
-    let res = await handler(req);
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
-      "http://subdomain.example.com",
-    );
+    }),
+  );
+  expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+    "http://subdomain.example.com",
+  );
 
-    req = new Request("http://localhost/api4/abc");
-    res = await handler(req);
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
-      "http://example.com",
-    );
+  res = await handler(new Request("http://localhost/"));
+  expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+    "http://example.com",
+  );
 
-    req = new Request("http://localhost/api4/abc", {
+  res = await handler(
+    new Request("http://localhost/", {
       headers: {
         Referer: "http://evil-example.com/",
       },
-    });
-    res = await handler(req);
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
-      "http://example.com",
-    );
-  });
+    }),
+  );
+  expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+    "http://example.com",
+  );
+});
 
-  it("With raw Response object", async () => {
-    const req = new Request("http://localhost/api5/abc");
-    const res = await handler(req);
+Deno.test("CORS - With raw Response object", async () => {
+  const handler = new App()
+    .use(cors())
+    .get("/", () => new Response("ok"))
+    .handler();
 
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
-    expect(res.headers.get("Vary")).toBeNull();
-  });
+  const res = await handler(new Request("http://localhost/"));
 
-  it("Should not return duplicate header values", async () => {
-    const req = new Request("http://localhost/api6/abc", {
+  expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  expect(res.headers.get("Vary")).toBeNull();
+});
+
+Deno.test("CORS - Should not return duplicate header values", async () => {
+  const handler = new App()
+    .use(cors({ origin: "http://example.com" }))
+    .get("/", () => new Response("ok"))
+    .handler();
+
+  const res = await handler(
+    new Request("http://localhost/", {
       headers: {
         origin: "http://example.com",
       },
-    });
-    const res = await handler(req);
+    }),
+  );
 
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
-      "http://example.com",
-    );
-  });
+  expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+    "http://example.com",
+  );
 });


### PR DESCRIPTION
- Remove some indirections
- Make tests self contained
- Switch tests to `Deno.test` as the LSP doesn't yet recognise `describe/it`