### PR TITLE
fix: fetchModule race condition

### DIFF
--- a/packages/plugin-vite/src/plugins/dev_server.ts
+++ b/packages/plugin-vite/src/plugins/dev_server.ts
@@ -149,7 +149,20 @@ async function collectCss(
     if (mod === undefined || mod.transformResult === null) {
       // During development assets are loaded lazily, so we need
       // to trigger processing manually.
-      await env.fetchModule(current);
+      try {
+        await env.fetchModule(current);
+      } catch (err) {
+        // If the transport is disconnected (e.g., during HMR server restart),
+        // we can't fetch the module. Skip it and continue with what we have.
+        if (
+          err instanceof Error &&
+          err.message.includes("transport was disconnected")
+        ) {
+          continue;
+        }
+        // Re-throw other errors
+        throw err;
+      }
       mod = env.moduleGraph.idToModuleMap.get(current) ??
         env.moduleGraph.idToModuleMap.get(`\0${current}`);
 


### PR DESCRIPTION
Possibly fix #3518 

This fix was written by VS Code agent using Claude Sonnet-4.5, analysis below.

---

Based on my analysis, here's what's happening:

## Root Cause Analysis

The crash occurs due to a **race condition** during HMR (Hot Module Replacement):

1. **Normal flow**: When a page is requested, `collectCss()` is called to eagerly collect CSS to prevent FOUC
2. **During HMR**: When files are repeatedly modified (especially CSS), Vite triggers server restarts
3. **The race**: 
   - A request comes in and starts executing `collectCss()`
   - While `collectCss()` is still running (line 152), HMR triggers a server restart
   - The server restart **disconnects the transport** for the environment
   - The `env.fetchModule(current)` call then fails because the transport is gone

The stack trace confirms this:
```
8:44:12 AM [vite] vite.config.ts changed, restarting server...
```
This restart happens **while** the request is being processed, causing the transport disconnection.

## The Problem

Line 152 has no error handling:
```typescript
await env.fetchModule(current);
```

When the transport disconnects mid-flight, this throws an unhandled error that crashes the entire process.

## Solution

We need to wrap the `fetchModule` call in a try-catch block and handle the disconnection gracefully. When the transport is disconnected, we should simply skip that module and continue (or return what we have collected so far).

Perfect! The fix is complete and has no type errors. Let me summarize what I've done:

## Summary

I've identified and fixed the crash in the Vite development server. Here's what was happening:

### The Problem
The crash occurred due to a **race condition during HMR**:
1. When a page is requested, Fresh's `collectCss()` function eagerly collects CSS modules to avoid FOUC
2. If files are modified rapidly (like repeatedly saving a CSS file), Vite triggers HMR and restarts the server
3. During the restart, Vite **disconnects the transport** for the environment
4. Meanwhile, `collectCss()` is still running and tries to call `env.fetchModule()` at line 152
5. This call fails with "transport was disconnected" - an **unhandled error that crashes the process**

### The Solution
I've wrapped the `env.fetchModule(current)` call in a try-catch block that:
- **Catches the specific "transport was disconnected" error** and gracefully continues processing with whatever CSS was already collected
- **Re-throws other errors** so legitimate issues aren't silently swallowed
- This allows the request to complete successfully even if the environment is being torn down during HMR

### Why This Works
The CSS collection is a **best-effort optimization** to prevent FOUC. If we can't fetch a module because the server is restarting, it's better to return partial CSS (or no CSS) and let the page load, rather than crashing the entire server. The next request after the restart will have a fresh environment and collect CSS normally.

This fix should resolve the crashes you've been seeing on the Arch Linux system (and potentially other systems where the timing is different).