### PR TITLE
feat: optimize static asset content type handling

### DIFF
--- a/src/build_cache.ts
+++ b/src/build_cache.ts
@@ -10,6 +10,7 @@ export interface FileSnapshot {
   name: string;
   filePath: string;
   hash: string | null;
+  contentType: string;
 }
 
 export interface BuildSnapshot<State> {
@@ -22,6 +23,7 @@ export interface BuildSnapshot<State> {
 export interface StaticFile {
   hash: string | null;
   size: number;
+  contentType: string;
   readable: ReadableStream<Uint8Array> | Uint8Array;
   close(): void;
 }
@@ -63,6 +65,7 @@ export class ProdBuildCache<State> implements BuildCache<State> {
 
     return {
       hash: info.hash,
+      contentType: info.contentType,
       size: stat.size,
       readable: file.readable,
       close: () => file.close(),

--- a/src/middlewares/static_files.ts
+++ b/src/middlewares/static_files.ts
@@ -1,5 +1,3 @@
-import * as path from "@std/path";
-import { contentType as getContentType } from "@std/media-types/content-type";
 import type { Middleware } from "./mod.ts";
 import { ASSET_CACHE_BUST_KEY } from "../runtime/shared_internal.tsx";
 import { BUILD_ID } from "../runtime/build_id.ts";
@@ -64,12 +62,9 @@ export function staticFiles<T>(): Middleware<T> {
         });
       }
 
-      const ext = path.extname(pathname);
       const etag = file.hash;
-
-      const contentType = getContentType(ext);
       const headers = new Headers({
-        "Content-Type": contentType ?? "text/plain",
+        "Content-Type": file.contentType,
         vary: "If-None-Match",
       });
 

--- a/src/middlewares/static_files_test.ts
+++ b/src/middlewares/static_files_test.ts
@@ -6,6 +6,7 @@ import { ASSET_CACHE_BUST_KEY } from "../runtime/shared_internal.tsx";
 import { BUILD_ID } from "../runtime/build_id.ts";
 import type { Command } from "../commands.ts";
 import type { ServerIslandRegistry } from "../context.ts";
+import { getContentType } from "../dev/dev_build_cache.ts";
 
 class MockBuildCache implements BuildCache {
   root = "";
@@ -23,6 +24,7 @@ class MockBuildCache implements BuildCache {
         hash: info.hash,
         size: text.byteLength,
         readable: text,
+        contentType: getContentType(normalized),
         close: () => {},
       });
     }


### PR DESCRIPTION
No need to detect them at runtime when we can do this during build. This saves us from having to load `@std/media-types` during production which is quite a heavy library due to the amount of file types out there.