### PR TITLE
fix(vite): ensure plugins are only instantiated once

### DIFF
--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -55,6 +55,7 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
   const plugins: Plugin[] = [
     {
       name: "fresh",
+      sharedDuringBuild: true,
       config(config, env) {
         isDev = env.command === "serve";
 

--- a/packages/plugin-vite/src/plugins/build_id.ts
+++ b/packages/plugin-vite/src/plugins/build_id.ts
@@ -7,6 +7,7 @@ export function buildIdPlugin(): Plugin {
 
   return {
     name: "fresh:build-id",
+    sharedDuringBuild: true,
     async config(_, env) {
       const isDev = env.command === "serve";
 

--- a/packages/plugin-vite/src/plugins/client_entry.ts
+++ b/packages/plugin-vite/src/plugins/client_entry.ts
@@ -10,6 +10,7 @@ export function clientEntryPlugin(options: ResolvedFreshViteConfig): Plugin {
 
   return {
     name: "fresh:client-entry",
+    sharedDuringBuild: true,
     config(_, env) {
       isDev = env.command === "serve";
     },

--- a/packages/plugin-vite/src/plugins/client_snapshot.ts
+++ b/packages/plugin-vite/src/plugins/client_snapshot.ts
@@ -15,6 +15,7 @@ export function clientSnapshot(options: ResolvedFreshViteConfig): Plugin[] {
   return [
     {
       name: "fresh:client-snapshot",
+      sharedDuringBuild: true,
       applyToEnvironment(env) {
         return env.name === "client";
       },
@@ -142,6 +143,7 @@ if (import.meta.hot) {
     },
     {
       name: "fresh:client-island",
+      sharedDuringBuild: true,
       resolveId: {
         filter: {
           id: /^fresh-client-island::/,

--- a/packages/plugin-vite/src/plugins/deno.ts
+++ b/packages/plugin-vite/src/plugins/deno.ts
@@ -24,6 +24,7 @@ export function deno(): Plugin {
 
   return {
     name: "deno",
+    sharedDuringBuild: true,
     // We must be first to be able to resolve before the
     // Vite's own`vite:resolve` plugin. It always treats bare
     // specifiers as external during SSR.

--- a/packages/plugin-vite/src/plugins/dev_server.ts
+++ b/packages/plugin-vite/src/plugins/dev_server.ts
@@ -9,6 +9,7 @@ export function devServer(): Plugin[] {
   return [
     {
       name: "fresh:dev_server",
+      sharedDuringBuild: true,
       configResolved(config) {
         publicDir = config.publicDir;
       },

--- a/packages/plugin-vite/src/plugins/patches.ts
+++ b/packages/plugin-vite/src/plugins/patches.ts
@@ -13,6 +13,7 @@ export function patches(): Plugin {
 
   return {
     name: "fresh:patches",
+    sharedDuringBuild: true,
     config(_, env) {
       isDev = env.command === "serve";
     },

--- a/packages/plugin-vite/src/plugins/server_entry.ts
+++ b/packages/plugin-vite/src/plugins/server_entry.ts
@@ -32,6 +32,7 @@ export function serverEntryPlugin(
 
   return {
     name: "fresh:server_entry",
+    sharedDuringBuild: true,
     applyToEnvironment(env) {
       return env.name === "ssr";
     },

--- a/packages/plugin-vite/src/plugins/server_snapshot.ts
+++ b/packages/plugin-vite/src/plugins/server_snapshot.ts
@@ -46,6 +46,7 @@ export function serverSnapshot(options: ResolvedFreshViteConfig): Plugin[] {
   return [
     {
       name: "fresh:server-snapshot",
+      sharedDuringBuild: true,
       applyToEnvironment(env) {
         return env.name === "ssr";
       },
@@ -389,6 +390,7 @@ export function serverSnapshot(options: ResolvedFreshViteConfig): Plugin[] {
     },
     {
       name: "fresh:island-resolver",
+      sharedDuringBuild: true,
       resolveId: {
         filter: {
           id: /^fresh-island::.*/,
@@ -407,6 +409,7 @@ export function serverSnapshot(options: ResolvedFreshViteConfig): Plugin[] {
     },
     {
       name: "fresh:route-css",
+      sharedDuringBuild: true,
       resolveId: {
         filter: {
           id: /^(\/@id\/)?fresh-route-css::/,
@@ -447,6 +450,7 @@ export default ${JSON.stringify(route.css)}
     },
     {
       name: "fresh-route-css-build-ssr",
+      sharedDuringBuild: true,
       applyToEnvironment(env) {
         return env.name === "ssr";
       },
@@ -475,6 +479,7 @@ export default ${JSON.stringify(route.css)}
     },
     {
       name: "fresh:route-resolver",
+      sharedDuringBuild: true,
       resolveId: {
         filter: {
           id: /^fresh-route::/,

--- a/packages/plugin-vite/src/plugins/shims.ts
+++ b/packages/plugin-vite/src/plugins/shims.ts
@@ -19,6 +19,7 @@ const SHIMS: Record<string, string> = {
 export function shims(): Plugin {
   return {
     name: "fresh:shims",
+    sharedDuringBuild: true,
     resolveId: {
       filter: {
         id: /(object\.entries|supports-color)/,

--- a/packages/plugin-vite/src/plugins/verify_imports.ts
+++ b/packages/plugin-vite/src/plugins/verify_imports.ts
@@ -41,6 +41,7 @@ export function checkImports(pluginOptions: CheckImportOptions): Plugin {
 
   return {
     name: "fresh:check-imports",
+    sharedDuringBuild: true,
     enforce: "pre",
     applyToEnvironment() {
       return true;


### PR DESCRIPTION
This makes debugging a lot easier as by default vite instantiates plugins multiple times for each environment.