### PR TITLE
fix: missing fs routes due to floating promise

### DIFF
--- a/src/dev/fs_crawl.ts
+++ b/src/dev/fs_crawl.ts
@@ -105,7 +105,7 @@ export async function crawlRouteDir<State>(
 export async function walkDir(
   fs: FsAdapter,
   dir: string,
-  callback: (entry: WalkEntry) => void,
+  callback: (entry: WalkEntry) => void | Promise<void>,
   ignore: RegExp[],
 ) {
   if (!await fs.isDirectory(dir)) return;
@@ -118,6 +118,6 @@ export async function walkDir(
   });
 
   for await (const entry of entries) {
-    callback(entry);
+    await callback(entry);
   }
 }

--- a/src/dev/fs_crawl_test.ts
+++ b/src/dev/fs_crawl_test.ts
@@ -1,0 +1,20 @@
+import { expect } from "@std/expect/expect";
+import { createFakeFs } from "../test_utils.ts";
+import { walkDir } from "./fs_crawl.ts";
+
+Deno.test("walkDir - ", async () => {
+  const fs = createFakeFs({
+    "foo/bar/baz.txt": "foo",
+    "foo/bar.txt": "foo",
+  });
+
+  const files: string[] = [];
+
+  await walkDir(fs, "foo", async (entry) => {
+    // Purposely delay
+    await new Promise((r) => setTimeout(r, 100));
+    files.push(entry.path);
+  }, []);
+
+  expect(files).toEqual(["foo/bar/baz.txt", "foo/bar.txt"]);
+});


### PR DESCRIPTION
This fixes a bug where file system routes where missing due to a floating promise.

We really need type aware lint rules in Deno :eyes: