### PR TITLE
fix(vite): allow optional property access to Deno global

### DIFF
--- a/packages/plugin-vite/src/plugins/patches/deno_global.ts
+++ b/packages/plugin-vite/src/plugins/patches/deno_global.ts
@@ -18,6 +18,13 @@ export function denoGlobal({ types: t }: { types: typeof types }): PluginObj {
           ) {
             return;
           }
+          // Ignore `Deno?.thing` expression. Those will result in undefined, and that might be used for shims.
+          if (
+            t.isOptionalMemberExpression(path.parent) &&
+            path.parent.object === path.node
+          ) {
+            return;
+          }
 
           throw path.buildCodeFrameError(
             `The Deno.* global cannot be used in the browser.`,


### PR DESCRIPTION
Ideally, those expressions should be replaced with undefined for better code optimizations, yet I haven't figured it out the best way for this.

Fixes: https://github.com/denoland/fresh/issues/3296#issuecomment-3270452525