### PR TITLE
feat: support lazily loading routes/handlers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -46,6 +46,7 @@
   "imports": {
     "@deno/doc": "jsr:@deno/doc@^0.172.0",
     "@deno/esbuild-plugin": "jsr:@deno/esbuild-plugin@^1.1.1",
+    "@deno/loader": "jsr:@deno/loader@^0.2.1",
     "@std/cli": "jsr:@std/cli@^1.0.19",
     "@std/collections": "jsr:@std/collections@^1.0.11",
     "@std/http": "jsr:@std/http@^1.0.15",

--- a/deno.json
+++ b/deno.json
@@ -46,7 +46,6 @@
   "imports": {
     "@deno/doc": "jsr:@deno/doc@^0.172.0",
     "@deno/esbuild-plugin": "jsr:@deno/esbuild-plugin@^1.1.1",
-    "@deno/loader": "jsr:@deno/loader@^0.2.1",
     "@std/cli": "jsr:@std/cli@^1.0.19",
     "@std/collections": "jsr:@std/collections@^1.0.11",
     "@std/http": "jsr:@std/http@^1.0.15",

--- a/deno.lock
+++ b/deno.lock
@@ -2202,6 +2202,7 @@
       "jsr:@astral/astral@~0.5.3",
       "jsr:@deno/doc@0.172",
       "jsr:@deno/esbuild-plugin@^1.1.1",
+      "jsr:@deno/loader@~0.2.1",
       "jsr:@fresh/core@^2.0.0-alpha.37",
       "jsr:@marvinh-test/fresh-island@^0.0.1",
       "jsr:@std/async@^1.0.13",

--- a/deno.lock
+++ b/deno.lock
@@ -2202,7 +2202,6 @@
       "jsr:@astral/astral@~0.5.3",
       "jsr:@deno/doc@0.172",
       "jsr:@deno/esbuild-plugin@^1.1.1",
-      "jsr:@deno/loader@~0.2.1",
       "jsr:@fresh/core@^2.0.0-alpha.37",
       "jsr:@marvinh-test/fresh-island@^0.0.1",
       "jsr:@std/async@^1.0.13",

--- a/init/src/init_test.ts
+++ b/init/src/init_test.ts
@@ -165,27 +165,33 @@ Deno.test(
   },
 );
 
-Deno.test("init - can start dev server", async () => {
-  await using tmp = await withTmpDir();
-  const dir = tmp.dir;
-  using _promptStub = stubPrompt(".");
-  using _confirmStub = stubConfirm();
-  await initProject(dir, [], {});
-  await expectProjectFile(dir, "main.ts");
-  await expectProjectFile(dir, "dev.ts");
+Deno.test({
+  // TODO: For some reason this test is flaky in GitHub CI. It works when
+  // testing locally on windows though. Not sure what's going on.
+  ignore: Deno.build.os === "windows" && Deno.env.get("CI") !== undefined,
+  name: "init - can start dev server",
+  fn: async () => {
+    await using tmp = await withTmpDir();
+    const dir = tmp.dir;
+    using _promptStub = stubPrompt(".");
+    using _confirmStub = stubConfirm();
+    await initProject(dir, [], {});
+    await expectProjectFile(dir, "main.ts");
+    await expectProjectFile(dir, "dev.ts");
 
-  await patchProject(dir);
-  await withChildProcessServer(
-    dir,
-    ["task", "dev"],
-    async (address) => {
-      await withBrowser(async (page) => {
-        await page.goto(address);
-        await page.locator("#decrement").click();
-        await waitForText(page, "button + p", "2");
-      });
-    },
-  );
+    await patchProject(dir);
+    await withChildProcessServer(
+      dir,
+      ["task", "dev"],
+      async (address) => {
+        await withBrowser(async (page) => {
+          await page.goto(address);
+          await page.locator("#decrement").click();
+          await waitForText(page, "button + p", "2");
+        });
+      },
+    );
+  },
 });
 
 Deno.test("init - can start built project", async () => {

--- a/src/app_test.tsx
+++ b/src/app_test.tsx
@@ -616,3 +616,64 @@ Deno.test("App - .route() with basePath", async () => {
   expect(await res.text()).toEqual("ok");
   expect(res.status).toEqual(200);
 });
+
+Deno.test("App - .use() - lazy", async () => {
+  const app = new App<{ text: string }>()
+    // deno-lint-ignore require-await
+    .use(async () => {
+      return (ctx) => {
+        ctx.state.text = "ok";
+        return ctx.next();
+      };
+    })
+    .get("/", (ctx) => new Response(ctx.state.text));
+
+  const server = new FakeServer(app.handler());
+
+  const res = await server.get("/");
+  expect(await res.text()).toEqual("ok");
+});
+
+Deno.test("App - .route() - lazy", async () => {
+  const app = new App()
+    // deno-lint-ignore require-await
+    .route("/", async () => {
+      return { handler: () => new Response("ok") };
+    });
+
+  const server = new FakeServer(app.handler());
+
+  const res = await server.get("/");
+  expect(await res.text()).toEqual("ok");
+});
+
+Deno.test("App - .get/post/patch/put/delete/head/all() - lazy", async () => {
+  const app = new App()
+    .get("/", () => Promise.resolve(() => new Response("ok")))
+    .post("/", () => Promise.resolve(() => new Response("ok")))
+    .patch("/", () => Promise.resolve(() => new Response("ok")))
+    .delete("/", () => Promise.resolve(() => new Response("ok")))
+    .put("/", () => Promise.resolve(() => new Response("ok")))
+    .head("/", () => Promise.resolve(() => new Response("ok")))
+    .all("/", () => Promise.resolve(() => new Response("ok")));
+
+  const server = new FakeServer(app.handler());
+
+  let res = await server.get("/");
+  expect(await res.text()).toEqual("ok");
+
+  res = await server.post("/");
+  expect(await res.text()).toEqual("ok");
+
+  res = await server.put("/");
+  expect(await res.text()).toEqual("ok");
+
+  res = await server.patch("/");
+  expect(await res.text()).toEqual("ok");
+
+  res = await server.delete("/");
+  expect(await res.text()).toEqual("ok");
+
+  res = await server.head("/");
+  expect(await res.text()).toEqual("ok");
+});

--- a/src/context.ts
+++ b/src/context.ts
@@ -110,7 +110,6 @@ export class Context<State> {
 
   #buildCache: BuildCache<State>;
 
-  // FIXME: remove after switching to <Slot />
   Component!: FunctionComponent;
 
   static {

--- a/src/define.ts
+++ b/src/define.ts
@@ -133,7 +133,9 @@ export interface Define<State> {
    *
    * @typeParam M The type of the middleware function. This will be inferred from the input function. Do not manually specify this type.
    */
-  middleware<M extends Middleware<State>>(middleware: M): typeof middleware;
+  middleware<M extends Middleware<State> | Middleware<State>[]>(
+    middleware: M,
+  ): typeof middleware;
 }
 
 /**

--- a/src/dev/file_transformer_test.ts
+++ b/src/dev/file_transformer_test.ts
@@ -17,6 +17,12 @@ function testTransformer(files: Record<string, string>, root = "/") {
       const buf = new TextEncoder().encode(content);
       return Promise.resolve(buf);
     },
+    readTextFile: (file) => {
+      if (file instanceof URL) throw new Error("Not supported");
+      // deno-lint-ignore no-explicit-any
+      const content = (files as any)[file];
+      return Promise.resolve(content);
+    },
   };
   return new FileTransformer(mockFs, root);
 }

--- a/src/dev/fs_crawl.ts
+++ b/src/dev/fs_crawl.ts
@@ -5,7 +5,6 @@ import * as path from "@std/path";
 import { pathToPattern } from "../router.ts";
 import { CommandType } from "../commands.ts";
 import { sortRoutePaths } from "../fs_routes.ts";
-import { RequestedModuleType, ResolutionMode, Workspace } from "@deno/loader";
 import type { RouteConfig } from "../types.ts";
 
 const GROUP_REG = /[/\\\\]\((_[^/\\\\]+)\)[/\\\\]/;
@@ -17,12 +16,6 @@ export async function crawlRouteDir<State>(
   onIslandSpecifier: (spec: string) => void,
   files: FsRouteFileNoMod<State>[],
 ) {
-  const workspace = await new Workspace({
-    noTranspile: true,
-    preserveJsx: true,
-  });
-  const loader = await workspace.createLoader({ entrypoints: [] });
-
   await walkDir(
     fs,
     routeDir,
@@ -82,23 +75,15 @@ export async function crawlRouteDir<State>(
 
         routePattern = pathToPattern(id.slice(1));
 
-        const resolved = loader.resolve(
-          entry.path,
-          undefined,
-          ResolutionMode.Import,
-        );
-        const loaded = await loader.load(resolved, RequestedModuleType.Text);
-        if (loaded.kind !== "external") {
-          const text = new TextDecoder().decode(loaded.code);
-          lazy = !text.includes("routeOverride");
+        const code = await fs.readTextFile(entry.path);
+        lazy = !code.includes("routeOverride");
 
-          // TODO: We could do an AST parse here to detect the
-          // kind of handler that's used to get a more accurate
-          // list of methods this route supports.
-          overrideConfig = {
-            methods: "ALL",
-          };
-        }
+        // TODO: We could do an AST parse here to detect the
+        // kind of handler that's used to get a more accurate
+        // list of methods this route supports.
+        overrideConfig = {
+          methods: "ALL",
+        };
       }
 
       files.push({

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -9,6 +9,7 @@ export interface FsAdapter {
   isDirectory(path: string | URL): Promise<boolean>;
   mkdirp(dir: string): Promise<void>;
   readFile(path: string | URL): Promise<Uint8Array>;
+  readTextFile(path: string | URL): Promise<string>;
 }
 
 export const fsAdapter: FsAdapter = {
@@ -33,4 +34,5 @@ export const fsAdapter: FsAdapter = {
     }
   },
   readFile: Deno.readFile,
+  readTextFile: Deno.readTextFile,
 };

--- a/src/fs_routes.ts
+++ b/src/fs_routes.ts
@@ -136,17 +136,26 @@ export function fsItemsToCommands<State>(
       }
       case CommandType.Route: {
         let normalized;
+        // Merge configs
+        let config: RouteConfig = {};
         if (isLazy(rawMod)) {
           normalized = async () => {
             const result = await rawMod();
             return normalizeRoute(filePath, result, routePattern);
           };
+
+          config.methods = item.overrideConfig?.methods ?? "ALL";
+          config.routeOverride = item.overrideConfig?.routeOverride ??
+            routePattern;
         } else {
           normalized = normalizeRoute(filePath, rawMod, routePattern);
+          if (rawMod.config) {
+            config = rawMod.config;
+          }
         }
 
         commands.push(
-          newRouteCmd(pattern, normalized, item.overrideConfig, false),
+          newRouteCmd(pattern, normalized, config, false),
         );
         continue;
       }

--- a/src/fs_routes_test.tsx
+++ b/src/fs_routes_test.tsx
@@ -1480,7 +1480,7 @@ Deno.test("fsRoutes - warn on _middleware with object handler", async () => {
 
   expect(warnSpy.fake).toHaveBeenCalledTimes(1);
   expect(warnSpy.fake).toHaveBeenLastCalledWith(
-    "🍋 %c[WARNING] Unsupported route config: Middleware does not support object handlers with GET, POST, etc.",
+    "🍋 %c[WARNING] Unsupported route config: Middleware does not support object handlers with GET, POST, etc. in routes/_middleware.ts",
     expect.any(String),
   );
 });

--- a/src/middlewares/mod.ts
+++ b/src/middlewares/mod.ts
@@ -71,19 +71,21 @@ import type { Define as _Define } from "../define.ts";
  * app.use(redirectMiddleware);
  * ```
  */
-export type MiddlewareFn<State> = (
+export type Middleware<State> = (
   ctx: Context<State>,
 ) => Response | Promise<Response>;
 
+/**
+ * @deprecated Use {@linkcode Middleware} instead.
+ */
+export type MiddlewareFn<State> = Middleware<State>;
+
+/**
+ * A lazy {@linkcode Middleware}
+ */
 export type MaybeLazyMiddleware<State> = (
   ctx: Context<State>,
 ) => Response | Promise<Response | MiddlewareFn<State>>;
-
-/**
- * A single middleware function or a lazy middleware function, or an array of middleware functions. For
- * further information, see {@link MiddlewareFn}.
- */
-export type Middleware<State> = MiddlewareFn<State> | MiddlewareFn<State>[];
 
 export function runMiddlewares<State>(
   middlewares: MaybeLazyMiddleware<State>[],

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -8,7 +8,7 @@ export {
   type RouteData,
   type RouteHandler,
 } from "./handlers.ts";
-export type { LayoutConfig, RouteConfig } from "./types.ts";
+export type { LayoutConfig, Lazy, MaybeLazy, RouteConfig } from "./types.ts";
 export type { Middleware, MiddlewareFn } from "./middlewares/mod.ts";
 export { staticFiles } from "./middlewares/static_files.ts";
 export { cors, type CORSOptions } from "./middlewares/cors.ts";

--- a/src/segments.ts
+++ b/src/segments.ts
@@ -1,5 +1,5 @@
 import type { AnyComponent } from "preact";
-import type { MiddlewareFn } from "./middlewares/mod.ts";
+import type { MaybeLazyMiddleware, MiddlewareFn } from "./middlewares/mod.ts";
 import { type Method, patternToSegments } from "./router.ts";
 import type { LayoutConfig, Route } from "./types.ts";
 import { type Context, getInternals } from "./context.ts";
@@ -18,7 +18,7 @@ export type RouteComponent<State> =
 
 export interface Segment<State> {
   pattern: string;
-  middlewares: MiddlewareFn<State>[];
+  middlewares: MaybeLazyMiddleware<State>[];
   layout: {
     component: RouteComponent<State>;
     config: LayoutConfig | null;
@@ -74,8 +74,8 @@ export function getOrCreateSegment<State>(
 
 export function segmentToMiddlewares<State>(
   segment: Segment<State>,
-): MiddlewareFn<State>[] {
-  const result: MiddlewareFn<State>[] = [];
+): MaybeLazyMiddleware<State>[] {
+  const result: MaybeLazyMiddleware<State>[] = [];
 
   const stack: Segment<State>[] = [];
   let current: Segment<State> | null = segment;

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -121,6 +121,10 @@ export function createFakeFs(files: Record<string, unknown>): FsAdapter {
     async mkdirp(_dir: string) {
     },
     readFile: Deno.readFile,
+    // deno-lint-ignore require-await
+    async readTextFile(path) {
+      return String(files[String(path)]);
+    },
   };
 }
 

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -103,13 +103,12 @@ export function createFakeFs(files: Record<string, unknown>): FsAdapter {
   return {
     cwd: () => ".",
     async *walk(_root) {
-      // FIXME: ignore
       for (const file of Object.keys(files)) {
         const entry: WalkEntry = {
           isDirectory: false,
           isFile: true,
           isSymlink: false,
-          name: file, // FIXME?
+          name: file,
           path: file,
         };
         yield entry;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { RouteHandler } from "./handlers.ts";
+import type { Method } from "./router.ts";
 import type { RouteComponent } from "./segments.ts";
 
 export interface RouteConfig {
@@ -29,6 +30,12 @@ export interface RouteConfig {
    * Default: `false`
    */
   skipAppWrapper?: boolean;
+  /**
+   * Which method to use when loading this route lazily. This is only used
+   * for lazy routes.
+   * Default: `ALL`
+   */
+  methods?: "ALL" | Method[];
 }
 
 export interface LayoutConfig {
@@ -50,6 +57,17 @@ export interface Route<State> {
   config?: RouteConfig;
   handler?: RouteHandler<unknown, State>;
 }
+
+/**
+ * Lazily construct items like middlewares, handlers, etc by wrapping them
+ * in a function.
+ */
+export type Lazy<T> = () => Promise<T>;
+
+/**
+ * Return T or lazy version of T
+ */
+export type MaybeLazy<T> = T | Lazy<T>;
 
 // TODO: Uncomment once JSR supports global types
 // declare global {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import * as path from "@std/path";
+import type { Lazy, MaybeLazy } from "./types.ts";
 
 export function assertInDir(
   filePath: string,
@@ -67,4 +68,8 @@ export class UniqueNamer {
 const PATH_TO_SPEC = /[\\/]+/g;
 export function pathToSpec(str: string): string {
   return str.replaceAll(PATH_TO_SPEC, "/");
+}
+
+export function isLazy<T>(value: MaybeLazy<T>): value is Lazy<T> {
+  return typeof value === "function";
 }

--- a/tests/partials_test.tsx
+++ b/tests/partials_test.tsx
@@ -76,7 +76,6 @@ Deno.test({
   fn: async () => {
     const app = testApp()
       .get("/partial", (ctx) => {
-        // FIXME: Add outer document
         return ctx.render(
           <Doc>
             <Partial name="foo">

--- a/www/components/CodeBlock.tsx
+++ b/www/components/CodeBlock.tsx
@@ -1,4 +1,4 @@
-import Prism from "prismjs";
+import { Prism } from "../utils/prism.ts";
 
 export function CodeBlock(
   { code, lang }: { code: string; lang: "js" | "ts" | "jsx" | "md" | "bash" },

--- a/www/utils/markdown.ts
+++ b/www/utils/markdown.ts
@@ -1,11 +1,3 @@
-import Prism from "prismjs";
-import "prismjs/components/prism-jsx.js";
-import "prismjs/components/prism-typescript.js";
-import "prismjs/components/prism-tsx.js";
-import "prismjs/components/prism-diff.js";
-import "prismjs/components/prism-json.js";
-import "prismjs/components/prism-bash.js";
-import "prismjs/components/prism-yaml.js";
 import denoJson from "../../deno.json" with { type: "json" };
 
 export { extractYaml as frontMatter } from "@std/front-matter";
@@ -14,6 +6,7 @@ import * as Marked from "marked";
 import { escape as escapeHtml } from "@std/html";
 import { mangle } from "marked-mangle";
 import GitHubSlugger from "github-slugger";
+import { Prism } from "./prism.ts";
 
 const slugger = new GitHubSlugger();
 

--- a/www/utils/prism.ts
+++ b/www/utils/prism.ts
@@ -1,0 +1,10 @@
+import Prism from "prismjs";
+import "prismjs/components/prism-jsx.js";
+import "prismjs/components/prism-typescript.js";
+import "prismjs/components/prism-tsx.js";
+import "prismjs/components/prism-diff.js";
+import "prismjs/components/prism-json.js";
+import "prismjs/components/prism-bash.js";
+import "prismjs/components/prism-yaml.js";
+
+export { Prism };


### PR DESCRIPTION
We can improve cold start times by only loading route modules when the particular pattern matches.

This PR introduces the concept of lazy middlewares, routes and handlers to do that.

Needs way more polishing, but the gist of it works.