### PR TITLE
chore: release `@fresh/plugin-vite@0.9.0`

### DIFF
--- a/packages/plugin-vite/deno.json
+++ b/packages/plugin-vite/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh/plugin-vite",
-  "version": "0.0.3",
+  "version": "0.9.0",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts"


### PR DESCRIPTION
Doing a bigger version jump because I think it's close to being ready.