### PR TITLE
docs: add deno.json update section to migration guide

### DIFF
--- a/docs/latest/examples/migration-guide.md
+++ b/docs/latest/examples/migration-guide.md
@@ -155,7 +155,7 @@ accordingly.
   }
 ```
 
-## Update `deno.json`
+## Update imports
 
 Add `jsr:@fresh/plugin-vite` and `npm:vite` to `imports` in your `deno.json`
 file, either manually or with this command:

--- a/docs/latest/examples/migration-guide.md
+++ b/docs/latest/examples/migration-guide.md
@@ -155,6 +155,17 @@ accordingly.
   }
 ```
 
+## Update `deno.json`
+
+Update your `deno.json` to use Vite for development and builds, and add
+`@fresh/plugin-vite` and `vite` to `imports`.
+
+> Note: With Vite, Fresh’s Tailwind plugin (`@fresh/plugin-tailwindcss*`) is not
+> needed; use the Vite integration instead (e.g. `@tailwindcss/vite`).
+
+You may also need to update `compilerOptions` and other parts. For a complete,
+up‑to‑date example, generate a new app (“Migrate by example” below) and compare.
+
 ## Update deployment settings
 
 Fresh 2 requires assets to be built during deployment instead of building them

--- a/docs/latest/examples/migration-guide.md
+++ b/docs/latest/examples/migration-guide.md
@@ -157,14 +157,19 @@ accordingly.
 
 ## Update `deno.json`
 
-Update your `deno.json` to use Vite for development and builds, and add
-`@fresh/plugin-vite` and `vite` to `imports`.
+Add `jsr:@fresh/plugin-vite` and `npm:vite` to `imports` in your `deno.json`
+file, either manually or with this command:
 
-> Note: With Vite, Fresh’s Tailwind plugin (`@fresh/plugin-tailwindcss*`) is not
-> needed; use the Vite integration instead (e.g. `@tailwindcss/vite`).
+```shell
+deno install npm:vite jsr:@fresh/plugin-vite
+```
 
-You may also need to update `compilerOptions` and other parts. For a complete,
+This should be enough in most cases. If you still encounter problems, you may
+also need to update `compilerOptions` and other parts. For a complete,
 up‑to‑date example, generate a new app (“Migrate by example” below) and compare.
+
+> Note: With Vite, Fresh’s Tailwind plugin (`jsr:@fresh/plugin-tailwindcss*`) is
+> not needed; use the Vite integration instead (e.g. `npm:@tailwindcss/vite`).
 
 ## Update deployment settings
 


### PR DESCRIPTION
fix #3470 

This adds a short blurb about `deno.json` focusing on imports.

Background: Without `npm:vite` and `jsr:@fresh/plugin-vite` installed it can lead to confusing errors like this one:
```shell
$ deno task dev
vite: command not found
```

Which might lead to users install Vite globally, which is not needed (and will not fix this problem).