### PR TITLE
docs: troubleshoot VS Code extension

### DIFF
--- a/docs/latest/advanced/troubleshooting.md
+++ b/docs/latest/advanced/troubleshooting.md
@@ -75,3 +75,17 @@ If your deployment doesn't boot, check the following things:
 1. Make sure that you ran `deno task build`.
 2. Make sure that your entry points to the generated `_fresh/server.js` file
    instead of `main.ts`. The latter won't work with Fresh 2.
+
+## VS Code does not find packages and/or types
+
+If you see errors in VS Code like `Cannot find module 'fresh/runtime'` or see a
+lot of TypeScript errors, you likely have not installed the Deno extension. You
+can easily find it inside VS Code's extension browser or get it from the market
+place:
+
+https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno
+
+When installed and successfully enabled the current installed Deno version
+should show up in the bottom status line. If for some reason this does not
+automatically happen you can enable the Deno extension via the command palette
+(Shift-Cmd-P) in VS Code and run `Deno: Enable`.

--- a/docs/latest/advanced/troubleshooting.md
+++ b/docs/latest/advanced/troubleshooting.md
@@ -80,12 +80,12 @@ If your deployment doesn't boot, check the following things:
 
 If you see errors in VS Code like `Cannot find module 'fresh/runtime'` or see a
 lot of TypeScript errors, you likely have not installed the Deno extension. You
-can easily find it inside VS Code's extension browser or get it from the market
-place:
+can easily find it inside VS Code's extension browser or get it from the
+marketplace:
 
 https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno
 
-When installed and successfully enabled the current installed Deno version
-should show up in the bottom status line. If for some reason this does not
-automatically happen you can enable the Deno extension via the command palette
-(Shift-Cmd-P) in VS Code and run `Deno: Enable`.
+Once installed and enabled, the currently installed Deno version should appear
+in the bottom status bar. If this does not happen automatically, you can enable
+the Deno extension via the command palette (Cmd+Shift+P on macOS, Ctrl+Shift+P
+on Windows/Linux) and run `Deno: Enable`.

--- a/docs/latest/advanced/troubleshooting.md
+++ b/docs/latest/advanced/troubleshooting.md
@@ -80,12 +80,14 @@ If your deployment doesn't boot, check the following things:
 
 If you see errors in VS Code like `Cannot find module 'fresh/runtime'` or see a
 lot of TypeScript errors, you likely have not installed the Deno extension. You
-can easily find it inside VS Code's extension browser or get it from the
-marketplace:
-
-https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno
+can easily find it inside VS Code's extension browser (identifier:
+`denoland.vscode-deno`) or get it from the
+[marketplace](https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno).
 
 Once installed and enabled, the currently installed Deno version should appear
 in the bottom status bar. If this does not happen automatically, you can enable
 the Deno extension via the command palette (Cmd+Shift+P on macOS, Ctrl+Shift+P
 on Windows/Linux) and run `Deno: Enable`.
+
+For detailed instructions see the official
+[Deno VS Code documentation](https://docs.deno.com/runtime/reference/vscode/)

--- a/docs/latest/advanced/troubleshooting.md
+++ b/docs/latest/advanced/troubleshooting.md
@@ -89,5 +89,5 @@ in the bottom status bar. If this does not happen automatically, you can enable
 the Deno extension via the command palette (Cmd+Shift+P on macOS, Ctrl+Shift+P
 on Windows/Linux) and run `Deno: Enable`.
 
-For detailed instructions see the official
-[Deno VS Code documentation](https://docs.deno.com/runtime/reference/vscode/)
+For detailed instructions, see the official
+[Deno VS Code documentation](https://docs.deno.com/runtime/reference/vscode/).


### PR DESCRIPTION
This adds a short blurb how to install the VS Code extension to the troubleshooting guide.

Possible concerns:
- maybe redundant as there are already official VS Code Deno docs
- could be shortened to just refer to the main docs or completely removed
