### PR TITLE
fix: bring back support for middleware Array

### DIFF
--- a/packages/plugin-vite/demo/routes/tests/middlewares/_middleware.ts
+++ b/packages/plugin-vite/demo/routes/tests/middlewares/_middleware.ts
@@ -1,0 +1,13 @@
+import type { Middleware } from "@fresh/core";
+
+const middleware1: Middleware<{ text: string }> = async (ctx) => {
+  ctx.state.text = "A";
+  return await ctx.next();
+};
+
+const middleware2: Middleware<{ text: string }> = async (ctx) => {
+  ctx.state.text += "B";
+  return await ctx.next();
+};
+
+export default [middleware1, middleware2];

--- a/packages/plugin-vite/demo/routes/tests/middlewares/index.tsx
+++ b/packages/plugin-vite/demo/routes/tests/middlewares/index.tsx
@@ -1,0 +1,4 @@
+import type { HandlerFn } from "@fresh/core";
+
+export const handler: HandlerFn<null, { text: string }> = (ctx) =>
+  new Response(ctx.state.text);

--- a/packages/plugin-vite/tests/build_test.ts
+++ b/packages/plugin-vite/tests/build_test.ts
@@ -474,3 +474,19 @@ Deno.test({
   sanitizeOps: false,
   sanitizeResources: false,
 });
+
+Deno.test({
+  name: "vite build - support _middleware Array",
+  fn: async () => {
+    await launchProd(
+      { cwd: viteResult.tmp },
+      async (address) => {
+        const res = await fetch(`${address}/tests/middlewares`);
+        const text = await res.text();
+        expect(text).toEqual("AB");
+      },
+    );
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});

--- a/packages/plugin-vite/tests/dev_server_test.ts
+++ b/packages/plugin-vite/tests/dev_server_test.ts
@@ -419,3 +419,14 @@ Deno.test({
   sanitizeOps: false,
   sanitizeResources: false,
 });
+
+Deno.test({
+  name: "vite dev - support _middleware Array",
+  fn: async () => {
+    const res = await fetch(`${demoServer.address()}/tests/middlewares`);
+    const text = await res.text();
+    expect(text).toEqual("AB");
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});


### PR DESCRIPTION
Our validation didn't account for `_middleware` files exporting an Array of middlewares.

Fixes https://github.com/denoland/fresh/issues/3400