### PR TITLE
feat: support `deno create` for project initialization

### DIFF
--- a/packages/init/deno.json
+++ b/packages/init/deno.json
@@ -2,7 +2,10 @@
   "name": "@fresh/init",
   "version": "2.3.0",
   "license": "MIT",
-  "exports": "./src/mod.ts",
+  "exports": {
+    ".": "./src/mod.ts",
+    "./create": "./src/create.ts"
+  },
   "exclude": ["**/tmp/*"],
   "publish": {
     "include": [

--- a/packages/init/src/create.ts
+++ b/packages/init/src/create.ts
@@ -2,12 +2,6 @@ import { parseArgs } from "@std/cli/parse-args";
 import { initProject } from "./init.ts";
 import { InitError } from "./init.ts";
 
-// deno-lint-ignore no-console
-console.warn(
-  "\x1b[33m%s\x1b[0m",
-  `Warning: "deno run -Ar jsr:@fresh/init" is deprecated. Use "deno create @fresh/init" instead.`,
-);
-
 const flags = parseArgs(Deno.args, {
   boolean: ["force", "tailwind", "vscode", "docker", "help", "builder"],
   default: {


### PR DESCRIPTION
## Summary
- Add a `./create` export to `@fresh/init` so users can scaffold projects with `deno create @fresh/init` (Deno 2.7+)
- The old `deno run -Ar jsr:@fresh/init` continues to work but now shows a deprecation warning

**New way (Deno 2.7+):**
```sh
deno create @fresh/init
```

**Old way (still works, with warning):**
```sh
deno run -Ar jsr:@fresh/init
```

## Test plan
- [x] `deno lint` and `deno fmt` clean
- [ ] `deno create @fresh/init` scaffolds a project correctly (requires Deno 2.7+)
- [ ] `deno run -Ar jsr:@fresh/init` still works and shows deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)