### PR TITLE
docs: troubleshoot deploy error message

### DIFF
--- a/docs/latest/advanced/troubleshooting.md
+++ b/docs/latest/advanced/troubleshooting.md
@@ -76,8 +76,8 @@ If your deployment doesn't boot, check the following things:
 2. Make sure that your entry points to the generated `_fresh/server.js` file
    instead of `main.ts`. The latter won't work with Fresh 2.
 
-Error messages like `ISOLATE_INTERNAL_FAILURE` may indicate the above issues,
-but can also be caused by other problems in your deployment configuration.
+Error messages like `ISOLATE_INTERNAL_FAILURE` may indicate above issues, but
+can also be caused by other problems in your deployment configuration.
 
 ## VS Code does not find packages and/or types
 

--- a/docs/latest/advanced/troubleshooting.md
+++ b/docs/latest/advanced/troubleshooting.md
@@ -76,8 +76,8 @@ If your deployment doesn't boot, check the following things:
 2. Make sure that your entry points to the generated `_fresh/server.js` file
    instead of `main.ts`. The latter won't work with Fresh 2.
 
-Error messages like `ISOLATE_INTERNAL_FAILURE` may indicate these issues, but
-can also be caused by other problems in your deployment configuration.
+Error messages like `ISOLATE_INTERNAL_FAILURE` may indicate the above issues,
+but can also be caused by other problems in your deployment configuration.
 
 ## VS Code does not find packages and/or types
 

--- a/docs/latest/advanced/troubleshooting.md
+++ b/docs/latest/advanced/troubleshooting.md
@@ -76,6 +76,9 @@ If your deployment doesn't boot, check the following things:
 2. Make sure that your entry points to the generated `_fresh/server.js` file
    instead of `main.ts`. The latter won't work with Fresh 2.
 
+Error messages like `ISOLATE_INTERNAL_FAILURE` may indicate these issues, but
+can also be caused by other problems in your deployment configuration.
+
 ## VS Code does not find packages and/or types
 
 If you see errors in VS Code like `Cannot find module 'fresh/runtime'` or see a


### PR DESCRIPTION
This adds one sentence to the "My deployment won't start" section mentioning the common `ISOLATE_INTERNAL_FAILURE` error message, so it can get found via search.

See also discussion in Discord -> https://discord.com/channels/684898665143206084/1422792167797166121