### PR TITLE
fix: returned handler headers only working with plain objects

### DIFF
--- a/packages/fresh/src/app_test.tsx
+++ b/packages/fresh/src/app_test.tsx
@@ -637,6 +637,50 @@ Deno.test("App - .route() with *", async () => {
   expect(await res.text()).toEqual("ok");
 });
 
+Deno.test("App - .route() handler returns headers", async () => {
+  const app = new App()
+    .route("/", {
+      handler: () => {
+        const headers = new Headers();
+        headers.set("X-Foo", "foo");
+        return { data: {}, headers };
+      },
+      component() {
+        return <h1>foo</h1>;
+      },
+    })
+    .route("/obj", {
+      handler: () => {
+        return { data: {}, headers: { "X-Foo": "foo" } };
+      },
+      component() {
+        return <h1>foo</h1>;
+      },
+    })
+    .route("/arr", {
+      handler: () => {
+        return { data: {}, headers: [["X-Foo", "foo"]] };
+      },
+      component() {
+        return <h1>foo</h1>;
+      },
+    });
+
+  const server = new FakeServer(app.handler());
+
+  let res = await server.get("/");
+  expect(await res.text()).toContain("<h1>foo</h1>");
+  expect(res.headers.get("X-Foo")).toEqual("foo");
+
+  res = await server.get("/obj");
+  expect(await res.text()).toContain("<h1>foo</h1>");
+  expect(res.headers.get("X-Foo")).toEqual("foo");
+
+  res = await server.get("/arr");
+  expect(await res.text()).toContain("<h1>foo</h1>");
+  expect(res.headers.get("X-Foo")).toEqual("foo");
+});
+
 Deno.test("App - .use() - lazy", async () => {
   const app = new App<{ text: string }>()
     // deno-lint-ignore require-await

--- a/packages/fresh/src/segments.ts
+++ b/packages/fresh/src/segments.ts
@@ -189,9 +189,20 @@ export async function renderRoute<State>(
   if (typeof res.status === "number") {
     status = res.status;
   }
-  if (res.headers) {
-    for (const [name, value] of Object.entries(res.headers)) {
-      headers.set(name, value);
+  if (res.headers !== undefined) {
+    if (res.headers instanceof Headers) {
+      res.headers.forEach((value, key) => {
+        headers.set(key, value);
+      });
+    } else if (Array.isArray(res.headers)) {
+      for (let i = 0; i < res.headers.length; i++) {
+        const entry = res.headers[i];
+        headers.set(entry[0], entry[1]);
+      }
+    } else {
+      for (const [name, value] of Object.entries(res.headers)) {
+        headers.set(name, value);
+      }
     }
   }
 


### PR DESCRIPTION
We only dealt with returned headers as objects instead of all potential shapes of `Headersinit`.

Fixes https://github.com/denoland/fresh/issues/3445