### PR TITLE
docs: fix minor issues in middleware docs

### DIFF
--- a/docs/latest/concepts/middleware.md
+++ b/docs/latest/concepts/middleware.md
@@ -60,7 +60,7 @@ Fresh ships with the following middlewares built-in:
 With file system based routing you can define a middleware in a `_middleware.ts`
 file inside the `routes/` folder or any of it's subfolders.
 
-```ts routes/foo/_middleware.ts
+```ts routes/_middleware.ts
 import { define } from "../utils.ts";
 
 export default define.middleware(async (ctx) => {

--- a/docs/latest/concepts/middleware.md
+++ b/docs/latest/concepts/middleware.md
@@ -39,7 +39,7 @@ excellent way to make http-related logic reusable on the server.
 Use the `define.middleware()` helper to get typings out of the box:
 
 ```ts middleware/my-middleware.ts
-import { define } from "./utils.ts";
+import { define } from "../utils.ts";
 
 const middleware = define.middleware(async (ctx) => {
   console.log("my middleware");
@@ -52,7 +52,7 @@ const middleware = define.middleware(async (ctx) => {
 Fresh ships with the following middlewares built-in:
 
 - [cors()](/docs/plugins/cors) - Set CORS HTTP headers
-- [csrf()](/docs/plugins/cors) - Set CSRF HTTP headers
+- [csrf()](/docs/plugins/csrf) - Set CSRF HTTP headers
 - [trailingSlash()](/docs/plugins/trailing-slashes) - Enforce trailing slashes
 
 ## Filesystem-based middlewares
@@ -61,28 +61,10 @@ With file system based routing you can define a middleware in a `_middleware.ts`
 file inside the `routes/` folder or any of it's subfolders.
 
 ```ts routes/foo/_middleware.ts
-import { define } from "./utils.ts";
+import { define } from "../utils.ts";
 
 export default define.middleware(async (ctx) => {
   console.log("my middleware");
   return await ctx.next();
 });
-```
-
-You can also export an array of middlewares:
-
-```ts routes/foo/_middleware.ts
-import { define } from "./utils.ts";
-
-const middleware1 = define.middleware(async (ctx) => {
-  console.log("A");
-  return await ctx.next();
-});
-
-const middleware2 = define.middleware(async (ctx) => {
-  console.log("B");
-  return await ctx.next();
-});
-
-export default [middleware1, middleware2];
 ```


### PR DESCRIPTION
fix #3400 

This fixes minor issue in the middleware docs. 

The example for the exporting an array of middlewares got removed for now, as it does not seem to work, it produces an longish error like this:

```
02:51:00 [vite] (ssr) Error when evaluating SSR module fresh:server_entry: Expected a route, middleware, layout or error template, but couldn't find relevant exports in: undefined
      at validateFsMod (deno::0::https:/jsr.io/@fresh/core/2.0.2/src/fs_routes.ts:32:383)
      at fsItemsToCommands (deno::0::https:/jsr.io/@fresh/core/2.0.2/src/fs_routes.ts:11:576)
      at ProdBuildCache.getFsRoutes (deno::0::https:/jsr.io/@fresh/core/2.0.2/src/build_cache.ts:9:421)
      at Object.getItems (deno::0::https:/jsr.io/@fresh/core/2.0.2/src/app.ts:58:205)
      at applyCommandsInner (deno::0::https:/jsr.io/@fresh/core/2.0.2/src/commands.ts:21:5174)
      at applyCommands (deno::0::https:/jsr.io/@fresh/core/2.0.2/src/commands.ts:21:2009)
      at App.handler (deno::0::https:/jsr.io/@fresh/core/2.0.2/src/app.ts:66:462)
      at eval (fresh:server_entry:19:36)
      at async ESModulesEvaluator.runInlinedModule (/fresh-local-dev/node_modules/.deno/vite@7.1.5_1/node_modules/vite/dist/node/module-runner.js:910:3)
      at async SSRCompatModuleRunner.directRequest (/fresh-local-dev/node_modules/.deno/vite@7.1.5_1/node_modules/vite/dist/node/module-runner.js:1119:59)
      at async SSRCompatModuleRunner.directRequest (/fresh-local-dev/node_modules/.deno/vite@7.1.5_1/node_modules/vite/dist/node/chunks/dep-M_KD0XSK.js:18863:22)
      at async SSRCompatModuleRunner.cachedRequest (/fresh-local-dev/node_modules/.deno/vite@7.1.5_1/node_modules/vite/dist/node/module-runner.js:1037:73)
      at async SSRCompatModuleRunner.import (/fresh-local-dev/node_modules/.deno/vite@7.1.5_1/node_modules/vite/dist/node/module-runner.js:997:10)
      at async instantiateModule (/fresh-local-dev/node_modules/.deno/vite@7.1.5_1/node_modules/vite/dist/node/chunks/dep-M_KD0XSK.js:18836:10)
      at async https://jsr.io/@fresh/plugin-vite/1.0.2/src/plugins/dev_server.ts:71:23
error: Uncaught (in promise) Error: Expected a route, middleware, layout or error template, but couldn't find relevant exports in: undefined
    at validateFsMod (deno::0::https:/jsr.io/@fresh/core/2.0.2/src/fs_routes.ts, <anonymous>:32:383)
    at fsItemsToCommands (deno::0::https:/jsr.io/@fresh/core/2.0.2/src/fs_routes.ts, <anonymous>:11:576)
    at ProdBuildCache.getFsRoutes (deno::0::https:/jsr.io/@fresh/core/2.0.2/src/build_cache.ts, <anonymous>:9:421)
    at Object.getItems (deno::0::https:/jsr.io/@fresh/core/2.0.2/src/app.ts, <anonymous>:58:205)
    at applyCommandsInner (deno::0::https:/jsr.io/@fresh/core/2.0.2/src/commands.ts, <anonymous>:21:5174)
    at applyCommands (deno::0::https:/jsr.io/@fresh/core/2.0.2/src/commands.ts, <anonymous>:21:2009)
    at App.handler (deno::0::https:/jsr.io/@fresh/core/2.0.2/src/app.ts, <anonymous>:66:462)
    at eval (fresh:server_entry, <anonymous>:19:36)
    at async ESModulesEvaluator.runInlinedModule (file:///fresh-local-dev/node_modules/.deno/vite@7.1.5_1/node_modules/vite/dist/node/module-runner.js:910:3)
    at async SSRCompatModuleRunner.directRequest (file:///fresh-local-dev/node_modules/.deno/vite@7.1.5_1/node_modules/vite/dist/node/module-runner.js:1119:59)
    at async SSRCompatModuleRunner.directRequest (file:///fresh-local-dev/node_modules/.deno/vite@7.1.5_1/node_modules/vite/dist/node/chunks/dep-M_KD0XSK.js:18863:22)
    at async SSRCompatModuleRunner.cachedRequest (file:///fresh-local-dev/node_modules/.deno/vite@7.1.5_1/node_modules/vite/dist/node/module-runner.js:1037:73)
    at async SSRCompatModuleRunner.import (file:///fresh-local-dev/node_modules/.deno/vite@7.1.5_1/node_modules/vite/dist/node/module-runner.js:997:10)
    at async instantiateModule (file:///fresh-local-dev/node_modules/.deno/vite@7.1.5_1/node_modules/vite/dist/node/chunks/dep-M_KD0XSK.js:18836:10)
    at async https://jsr.io/@fresh/plugin-vite/1.0.2/src/plugins/dev_server.ts:71:23
```
