### PR TITLE
fix: hide `node_modules` and `vendor` from update output

### DIFF
--- a/update/src/update.ts
+++ b/update/src/update.ts
@@ -170,7 +170,7 @@ export async function updateProject(dir: string) {
   );
 
   // Filter out node_modules and vendor files for user display
-  const userFiles = sfs.filter((sf) => !shouldHideFromLogs(sf.getFilePath()));
+  const userFiles = sfs.filter((sf) => !HIDE_FILES.test(sf.getFilePath()));
 
   // deno-lint-ignore no-console
   console.log(colors.cyan(`📁 Found ${userFiles.length} files to process`));
@@ -220,7 +220,7 @@ export async function updateProject(dir: string) {
 
   // Filter modified files to show only user files
   const modifiedFilesToShow = modifiedFilesList.filter((filePath) =>
-    !shouldHideFromLogs(filePath)
+    !HIDE_FILES.test(filePath)
   );
 
   // add migration summary

--- a/update/src/update.ts
+++ b/update/src/update.ts
@@ -11,12 +11,7 @@ export const PREACT_VERSION = "10.26.9";
 export const PREACT_SIGNALS_VERSION = "2.2.1";
 
 // Function to filter out node_modules and vendor directories from logs
-function shouldHideFromLogs(filePath: string): boolean {
-  const normalizedPath = filePath.replace(/\\/g, "/");
-  return normalizedPath.includes("/node_modules/") ||
-    normalizedPath.includes("/vendor/");
-}
-
+const HIDE_FILES = /[\\/]+(node_modules|vendor)[\\/]+/;
 export interface DenoJson {
   lock?: boolean;
   tasks?: Record<string, string>;

--- a/update/src/update.ts
+++ b/update/src/update.ts
@@ -248,7 +248,9 @@ export async function updateProject(dir: string) {
     console.log("\n" + colors.bold("📝 Modified Files:"));
     modifiedFilesToShow.forEach((filePath) => {
       // show relative path
-      const relativePath = path.relative(dir, filePath);
+      let relativePath = path.relative(dir, filePath);
+      // Ensure consistent path separators for logging
+      relativePath = relativePath.replace(/\\/g, "/");
       // deno-lint-ignore no-console
       console.log(colors.green(`   ✓ ${relativePath}`));
     });

--- a/update/src/update_test.ts
+++ b/update/src/update_test.ts
@@ -366,10 +366,9 @@ Deno.test(
   },
 );
 
-Deno.test({
-  ignore: true,
-  name: "update - 1.x update handler signature variable",
-  fn: async () => {
+Deno.test.ignore(
+  "update - 1.x update handler signature variable",
+  async () => {
     await using _tmp = await withTmpDir();
     const dir = _tmp.dir;
     await writeFiles(dir, {
@@ -400,12 +399,11 @@ Deno.test({
   },
 };`);
   },
-});
+);
 
-Deno.test({
-  ignore: true,
-  name: "update - 1.x update handler signature non-inferred",
-  fn: async () => {
+Deno.test(
+  "update - 1.x update handler signature non-inferred",
+  async () => {
     await using _tmp = await withTmpDir();
     const dir = _tmp.dir;
     await writeFiles(dir, {
@@ -429,12 +427,11 @@ export const handler = {
   },
 };`);
   },
-});
+);
 
-Deno.test({
-  ignore: true,
-  name: "update - 1.x update handler signature with destructure",
-  fn: async () => {
+Deno.test(
+  "update - 1.x update handler signature with destructure",
+  async () => {
     await using _tmp = await withTmpDir();
     const dir = _tmp.dir;
     await writeFiles(dir, {
@@ -472,7 +469,7 @@ export const handler: Handlers = {
   },
 };`);
   },
-});
+);
 
 Deno.test("update - 1.x update define* handler signatures", async () => {
   await using _tmp = await withTmpDir();
@@ -561,10 +558,9 @@ export default async function Index(ctx: FreshContext) {
   },
 );
 
-Deno.test({
-  ignore: true,
-  name: "update - 1.x ctx.renderNotFound() -> ctx.throw()",
-  fn: async () => {
+Deno.test.ignore(
+  "update - 1.x ctx.renderNotFound() -> ctx.throw()",
+  async () => {
     await using _tmp = await withTmpDir();
     const dir = _tmp.dir;
     await writeFiles(dir, {
@@ -598,12 +594,11 @@ export const handler: Handlers = {
   throw HttpError(404);
 };`);
   },
-});
+);
 
-Deno.test({
-  ignore: true,
-  name: "update - 1.x ctx.remoteAddr -> ctx.info.remoteAddr",
-  fn: async () => {
+Deno.test.ignore(
+  "update - 1.x ctx.remoteAddr -> ctx.info.remoteAddr",
+  async () => {
     await using _tmp = await withTmpDir();
     const dir = _tmp.dir;
     await writeFiles(dir, {
@@ -633,17 +628,14 @@ export const handler: Handlers = {
   },
 };`);
   },
-});
+);
 
-Deno.test({
-  ignore: true,
-  name: "update - 1.x destructured ctx members",
-  fn: async () => {
-    await using _tmp = await withTmpDir();
-    const dir = _tmp.dir;
-    await writeFiles(dir, {
-      "/deno.json": `{}`,
-      "/routes/index.tsx": `import { Handlers } from "$fresh/server.ts";
+Deno.test.ignore("update - 1.x destructured ctx members", async () => {
+  await using _tmp = await withTmpDir();
+  const dir = _tmp.dir;
+  await writeFiles(dir, {
+    "/deno.json": `{}`,
+    "/routes/index.tsx": `import { Handlers } from "$fresh/server.ts";
 
 export const handler: Handlers = {
   async GET(_req, { url, renderNotFound, remoteAddr }) {
@@ -655,13 +647,13 @@ export const handler: Handlers = {
     }
   },
 };`,
-    });
+  });
 
-    await updateProject(dir);
-    const files = await readFiles(dir);
+  await updateProject(dir);
+  const files = await readFiles(dir);
 
-    expect(files["/routes/index.tsx"])
-      .toEqual(`import { Handlers } from "fresh";
+  expect(files["/routes/index.tsx"])
+    .toEqual(`import { Handlers } from "fresh";
 
 export const handler: Handlers = {
   async GET({ url, throw, info }) {
@@ -676,7 +668,6 @@ export const handler: Handlers = {
     }
   },
 };`);
-  },
 });
 
 Deno.test("update - 1.x remove reference comments", async () => {

--- a/update/src/update_test.ts
+++ b/update/src/update_test.ts
@@ -6,7 +6,7 @@ import {
   updateProject,
 } from "./update.ts";
 import { expect } from "@std/expect";
-import { type SpyCall, spy } from "@std/testing/mock";
+import { spy, type SpyCall } from "@std/testing/mock";
 import { walk } from "@std/fs/walk";
 import { withTmpDir } from "../../src/test_utils.ts";
 
@@ -751,7 +751,9 @@ export default function Foo(props: PageProps) {
 }`,
   );
 
-  const fullLog = consoleLogSpy.calls.map((call: SpyCall) => call.args.join(" ")).join(
+  const fullLog = consoleLogSpy.calls.map((call: SpyCall) =>
+    call.args.join(" ")
+  ).join(
     "\n",
   );
 


### PR DESCRIPTION
Added logic to filter out files in node_modules and vendor directories from user-facing logs and migration summaries in the update process. Updated tests to verify that these files are processed but not shown in logs.

close #3082 