### PR TITLE
fix: correct anchors by using heading text only

### DIFF
--- a/docs/canary/concepts/middleware.md
+++ b/docs/canary/concepts/middleware.md
@@ -52,6 +52,7 @@ const middleware = define.middleware(async (ctx) => {
 Fresh ships with the following middlewares built-in:
 
 - [cors()](/docs/canary/plugins/cors) - Set CORS HTTP headers
+- [csrf()](/docs/canary/plugins/cors) - Set CSRF HTTP headers
 - [trailingSlash()](/docs/canary/plugins/trailing-slashes) - Enforce trailing
   slashes
 

--- a/docs/latest/concepts/deployment.md
+++ b/docs/latest/concepts/deployment.md
@@ -8,8 +8,8 @@ deployed to any system or platform that can run a Deno based web server.
 
 Here are instructions for specific providers / systems:
 
-- [Deno Deploy](#-deno-deploy)
-- [Docker](#-docker)
+- [Deno Deploy](#deno-deploy)
+- [Docker](#docker)
 
 ## Deno Deploy
 

--- a/docs/toc.ts
+++ b/docs/toc.ts
@@ -85,8 +85,8 @@ const toc: RawTableOfContents = {
           ["daisyui", "daisyUI", "link:canary"],
           ["modifying-the-head", "Modifying the <head>", "link:latest"],
           ["creating-a-crud-api", "Creating a CRUD API", "link:latest"],
+          ["markdown", "Rendering Markdown", "link:canary"],
           ["rendering-raw-html", "Rendering raw HTML", "link:canary"],
-          ["markdown", "Markdown", "link:canary"],
           [
             "sharing-state-between-islands",
             "Sharing state between islands",

--- a/www/routes/_error.tsx
+++ b/www/routes/_error.tsx
@@ -28,7 +28,7 @@ export function ServerCodePage(
   );
 }
 
-export default function PageNotFound(props: PageProps) {
+export default function ErrorPage(props: PageProps) {
   const error = props.error;
   if (error instanceof HttpError) {
     if (error.status === 404) {


### PR DESCRIPTION
Addresses the issue mentioned in https://github.com/denoland/fresh/pull/3163#discussion_r2246708003.

The issue was that the `raw` markdown was being used for e.g. `## My title`, thus the slug became `-my-title` instead of `my-title`. Slugs were working correctly for `codespan` in headers, e.g. ``## `someCode` ``.

I decided to hard error if unexpected heading syntax is used over sluggifying unexpected content (can become super weird otherwise, e.g. `## <button ...>My heading</button>`). I can revert to fallbacking to `raw` if preferred, but perhaps with at least trimming leading `-` just in case.