### PR TITLE
feat(plugin-vite): read build id from env if present

### DIFF
--- a/packages/build-id/mod.ts
+++ b/packages/build-id/mod.ts
@@ -6,6 +6,7 @@ export const DENO_DEPLOYMENT_ID: string | undefined = Deno.env.get(
 const deploymentId = DENO_DEPLOYMENT_ID ||
   // For CI
   Deno.env.get("GITHUB_SHA") ||
+  Deno.env.get("CI_COMMIT_SHA") ||
   crypto.randomUUID();
 const buildIdHash = await crypto.subtle.digest(
   "SHA-1",

--- a/packages/plugin-vite/demo/routes/tests/build_id.tsx
+++ b/packages/plugin-vite/demo/routes/tests/build_id.tsx
@@ -1,0 +1,10 @@
+import { BUILD_ID } from "@fresh/build-id";
+
+export default function BuildIdPage() {
+  return (
+    <div>
+      <div class="ready">Ready</div>
+      <div id="build-id">{BUILD_ID}</div>
+    </div>
+  );
+}

--- a/packages/plugin-vite/demo/routes/tests/build_id.tsx
+++ b/packages/plugin-vite/demo/routes/tests/build_id.tsx
@@ -1,10 +1,3 @@
 import { BUILD_ID } from "@fresh/build-id";
 
-export default function BuildIdPage() {
-  return (
-    <div>
-      <div class="ready">Ready</div>
-      <div id="build-id">{BUILD_ID}</div>
-    </div>
-  );
-}
+export const handler = () => new Response(BUILD_ID);

--- a/packages/plugin-vite/src/plugins/build_id.ts
+++ b/packages/plugin-vite/src/plugins/build_id.ts
@@ -39,18 +39,22 @@ export function setBuildId(id) {
 }
 
 export async function getBuildId(dev: boolean): Promise<string> {
-  // Check for GIT_REVISION environment variable first
-  const gitRevision = Deno.env.get("GIT_REVISION");
+  const gitRevision = Deno.env.get("DENO_DEPLOYMENT_ID") ??
+    Deno.env.get("GITHUB_SHA") ?? Deno.env.get("CI_COMMIT_SHA");
   if (gitRevision !== undefined) {
     return gitRevision;
   }
 
   if (!dev) {
-    const bin = Deno.build.os === "windows" ? "git.exe" : "git";
-    const res = await new Deno.Command(bin, { args: ["rev-parse", "HEAD"] })
-      .output();
+    try {
+      const bin = Deno.build.os === "windows" ? "git.exe" : "git";
+      const res = await new Deno.Command(bin, { args: ["rev-parse", "HEAD"] })
+        .output();
 
-    return new TextDecoder().decode(res.stdout);
+      return new TextDecoder().decode(res.stdout);
+    } catch {
+      // ignore
+    }
   }
 
   const arr = new Uint32Array(1);

--- a/packages/plugin-vite/src/plugins/build_id.ts
+++ b/packages/plugin-vite/src/plugins/build_id.ts
@@ -39,6 +39,12 @@ export function setBuildId(id) {
 }
 
 export async function getBuildId(dev: boolean): Promise<string> {
+  // Check for GIT_REVISION environment variable first
+  const gitRevision = Deno.env.get("GIT_REVISION");
+  if (gitRevision !== undefined) {
+    return gitRevision;
+  }
+
   if (!dev) {
     const bin = Deno.build.os === "windows" ? "git.exe" : "git";
     const res = await new Deno.Command(bin, { args: ["rev-parse", "HEAD"] })

--- a/packages/plugin-vite/tests/build_test.ts
+++ b/packages/plugin-vite/tests/build_test.ts
@@ -310,6 +310,8 @@ Deno.test({
         "OTHER",
       ]
     ) {
+      // deno-lint-ignore no-console
+      console.log("Checking...", key);
       using _ = usingEnv(key, revision);
       await using res = await buildVite(DEMO_DIR);
 

--- a/packages/plugin-vite/tests/build_test.ts
+++ b/packages/plugin-vite/tests/build_test.ts
@@ -298,7 +298,6 @@ Deno.test({
 });
 
 Deno.test({
-  only: true,
   name: "vite build - build ID uses env variables when set",
   fn: async () => {
     const revision = "test-commit-hash-123";

--- a/packages/plugin-vite/tests/build_test.ts
+++ b/packages/plugin-vite/tests/build_test.ts
@@ -317,6 +317,9 @@ Deno.test({
         {
           cwd: res.tmp,
           args: ["serve", "-A", "--port", "0", "_fresh/server.js"],
+          env: {
+            [key]: revision,
+          },
         },
         async (address) => {
           const res = await fetch(`${address}/tests/build_id`);

--- a/packages/plugin-vite/tests/build_test.ts
+++ b/packages/plugin-vite/tests/build_test.ts
@@ -310,9 +310,9 @@ Deno.test({
         "OTHER",
       ]
     ) {
-      // deno-lint-ignore no-console
-      console.log("Checking...", key);
       using _ = usingEnv(key, revision);
+      // deno-lint-ignore no-console
+      console.log("Checking...", key, Deno.env.get(key));
       await using res = await buildVite(DEMO_DIR);
 
       await withChildProcessServer(

--- a/packages/plugin-vite/tests/build_test.ts
+++ b/packages/plugin-vite/tests/build_test.ts
@@ -302,6 +302,10 @@ Deno.test({
   fn: async () => {
     const revision = "test-commit-hash-123";
 
+    // We're running on GitHub Actions, so GITHUB_SHA will always
+    // be set
+    Deno.env.delete("GITHUB_SHA");
+
     for (
       const key of [
         "DENO_DEPLOYMENT_ID",

--- a/packages/plugin-vite/tests/build_test.ts
+++ b/packages/plugin-vite/tests/build_test.ts
@@ -317,9 +317,6 @@ Deno.test({
         {
           cwd: res.tmp,
           args: ["serve", "-A", "--port", "0", "_fresh/server.js"],
-          env: {
-            [key]: revision,
-          },
         },
         async (address) => {
           const res = await fetch(`${address}/tests/build_id`);

--- a/packages/plugin-vite/tests/test_utils.ts
+++ b/packages/plugin-vite/tests/test_utils.ts
@@ -78,9 +78,7 @@ export default defineConfig({
   );
 }
 
-export async function buildVite(
-  fixtureDir: string,
-) {
+export async function buildVite(fixtureDir: string) {
   const tmp = await withTmpDir({
     dir: path.join(import.meta.dirname!, ".."),
     prefix: "tmp_vite_",


### PR DESCRIPTION
Fix #3232

Disclaimer: This code was mostly generated by GitHub Copilot agent using Sonnet-4, but tested and verified by me.