### PR TITLE
docs: include missing imports in the getting started tutorial

### DIFF
--- a/docs/canary/getting-started/index.md
+++ b/docs/canary/getting-started/index.md
@@ -76,6 +76,9 @@ in the browser.
 Create a new file at `islands/Countdown.tsx`
 
 ```tsx islands/Countdown.tsx
+import { useSignal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+
 export function Countdown(props: { target: string }) {
   const count = useSignal(10);
 


### PR DESCRIPTION
The Countdown code in the tutorial doesn't work when copied and pasted because the imports for useSignal and useEffect are missing. Adding the missing imports will help those following the tutorial to have a better experience.