### PR TITLE
test: check that _app and _layout are ignored by dev err frame

### DIFF
--- a/src/dev/builder_test.ts
+++ b/src/dev/builder_test.ts
@@ -382,8 +382,6 @@ Deno.test({
         controller.abort();
       },
     });
-
-    // expect(text).toContain("<h1>ok</h1>");
   },
   sanitizeOps: false,
   sanitizeResources: false,
@@ -421,8 +419,6 @@ Deno.test({
         controller.abort();
       },
     });
-
-    // expect(text).toContain("<h1>ok</h1>");
   },
   sanitizeOps: false,
   sanitizeResources: false,


### PR DESCRIPTION
Encountered this issue in #3167, but already fixed in #3165. I noticed `/_frsh/error_overlay` was using `_app`/`_layout`, which seemed unnecessary.

Since this was already fixed in #3165, I just added a test to check that this is not a regression in the future.