### PR TITLE
test(init): fix address in use

### DIFF
--- a/packages/init/src/init_test.ts
+++ b/packages/init/src/init_test.ts
@@ -255,7 +255,7 @@ Deno.test("init - can start built project", async () => {
   }).output();
 
   await withChildProcessServer(
-    { cwd: dir, env: { PORT: "0" }, args: ["task", "start"] },
+    { cwd: dir, args: ["serve", "-A", "--port", "0", "_fresh/server.js"] },
     async (address) => {
       await withBrowser(async (page) => {
         await page.goto(address);
@@ -338,7 +338,7 @@ Deno.test.ignore("init - vite build", async () => {
   }).output();
 
   await withChildProcessServer(
-    { cwd: dir, env: { PORT: "0" }, args: ["task", "start"] },
+    { cwd: dir, args: ["serve", "-A", "--port", "0", "_fresh/server.js"] },
     async (address) => {
       await withBrowser(async (page) => {
         await page.goto(address);


### PR DESCRIPTION
Reverting back to the old init script also re-introduced the "address in use" problem.

This does not have any effect: `env: { PORT: "0" }`

Adding arguments to `deno task start` also have no effect.

The only solution I can come up with is to ignore the task and call `deno serve` with proper arguments directly for the build tests.

