### PR TITLE
chore: update CI to test build www on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,7 @@ jobs:
 
       - name: Check docs
         run: deno task check:docs
+
+      - name: Build fresh.deno.dev
+        if: startsWith(matrix.os, 'ubuntu') && matrix.deno == 'v2.x'
+        run: deno task build-www


### PR DESCRIPTION
This updates our CI workflow to build fresh.deno.dev as a quick e2e way of checking you can build something.

We ran into a particular bug in the underlying `@deno/loader` library that we use in our esbuild plugin that would have been caught by this.