### PR TITLE
feat: support passing URL to islands

### DIFF
--- a/docs/canary/concepts/islands.md
+++ b/docs/canary/concepts/islands.md
@@ -40,12 +40,15 @@ const app = new App()
 Passing props to islands is supported, but only if the props are serializable.
 Fresh can serialize the following types of values:
 
-- Primitive types `string`, `number`, `boolean`, `bigint`, and `null`
-- `Infinity`, `-Infinity`, and `NaN`
+- Primitive types `string`, `number`, `boolean`, `bigint`, `undefined`, and
+  `null`
+- `Infinity`, `-Infinity`, `-0`, and `NaN`
 - `Uint8Array`
+- `URL`
 - `Date`
 - `RegExp`
 - `JSX` Elements
+- Collections `Map` and `Set`
 - Plain objects with string keys and serializable values
 - Arrays containing serializable values
 - Preact Signals (if the inner value is serializable)

--- a/src/jsonify/__snapshots__/round_trip_test.ts.snap
+++ b/src/jsonify/__snapshots__/round_trip_test.ts.snap
@@ -40,6 +40,8 @@ snapshot[`round trip - { a: 1, b: null, c: -2 } 1`] = `'[{"a":1,"b":-2,"c":2},1,
 
 snapshot[`round trip - Uint8Array(3) [ 1, 2, 3 ] 1`] = `'[["Uint8Array","AQID"]]'`;
 
+snapshot[`round trip - URL {\\n  href: 'https://fresh.deno.dev/',\\n  origin: 'https://fresh.deno.dev',\\n  protocol: 'https:',\\n  username: '',\\n  password: '',\\n  host: 'fresh.deno.dev',\\n  hostname: 'fresh.deno.dev',\\n  port: '',\\n  pathname: '/',\\n  hash: '',\\n  search: ''\\n} 1`] = `'[["URL","https://fresh.deno.dev/"]]'`;
+
 snapshot[`round trip - 1990-05-31T00:00:00.000Z 1`] = `'[["Date","1990-05-31T00:00:00.000Z"]]'`;
 
 snapshot[`round trip - Map(2) { 1 => null, undefined => -2 } 1`] = `'[["Map",[1,-2,-1,2]],1,-2]'`;

--- a/src/jsonify/parse.ts
+++ b/src/jsonify/parse.ts
@@ -65,6 +65,8 @@ function unpack(
       switch (name) {
         case "BigInt":
           return hydrated[idx] = BigInt(current[1]);
+        case "URL":
+          return hydrated[idx] = new URL(current[1]);
         case "Date":
           return hydrated[idx] = new Date(current[1]);
         case "RegExp":

--- a/src/jsonify/round_trip_test.ts
+++ b/src/jsonify/round_trip_test.ts
@@ -32,6 +32,7 @@ const TESTS = [
   [null, undefined, -2],
   { a: 1, b: null, c: -2 },
   new Uint8Array([1, 2, 3]),
+  new URL("https://fresh.deno.dev"),
   new Date("1990-05-31"),
   new Map([[1, null], [undefined, -2]]),
   new Set([1, 2, null, -2, NaN]),

--- a/src/jsonify/stringify.ts
+++ b/src/jsonify/stringify.ts
@@ -26,6 +26,7 @@ export type Stringifiers = Record<
  * - `array`
  * - `object` (no prototypes)
  * - `Uint8Array`
+ * - `URL`
  * - `Date`
  * - `RegExp`
  * - `Set`
@@ -104,7 +105,9 @@ function serializeInner(
       }
     }
 
-    if (value instanceof Date) {
+    if (value instanceof URL) {
+      str += `["URL","${value.href}"]`;
+    } else if (value instanceof Date) {
       str += `["Date","${value.toISOString()}"]`;
     } else if (value instanceof RegExp) {
       str += `["RegExp",${JSON.stringify(value.source)}, "${value.flags}"]`;


### PR DESCRIPTION
Adds support for passing `URL` values to Islands.

```tsx
// routes/index.html
export default function Page() {
  return <MyIsland url={new URL("https://fresh.deno.dev")} />;
}
```

Also updates documentation with some missing serialization features (`undefined`, `Map`, `Set`, and `-0`).