### PR TITLE
fix: nested index route not working in prod builds

### DIFF
--- a/init/src/init.ts
+++ b/init/src/init.ts
@@ -379,6 +379,7 @@ app.fsRoutes();`;
     `import type { ComponentChildren } from "preact";
 
 export interface ButtonProps {
+  id?: string;
   onClick?: () => void;
   children?: ComponentChildren;
   disabled?: boolean;
@@ -472,9 +473,9 @@ interface CounterProps {
 export default function Counter(props: CounterProps) {
   return (
     <div class="flex gap-8 py-6">
-      <Button onClick={() => props.count.value -= 1}>-1</Button>
+      <Button id="decrement" onClick={() => props.count.value -= 1}>-1</Button>
       <p class="text-3xl tabular-nums">{props.count}</p>
-      <Button onClick={() => props.count.value += 1}>+1</Button>
+      <Button id="increment" onClick={() => props.count.value += 1}>+1</Button>
     </div>
   );
 }`;

--- a/init/src/init_test.ts
+++ b/init/src/init_test.ts
@@ -181,7 +181,7 @@ Deno.test("init - can start dev server", async () => {
     async (address) => {
       await withBrowser(async (page) => {
         await page.goto(address);
-        await page.locator("button").click();
+        await page.locator("#decrement").click();
         await waitForText(page, "button + p", "2");
       });
     },

--- a/init/src/init_test.ts
+++ b/init/src/init_test.ts
@@ -177,7 +177,7 @@ Deno.test("init - can start dev server", async () => {
   await patchProject(dir);
   await withChildProcessServer(
     dir,
-    "dev",
+    ["task", "dev"],
     async (address) => {
       await withBrowser(async (page) => {
         await page.goto(address);
@@ -210,7 +210,7 @@ Deno.test("init - can start built project", async () => {
 
   await withChildProcessServer(
     dir,
-    "start",
+    ["task", "start"],
     async (address) => {
       await withBrowser(async (page) => {
         await page.goto(address);

--- a/src/dev/dev_build_cache.ts
+++ b/src/dev/dev_build_cache.ts
@@ -405,10 +405,10 @@ ${
           .map((item, i) => {
             const id = JSON.stringify(item.id);
             const pattern = JSON.stringify(item.pattern);
+            const type = JSON.stringify(item.type);
+            const routePattern = JSON.stringify(item.routePattern);
 
-            return `  { id: ${id}, mod: fsRoute_${i}, type: ${
-              JSON.stringify(item.type)
-            }, pattern: ${pattern} },`;
+            return `  { id: ${id}, mod: fsRoute_${i}, type: ${type}, pattern: ${pattern}, routePattern: ${routePattern} },`;
           })
           .join("\n")
       }

--- a/tests/test_utils.tsx
+++ b/tests/test_utils.tsx
@@ -97,12 +97,12 @@ export async function withBrowser(fn: (page: Page) => void | Promise<void>) {
 
 export async function withChildProcessServer(
   dir: string,
-  task: string,
+  args: string[],
   fn: (address: string) => void | Promise<void>,
 ) {
   const aborter = new AbortController();
   const cp = await new Deno.Command(Deno.execPath(), {
-    args: ["task", task],
+    args,
     stdin: "null",
     stdout: "piped",
     stderr: "piped",
@@ -137,6 +137,8 @@ export async function withChildProcessServer(
   }
 
   if (!found) {
+    // deno-lint-ignore no-console
+    console.log(output);
     throw new Error(`Could not find server address`);
   }
 

--- a/update/src/update_test.ts
+++ b/update/src/update_test.ts
@@ -8,23 +8,7 @@ import {
 import { expect } from "@std/expect";
 import { spy, type SpyCall } from "@std/testing/mock";
 import { walk } from "@std/fs/walk";
-import { withTmpDir } from "../../src/test_utils.ts";
-
-async function writeFiles(dir: string, files: Record<string, string>) {
-  const entries = Object.entries(files);
-  await Promise.all(entries.map(async (entry) => {
-    const [pathname, content] = entry;
-    const fullPath = path.join(dir, pathname);
-    try {
-      await Deno.mkdir(path.dirname(fullPath), { recursive: true });
-      await Deno.writeTextFile(fullPath, content);
-    } catch (err) {
-      if (!(err instanceof Deno.errors.AlreadyExists)) {
-        throw err;
-      }
-    }
-  }));
-}
+import { withTmpDir, writeFiles } from "../../src/test_utils.ts";
 
 async function readFiles(dir: string): Promise<Record<string, string>> {
   const files: Record<string, string> = {};


### PR DESCRIPTION
This was due to a mismatch in the disk snapshot compared to in memory.