### PR TITLE
fix: find nearest deno config with compiler options

### DIFF
--- a/src/dev/builder.ts
+++ b/src/dev/builder.ts
@@ -157,7 +157,9 @@ export class Builder implements FreshBuilder {
       }
     }
 
-    const denoJson = await findNearestDenoConfigWithCompilerOptions(app.config.root);
+    const denoJson = await findNearestDenoConfigWithCompilerOptions(
+      app.config.root,
+    );
 
     const jsxImportSource = denoJson.config.compilerOptions?.jsxImportSource;
     if (jsxImportSource === undefined) {

--- a/src/dev/builder.ts
+++ b/src/dev/builder.ts
@@ -157,7 +157,7 @@ export class Builder implements FreshBuilder {
       }
     }
 
-    const denoJson = await readDenoConfigForCompilerOptions(app.config.root);
+    const denoJson = await findNearestDenoConfigWithCompilerOptions(app.config.root);
 
     const jsxImportSource = denoJson.config.compilerOptions?.jsxImportSource;
     if (jsxImportSource === undefined) {
@@ -231,12 +231,11 @@ export interface DenoConfig {
   };
 }
 
-export async function readDenoConfigForCompilerOptions(
+export async function findNearestDenoConfigWithCompilerOptions(
   directory: string,
 ): Promise<{ config: DenoConfig; filePath: string }> {
   let dir = directory;
-  const configs: { config: DenoConfig; filePath: string }[] = [];
-  outer: while (true) {
+  while (true) {
     for (const name of ["deno.json", "deno.jsonc"]) {
       const filePath = path.join(dir, name);
       try {
@@ -247,10 +246,8 @@ export async function readDenoConfigForCompilerOptions(
         } else {
           config = JSON.parse(file);
         }
-        configs.push({ config, filePath });
-        if (config.workspace) {
-          break outer;
-        }
+        if (config.compilerOptions) return { config, filePath };
+        if (config.workspace) break;
         break;
       } catch (err) {
         if (!(err instanceof Deno.errors.NotFound)) {
@@ -263,36 +260,7 @@ export async function readDenoConfigForCompilerOptions(
     dir = parent;
   }
 
-  if (configs.length === 0) {
-    throw new Error(
-      `Could not find a deno.json or deno.jsonc file in the current directory or any parent directory.`,
-    );
-  }
-
-  const firstConfig = configs[0];
-  const lastConfig = configs.at(-1);
-  if (lastConfig?.config.workspace) {
-    if (lastConfig === firstConfig) return lastConfig;
-    if (!Array.isArray(lastConfig.config.workspace)) {
-      throw new Error(
-        `Expected "workspace" option to be an array in: ${lastConfig.filePath}`,
-      );
-    }
-    const members = lastConfig.config.workspace.map((member) => {
-      if (typeof member !== "string") {
-        throw new Error(
-          `Expected "workspace" member to be a string in: ${lastConfig.filePath}`,
-        );
-      }
-      return path.join(lastConfig.filePath, "..", member);
-    });
-    const parent = path.dirname(firstConfig.filePath);
-    if (!members.includes(parent)) {
-      return firstConfig;
-    } else {
-      return lastConfig;
-    }
-  }
-
-  return firstConfig;
+  throw new Error(
+    `Could not find a deno.json or deno.jsonc file in the current directory or any parent directory that contains a 'compilerOptions' field.`,
+  );
 }


### PR DESCRIPTION
Previously it would only consult the compiler options in the workspace root deno.json, now it also considers relevant workspace members.

Fixes https://github.com/denoland/fresh/issues/3004
