### PR TITLE
style: fix horizontal scrollbar for some screen sizes

### DIFF
--- a/www/components/NavigationBar.tsx
+++ b/www/components/NavigationBar.tsx
@@ -22,7 +22,7 @@ export default function NavigationBar(
   const isDocs = props.active == "/docs";
   return (
     <nav class={"flex " + (props.class ?? "")} f-client-nav={false}>
-      <ul class="flex items-center gap-x-2 sm:gap-4 mx-4 my-2 sm:my-6 flex-wrap lg:mx-8 2xl:mr-0">
+      <ul class="flex items-center gap-x-2 sm:gap-4 mx-4 my-2 sm:my-6 flex-wrap lg:mx-8 2xl:mr-1">
         {items.map((item) => (
           <li key={item.name}>
             <a

--- a/www/islands/ThemeToggle.tsx
+++ b/www/islands/ThemeToggle.tsx
@@ -16,7 +16,7 @@ export default function ThemeToggle() {
     <button
       type="button"
       onClick={toggleTheme}
-      class="dark-mode-toggle button p-1 -m-1"
+      class="cursor-pointer p-1 -m-1"
       aria-label="Toggle Theme"
     >
       {theme.value === "light"

--- a/www/static/styles.css
+++ b/www/static/styles.css
@@ -79,10 +79,6 @@ hr {
   border-color: hsl(from var(--color-foreground-secondary) h s l / 0.1);
 }
 
-.dark-mode-toggle-button img {
-  fill: var(--color-foreground-primary);
-}
-
 ::selection {
   background-color: #b1d5ff;
 }


### PR DESCRIPTION
On the Fresh docs, I get a vertical scrollbar for a small range of viewport size of the browser. This is annoying me, since I get it when I place two windows next to each other on a 21:9 screen.

The issue seems to stem from a button using `p-1 -m-1`. But the negative margin is there to address the increased space due to making the button easier to click (most likely for touch/mobile). But this makes the button overflow when there is no right-margin (`2xl:mr-0`).

<img width="1637" height="661" alt="image" src="https://github.com/user-attachments/assets/48773cf5-316d-41f3-99e0-54f49b1f2cc9" />

## Solution

The simplest and easiest fix here is just to increase the margin to cover for this case. `2xl:mr-1` seems to do the trick. But it might be a good idea to have a little more gap towards the edge of the screen, e.g. `2xl-mr-2`.