### PR TITLE
Revert "feat: support overwriting default 404 handler (#3081)"

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -245,13 +245,7 @@ export class App<State> {
     return this;
   }
 
-  /**
-   * Create handler function for `Deno.serve` or to be used in
-   * testing.
-   * @param {() => Promise<Response>} [nextFn] overwrite default 404 handler
-   * @returns {Deno.ServeHandler}
-   */
-  handler(nextFn?: () => Promise<Response>): (
+  handler(): (
     request: Request,
     info?: Deno.ServeHandlerInfo,
   ) => Promise<Response> {
@@ -282,7 +276,7 @@ export class App<State> {
 
       const next = matched.patternMatch && !matched.methodMatch
         ? DEFAULT_NOT_ALLOWED_METHOD
-        : nextFn ?? DEFAULT_NOT_FOUND;
+        : DEFAULT_NOT_FOUND;
 
       const { params, handlers, pattern } = matched;
       const ctx = new FreshReqContext<State>(

--- a/src/app_test.tsx
+++ b/src/app_test.tsx
@@ -532,15 +532,3 @@ Deno.test("App - adding Island should convert to valid export names", () => {
     fn: component3,
   });
 });
-
-Deno.test("App - overwrite default 404 handler", async () => {
-  const app = new App().get("/foo", () => new Response("foo"));
-
-  const server = new FakeServer(
-    app.handler(() => Promise.resolve(new Response("bar"))),
-  );
-
-  const res = await server.get("/invalid");
-  const text = await res.text();
-  expect(text).toEqual("bar");
-});


### PR DESCRIPTION
This reverts commit 0b3546f2013c58880084a72d89f76a7a3363d039.

Reverting this because it will be superseded by https://github.com/denoland/fresh/pull/3086