### PR TITLE
fix: incorrect middleware ordering

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -243,7 +243,7 @@ export class App<State> {
       fns = middlewares;
     }
 
-    const segment = getOrCreateSegment(this.#root, path, false);
+    const segment = getOrCreateSegment(this.#root, path, true);
     segment.middlewares.push(...fns);
 
     return this;


### PR DESCRIPTION
This is a regression introduced in https://github.com/denoland/fresh/pull/3086