### PR TITLE
feat: allow ctx.render to skip wrappers

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -10,6 +10,7 @@ import {
 import { SpanStatusCode } from "@opentelemetry/api";
 import type { ResolvedFreshConfig } from "./config.ts";
 import type { BuildCache } from "./build_cache.ts";
+import type { LayoutConfig } from "./types.ts";
 import { RenderState, setRenderState } from "./runtime/server/preact_hooks.tsx";
 import { PARTIAL_SEARCH_PARAM } from "./constants.ts";
 import { tracer } from "./otel.ts";
@@ -187,6 +188,7 @@ export class Context<State> {
     // deno-lint-ignore no-explicit-any
     vnode: VNode<any> | null,
     init: ResponseInit | undefined = {},
+    config: LayoutConfig = {},
   ): Promise<Response> {
     if (arguments.length === 0) {
       throw new Error(`No arguments passed to: ctx.render()`);
@@ -194,8 +196,8 @@ export class Context<State> {
       throw new Error(`Non-JSX element passed to: ctx.render()`);
     }
 
-    const defs = this.#internal.layouts;
-    const appDef = this.#internal.app;
+    const defs = config.skipInheritedLayouts ? [] : this.#internal.layouts;
+    const appDef = config.skipAppWrapper ? null : this.#internal.app;
     const props = this as Context<State>;
 
     // Compose final vnode tree


### PR DESCRIPTION
Allow `ctx.render()` to bypass app wrapper and layouts.

- I originally intended this as a solution for middleware (`app.use()`) to have the same capability as routes (`app.route()`) to solve the `devErrorOverlay()` including wrappers.
- The docs mention it's possible to "opt-out" during `ctx.render()`
  > Every [ctx.render()](https://fresh.deno.dev/docs/canary/concepts/context#render-1) call will include the app wrapper component by default, unless opted out.
  > \- https://fresh.deno.dev/docs/canary/advanced/app-wrapper

I don't need this myself currently, but it seemed a bit weird that middleware was not able to bypass app wrapper or layouts, because it's not possible to pass a `RouteConfig`. If this API is not something you want to support, I could remove the code changes in favor of just updating docs (above) and adding the tests.

### Open questions

Should it not be possible for "index" to use a layout? E.g. calls to `/foo` should include the layout:

```ts
const app = new App()
  .layout("/foo", ({ Component }) => (<>foo/<Component /></>))
  .get("/foo", (ctx) => ctx.render(<>index</>));

// Should this not be "foo/index"? Currently renders "index"
```

Currently, I ignored the test for this, since it was not what I expected. I tried to simulate the following folder layout, but with imperative code:

```
<root>/routes
└── /foo
    ├── _layout.tsx
    └── index.tsx
```