### PR TITLE
fix: improve missing build cache error message

### DIFF
--- a/docs/latest/advanced/troubleshooting.md
+++ b/docs/latest/advanced/troubleshooting.md
@@ -54,3 +54,11 @@ To debug vite plugin transformations, use
 [`vite-plugin-inspect`](https://github.com/antfu-collective/vite-plugin-inspect).
 This gives you a UI that shows all transformations of all plugins for every
 file.
+
+## My deployment won't start
+
+If your deployment doesn't boot, check the following things:
+
+1. Make sure that you ran `deno task build`.
+2. Make sure that your entry points to the generated `_fresh/server.js` file
+   instead of `main.ts`. The latter won't work with Fresh 2.

--- a/packages/fresh/src/app.ts
+++ b/packages/fresh/src/app.ts
@@ -368,7 +368,7 @@ export class App<State> {
         DENO_DEPLOYMENT_ID !== undefined
       ) {
         throw new Error(
-          `Could not find _fresh directory. Maybe you forgot to run "deno task build"?`,
+          `Could not find _fresh directory. Maybe you forgot to run "deno task build" or maybe you're trying to run "main.ts" directly instead of "_fresh/server.js"?`,
         );
       } else {
         buildCache = new MockBuildCache([], this.config.mode);


### PR DESCRIPTION
Hoping that this helps folks who ignore the migration guide and keep the entry pointed to `main.ts`.