### PR TITLE
Fix wrong variable name in migration guide

### DIFF
--- a/docs/latest/examples/migration-guide.md
+++ b/docs/latest/examples/migration-guide.md
@@ -261,7 +261,7 @@ generalized to render JSX, so it's no longer needed.
 Fresh 1.x:
 
 ```ts
-export const handlers = {
+export const handler = {
   async GET(req, ctx) {
     const data = await Query();
     await ctx.render({ value: data });
@@ -276,7 +276,7 @@ export default function Page({ data }) {
 Fresh 2 (removed):
 
 ```ts
-export const handlers = {
+export const handler = {
   async GET(ctx) {
     const data = await Query();
     return { data: { value: data } };


### PR DESCRIPTION
You have `export const handlers = ` when it needs to be `export const handler = `.

I'm unsure if there's any build process I need to run for this.