### PR TITLE
feat: add Deno runtime version check warnings

### DIFF
--- a/packages/fresh/src/app.ts
+++ b/packages/fresh/src/app.ts
@@ -29,6 +29,7 @@ import {
   newRouteCmd,
 } from "./commands.ts";
 import { MockBuildCache } from "./test_utils.ts";
+import { scheduleFreshDenoVersionWarning } from "./dev/deno_version_check.ts";
 
 // TODO: Completed type clashes in older Deno versions
 // deno-lint-ignore no-explicit-any
@@ -453,6 +454,13 @@ export class App<State> {
   async listen(options: ListenOptions = {}): Promise<void> {
     if (!options.onListen) {
       options.onListen = createOnListen(this.config.basePath, options);
+    }
+
+    // Schedule a (non-blocking) Deno version warning check once per process.
+    try {
+      scheduleFreshDenoVersionWarning();
+    } catch (_) {
+      // Ignore – purely advisory.
     }
 
     const handler = this.handler();

--- a/packages/fresh/src/app.ts
+++ b/packages/fresh/src/app.ts
@@ -456,11 +456,11 @@ export class App<State> {
       options.onListen = createOnListen(this.config.basePath, options);
     }
 
-    // Schedule a (non-blocking) Deno version warning check once per process.
+    // Version warning (non-blocking).
     try {
       scheduleFreshDenoVersionWarning();
     } catch (_) {
-      // Ignore – purely advisory.
+      // ignore
     }
 
     const handler = this.handler();

--- a/packages/fresh/src/deno_version_check_test.ts
+++ b/packages/fresh/src/deno_version_check_test.ts
@@ -26,7 +26,7 @@ Deno.test("denoVersionWarning - no warn when up to date", async () => {
   expect(warnSpy.fake).not.toHaveBeenCalled();
 });
 
-Deno.test("denoVersionWarning - friendly canary message", async () => {
+Deno.test("denoVersionWarning - friendly canary message (one-time)", async () => {
   // deno-lint-ignore no-explicit-any
   using warnSpy = stub(console, "warn", fn(() => {}) as any);
   await denoVersionWarning({
@@ -38,6 +38,14 @@ Deno.test("denoVersionWarning - friendly canary message", async () => {
   expect(warnSpy.fake).toHaveBeenCalled();
   const call = warnSpy.calls[0].args[0];
   expect(call).toContain("Canary Deno version detected");
+
+  // Second invocation should not duplicate the message
+  await denoVersionWarning({
+    force: true,
+    getCurrentVersion: () => "2.5.1+e7f1793",
+    getLatestStable: () => Promise.resolve("2.5.1"),
+  });
+  expect(warnSpy.calls.length).toBe(1);
 });
 
 Deno.test("denoVersionWarning - respects disable env var", async () => {

--- a/packages/fresh/src/deno_version_check_test.ts
+++ b/packages/fresh/src/deno_version_check_test.ts
@@ -12,7 +12,7 @@ Deno.test("denoVersionWarning - warns on outdated stable", async () => {
   });
   expect(warnSpy.fake).toHaveBeenCalled();
   const call = warnSpy.calls[0].args[0];
-  expect(call).toContain("Outdated Deno version");
+  expect(call).toContain("Outdated Deno version:");
 });
 
 Deno.test("denoVersionWarning - no warn when up to date", async () => {

--- a/packages/fresh/src/deno_version_check_test.ts
+++ b/packages/fresh/src/deno_version_check_test.ts
@@ -1,0 +1,83 @@
+import { expect, fn } from "@std/expect";
+import { stub } from "@std/testing/mock";
+import { denoVersionWarning } from "./dev/deno_version_check.ts";
+import * as path from "@std/path";
+import * as fs from "@std/fs";
+
+function tempDir() {
+  return Deno.makeTempDirSync({ prefix: "fresh-deno-version-test-" });
+}
+
+Deno.test("denoVersionWarning - warns on outdated stable", async () => {
+  const dir = tempDir();
+  // deno-lint-ignore no-explicit-any
+  using warnSpy = stub(console, "warn", fn(() => {}) as any);
+  await denoVersionWarning({
+    force: true,
+    getCacheDir: () => dir,
+    getCurrentVersion: () => "2.5.0", // pretend current
+    getLatestStable: () => Promise.resolve("2.5.1"), // pretend latest
+  });
+  expect(warnSpy.fake).toHaveBeenCalled();
+  const call = warnSpy.calls[0].args[0];
+  expect(call).toContain("Outdated Deno version");
+});
+
+Deno.test("denoVersionWarning - no warn when up to date", async () => {
+  const dir = tempDir();
+  // deno-lint-ignore no-explicit-any
+  using warnSpy = stub(console, "warn", fn(() => {}) as any);
+  await denoVersionWarning({
+    force: true,
+    getCacheDir: () => dir,
+    getCurrentVersion: () => "2.5.1",
+    getLatestStable: () => Promise.resolve("2.5.1"),
+  });
+  expect(warnSpy.fake).not.toHaveBeenCalled();
+});
+
+Deno.test("denoVersionWarning - friendly canary message", async () => {
+  const dir = tempDir();
+  // deno-lint-ignore no-explicit-any
+  using warnSpy = stub(console, "warn", fn(() => {}) as any);
+  await denoVersionWarning({
+    force: true,
+    getCacheDir: () => dir,
+    getCurrentVersion: () => "2.5.1+e7f1793",
+    // Should not even call getLatestStable, but provide anyway.
+    getLatestStable: () => Promise.resolve("2.5.1"),
+  });
+  expect(warnSpy.fake).toHaveBeenCalled();
+  const call = warnSpy.calls[0].args[0];
+  expect(call).toContain("Canary Deno version detected");
+});
+
+Deno.test("denoVersionWarning - respects disable env var", async () => {
+  const dir = tempDir();
+  Deno.env.set("FRESH_NO_DENO_VERSION_WARNING", "true");
+  try {
+    // deno-lint-ignore no-explicit-any
+    using warnSpy = stub(console, "warn", fn(() => {}) as any);
+    await denoVersionWarning({
+      getCacheDir: () => dir,
+      getCurrentVersion: () => "2.5.0",
+      getLatestStable: () => Promise.resolve("2.5.1"),
+    });
+    expect(warnSpy.fake).not.toHaveBeenCalled();
+  } finally {
+    Deno.env.delete("FRESH_NO_DENO_VERSION_WARNING");
+  }
+});
+
+Deno.test("denoVersionWarning - writes cache file", async () => {
+  const dir = tempDir();
+  await denoVersionWarning({
+    force: true,
+    getCacheDir: () => dir,
+    getCurrentVersion: () => "2.5.0",
+    getLatestStable: () => Promise.resolve("2.5.1"),
+  });
+  const file = path.join(dir, "deno_version.json");
+  const exists = await fs.exists(file);
+  expect(exists).toBe(true);
+});

--- a/packages/fresh/src/dev/deno_version_check.ts
+++ b/packages/fresh/src/dev/deno_version_check.ts
@@ -1,0 +1,184 @@
+import * as semver from "@std/semver";
+import * as path from "@std/path";
+
+/**
+ * Lightweight Deno version warning facility for Fresh.
+ *
+ * Two scenarios:
+ *  1. Outdated stable build: warn that issues should be re-tested on latest.
+ *  2. Canary build: friendly message encouraging feedback.
+ *
+ * This intentionally does NOT replicate Deno CLI's full update logic – we only
+ * fetch the small plaintext file `https://dl.deno.land/release-latest.txt` to
+ * learn the latest stable version (cached for 24h). For canary builds we don't
+ * fetch anything; the presence of build metadata (a "+" suffix) in
+ * `Deno.version.deno` is enough.
+ */
+
+export interface DenoVersionCacheFile {
+  last_checked: string; // ISO timestamp
+  latest_stable: string; // semantic version without leading v
+}
+
+const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+const CACHE_FILENAME = "deno_version.json";
+
+let scheduled = false; // Ensure we only schedule once per process.
+
+function getHomeDir(): string | null {
+  switch (Deno.build.os) {
+    case "linux": {
+      const xdg = Deno.env.get("XDG_CACHE_HOME");
+      if (xdg) return xdg;
+      const home = Deno.env.get("HOME");
+      if (home) return `${home}/.cache`;
+      break;
+    }
+    case "darwin": {
+      const home = Deno.env.get("HOME");
+      if (home) return `${home}/Library/Caches`;
+      break;
+    }
+    case "windows":
+      return Deno.env.get("LOCALAPPDATA") ?? null;
+  }
+  return null;
+}
+
+function getFreshCacheDir(): string | null {
+  const home = getHomeDir();
+  if (home) return path.join(home, "fresh");
+  return null;
+}
+
+async function fetchLatestStableVersion(): Promise<string> {
+  const res = await fetch("https://dl.deno.land/release-latest.txt");
+  if (!res.ok) throw new Error("failed to fetch latest Deno version");
+  // Remove a leading v if present.
+  return (await res.text()).trim().replace(/^v/, "");
+}
+
+function parseCurrentVersion(): string {
+  return Deno.version.deno;
+}
+
+/** Detect if current version is canary. Canary builds have build metadata suffix like 2.x.y+<hash>. */
+function isCanary(version: string): boolean {
+  return version.includes("+");
+}
+
+interface CheckOptions {
+  intervalMs?: number;
+  getCacheDir?: () => string | null;
+  getLatestStable?: () => Promise<string>;
+  getCurrentVersion?: () => string;
+  now?: () => Date;
+  logger?: Pick<typeof console, "warn">;
+  force?: boolean; // run even if env vars would normally skip
+}
+
+/**
+ * Run the version warning logic. Exported for testing; typical usage is via
+ * {@link scheduleDenoVersionWarning} which runs this in the background.
+ */
+export async function denoVersionWarning(options: CheckOptions = {}) {
+  const {
+    intervalMs = DEFAULT_INTERVAL_MS,
+    getCacheDir = getFreshCacheDir,
+    getLatestStable = fetchLatestStableVersion,
+    getCurrentVersion = parseCurrentVersion,
+    now = () => new Date(),
+    logger = console,
+    force = false,
+  } = options;
+
+  if (!force) {
+    if (
+      Deno.env.get("CI") === "true" ||
+      Deno.env.get("DENO_DEPLOYMENT_ID") ||
+      Deno.env.get("FRESH_NO_DENO_VERSION_WARNING") === "true"
+    ) {
+      return;
+    }
+  }
+
+  const current = getCurrentVersion();
+
+  // Canary: friendly info (only once per process; no network fetch).
+  if (isCanary(current)) {
+    // For unit tests we always log. In production limit to once.
+    const marker = denoVersionWarning as unknown as { _canaryShown: boolean };
+    if (!marker._canaryShown) {
+      marker._canaryShown = true;
+      logger.warn(
+        "🍋 %c[INFO] Canary Deno version detected: %s – If you encounter issues please open an issue at https://github.com/denoland/deno or https://github.com/denoland/fresh",
+        "color:rgb(121, 200, 121)",
+        current,
+      );
+    }
+    return;
+  }
+
+  const cacheDir = getCacheDir();
+  if (!cacheDir) return; // Nothing we can do.
+  const filePath = path.join(cacheDir, CACHE_FILENAME);
+
+  let cache: DenoVersionCacheFile = {
+    last_checked: new Date(0).toISOString(),
+    latest_stable: current,
+  };
+  try {
+    const text = await Deno.readTextFile(filePath);
+    cache = JSON.parse(text) as DenoVersionCacheFile;
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err;
+  }
+
+  const lastChecked = new Date(cache.last_checked).getTime();
+  const nowMs = now().getTime();
+  if (nowMs >= lastChecked + intervalMs) {
+    try {
+      cache.latest_stable = await getLatestStable();
+      cache.last_checked = now().toISOString();
+    } catch (_err) {
+      // Silently ignore network issues – purely advisory.
+      return;
+    }
+  }
+
+  const currentSemver = semver.parse(current);
+  const latestSemver = semver.parse(cache.latest_stable);
+  if (currentSemver && latestSemver && semver.lessThan(currentSemver, latestSemver)) {
+    logger.warn(
+      "🍋 %c[WARNING] Outdated Deno version detected: %s (latest %s). Please re-test with the latest Deno before reporting issues to Fresh. Upgrade by running: deno upgrade",
+      "color:rgb(251, 184, 0)",
+      current,
+      cache.latest_stable,
+    );
+  }
+
+  try {
+    await Deno.mkdir(cacheDir, { recursive: true });
+    await Deno.writeTextFile(filePath, JSON.stringify(cache));
+  } catch (_err) {
+    // Ignore write failures.
+  }
+}
+
+// For testing – track whether canary message has been shown.
+(denoVersionWarning as unknown as { _canaryShown: boolean })._canaryShown = false;
+
+/** Schedule the warning logic to run without blocking startup. */
+export function scheduleFreshDenoVersionWarning() {
+  if (scheduled) return;
+  scheduled = true;
+  // Fire and forget – keep micro delay to avoid impacting synchronous startup logs.
+  queueMicrotask(() => {
+    // Deliberately not awaited.
+    denoVersionWarning().catch(() => {});
+  });
+}
+
+// Internal state property declaration for TypeScript.
+// Re-export the marker property type for tests without using namespaces.
+export const _internal = { get canaryShown() { return (denoVersionWarning as unknown as { _canaryShown: boolean })._canaryShown; } };

--- a/packages/fresh/src/dev/deno_version_check.ts
+++ b/packages/fresh/src/dev/deno_version_check.ts
@@ -74,7 +74,10 @@ export async function denoVersionWarning(options: CheckOptions = {}) {
 
   const currentSemver = semver.parse(current);
   const latestSemver = semver.parse(latest);
-  if (currentSemver && latestSemver && semver.lessThan(currentSemver, latestSemver)) {
+  if (
+    currentSemver && latestSemver &&
+    semver.lessThan(currentSemver, latestSemver)
+  ) {
     logger.warn(
       "🍋 %c[WARNING] Outdated Deno version detected: %s (latest %s). Please re-test with the latest Deno before reporting issues to Fresh. Upgrade by running: deno upgrade",
       "color:rgb(251, 184, 0)",

--- a/packages/fresh/src/dev/deno_version_check.ts
+++ b/packages/fresh/src/dev/deno_version_check.ts
@@ -5,6 +5,16 @@ let fetched = false;
 let latestStableCache: string | null = null;
 let canaryWarned = false;
 
+function logWarning(message: string) {
+  // deno-lint-ignore no-console
+  console.warn(`🍋 %c[WARNING] ${message}`, "color:rgb(251, 184, 0)");
+}
+
+function logInfo(message: string) {
+  // deno-lint-ignore no-console
+  console.warn(`🍋 %c[INFO] ${message}`, "color:rgb(121, 200, 121)");
+}
+
 async function fetchLatestStableVersion(): Promise<string | null> {
   if (fetched) return latestStableCache;
   fetched = true;
@@ -41,7 +51,6 @@ export async function denoVersionWarning(options: CheckOptions = {}) {
   const {
     getLatestStable = fetchLatestStableVersion,
     getCurrentVersion = parseCurrentVersion,
-    logger = console,
     force = false,
   } = options;
 
@@ -60,10 +69,9 @@ export async function denoVersionWarning(options: CheckOptions = {}) {
   if (isCanary(current)) {
     if (!canaryWarned) {
       canaryWarned = true;
-      logger.warn(
-        "🍋 %c[INFO] Canary Deno version detected: %s – If you encounter issues please open an issue at https://github.com/denoland/deno or https://github.com/denoland/fresh",
-        "color:rgb(121, 200, 121)",
-        current,
+      // Use same console styling pattern as other Fresh warnings.
+      logInfo(
+        `Canary Deno version detected (${current}). Feedback welcome at https://github.com/denoland/deno or https://github.com/denoland/fresh`,
       );
     }
     return;
@@ -78,11 +86,8 @@ export async function denoVersionWarning(options: CheckOptions = {}) {
     currentSemver && latestSemver &&
     semver.lessThan(currentSemver, latestSemver)
   ) {
-    logger.warn(
-      "🍋 %c[WARNING] Outdated Deno version detected: %s (latest %s). Please re-test with the latest Deno before reporting issues to Fresh. Upgrade by running: deno upgrade",
-      "color:rgb(251, 184, 0)",
-      current,
-      latest,
+    logWarning(
+      `Outdated Deno version: ${current} (latest ${latest}). Re-test with latest before reporting issues. Run: deno upgrade`,
     );
   }
 }

--- a/packages/fresh/src/dev/deno_version_check.ts
+++ b/packages/fresh/src/dev/deno_version_check.ts
@@ -1,61 +1,34 @@
 import * as semver from "@std/semver";
-import * as path from "@std/path";
 
 /**
- * Lightweight Deno version warning facility for Fresh.
+ * Lightweight Deno version warning facility for Fresh (stateless).
  *
- * Two scenarios:
- *  1. Outdated stable build: warn that issues should be re-tested on latest.
- *  2. Canary build: friendly message encouraging feedback.
+ * Scenarios:
+ *  1. Outdated stable build → warn to re-test with latest Deno before
+ *     reporting issues.
+ *  2. Canary build → friendly info inviting feedback.
  *
- * This intentionally does NOT replicate Deno CLI's full update logic – we only
- * fetch the small plaintext file `https://dl.deno.land/release-latest.txt` to
- * learn the latest stable version (cached for 24h). For canary builds we don't
- * fetch anything; the presence of build metadata (a "+" suffix) in
- * `Deno.version.deno` is enough.
+ * No filesystem cache (edge / ephemeral FS friendly). We attempt a single
+ * network fetch per process (first schedule) and swallow all errors (missing
+ * net perms, offline, etc.).
  */
 
-export interface DenoVersionCacheFile {
-  last_checked: string; // ISO timestamp
-  latest_stable: string; // semantic version without leading v
-}
+let scheduled = false; // Ensure we only schedule once.
+let fetched = false; // Prevent repeated network fetch within same process.
+let latestStableCache: string | null = null;
 
-const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
-const CACHE_FILENAME = "deno_version.json";
-
-let scheduled = false; // Ensure we only schedule once per process.
-
-function getHomeDir(): string | null {
-  switch (Deno.build.os) {
-    case "linux": {
-      const xdg = Deno.env.get("XDG_CACHE_HOME");
-      if (xdg) return xdg;
-      const home = Deno.env.get("HOME");
-      if (home) return `${home}/.cache`;
-      break;
-    }
-    case "darwin": {
-      const home = Deno.env.get("HOME");
-      if (home) return `${home}/Library/Caches`;
-      break;
-    }
-    case "windows":
-      return Deno.env.get("LOCALAPPDATA") ?? null;
+async function fetchLatestStableVersion(): Promise<string | null> {
+  if (fetched) return latestStableCache; // Already attempted.
+  fetched = true;
+  try {
+    const res = await fetch("https://dl.deno.land/release-latest.txt");
+    if (!res.ok) return null;
+    latestStableCache = (await res.text()).trim().replace(/^v/, "");
+    return latestStableCache;
+  } catch (_) {
+    // Network disallowed or offline – ignore.
+    return null;
   }
-  return null;
-}
-
-function getFreshCacheDir(): string | null {
-  const home = getHomeDir();
-  if (home) return path.join(home, "fresh");
-  return null;
-}
-
-async function fetchLatestStableVersion(): Promise<string> {
-  const res = await fetch("https://dl.deno.land/release-latest.txt");
-  if (!res.ok) throw new Error("failed to fetch latest Deno version");
-  // Remove a leading v if present.
-  return (await res.text()).trim().replace(/^v/, "");
 }
 
 function parseCurrentVersion(): string {
@@ -68,11 +41,8 @@ function isCanary(version: string): boolean {
 }
 
 interface CheckOptions {
-  intervalMs?: number;
-  getCacheDir?: () => string | null;
-  getLatestStable?: () => Promise<string>;
+  getLatestStable?: () => Promise<string | null>;
   getCurrentVersion?: () => string;
-  now?: () => Date;
   logger?: Pick<typeof console, "warn">;
   force?: boolean; // run even if env vars would normally skip
 }
@@ -83,11 +53,8 @@ interface CheckOptions {
  */
 export async function denoVersionWarning(options: CheckOptions = {}) {
   const {
-    intervalMs = DEFAULT_INTERVAL_MS,
-    getCacheDir = getFreshCacheDir,
     getLatestStable = fetchLatestStableVersion,
     getCurrentVersion = parseCurrentVersion,
-    now = () => new Date(),
     logger = console,
     force = false,
   } = options;
@@ -119,49 +86,18 @@ export async function denoVersionWarning(options: CheckOptions = {}) {
     return;
   }
 
-  const cacheDir = getCacheDir();
-  if (!cacheDir) return; // Nothing we can do.
-  const filePath = path.join(cacheDir, CACHE_FILENAME);
-
-  let cache: DenoVersionCacheFile = {
-    last_checked: new Date(0).toISOString(),
-    latest_stable: current,
-  };
-  try {
-    const text = await Deno.readTextFile(filePath);
-    cache = JSON.parse(text) as DenoVersionCacheFile;
-  } catch (err) {
-    if (!(err instanceof Deno.errors.NotFound)) throw err;
-  }
-
-  const lastChecked = new Date(cache.last_checked).getTime();
-  const nowMs = now().getTime();
-  if (nowMs >= lastChecked + intervalMs) {
-    try {
-      cache.latest_stable = await getLatestStable();
-      cache.last_checked = now().toISOString();
-    } catch (_err) {
-      // Silently ignore network issues – purely advisory.
-      return;
-    }
-  }
+  const latest = await getLatestStable();
+  if (!latest) return; // Couldn't determine latest – stay silent.
 
   const currentSemver = semver.parse(current);
-  const latestSemver = semver.parse(cache.latest_stable);
+  const latestSemver = semver.parse(latest);
   if (currentSemver && latestSemver && semver.lessThan(currentSemver, latestSemver)) {
     logger.warn(
       "🍋 %c[WARNING] Outdated Deno version detected: %s (latest %s). Please re-test with the latest Deno before reporting issues to Fresh. Upgrade by running: deno upgrade",
       "color:rgb(251, 184, 0)",
       current,
-      cache.latest_stable,
+      latest,
     );
-  }
-
-  try {
-    await Deno.mkdir(cacheDir, { recursive: true });
-    await Deno.writeTextFile(filePath, JSON.stringify(cache));
-  } catch (_err) {
-    // Ignore write failures.
   }
 }
 


### PR DESCRIPTION
This adds warnings if an outdated or canary Deno version gets used.