### PR TITLE
ci: reduce workflow failures on forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Upload to Deno Deploy
         uses: denoland/deployctl@v1
+        # Skip publishing for forks
+        if: github.repository_owner == 'denoland'
         with:
           project: "fresh"
           entrypoint: "./www/_fresh/server.js"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ jobs:
       contents: read
       id-token: write
 
+    # Skip publishing for forks
+    if: github.repository_owner == 'denoland'
+
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Publishing packages workflow and deploying to Deno Deploy step runs even for forks. This is annoying, since it creates some spam every push for any open PR's.

This PR tries to address this, by skipping certain steps or workflows unless the current GitHub org is `denoland`, which should be pretty safe long term.

## Failed workflow spam

<img width="1396" height="635" alt="image" src="https://github.com/user-attachments/assets/d939d1f5-e736-42a4-9355-f946b3d6ddf2" />

<img width="1577" height="905" alt="image" src="https://github.com/user-attachments/assets/fbf7ffe3-2759-430a-a33e-c8de0d7e113c" />
