### PR TITLE
feat: warn on outdated Deno version in dev server

### DIFF
--- a/packages/fresh/src/app.ts
+++ b/packages/fresh/src/app.ts
@@ -2,6 +2,7 @@ import { trace } from "@opentelemetry/api";
 
 import { DENO_DEPLOYMENT_ID } from "@fresh/build-id";
 import * as colors from "@std/fmt/colors";
+import * as semver from "@std/semver";
 import type { MaybeLazyMiddleware, Middleware } from "./middlewares/mod.ts";
 import { Context } from "./context.ts";
 import { mergePath, type Method, UrlPatternRouter } from "./router.ts";
@@ -61,6 +62,8 @@ const DEFAULT_ERROR_HANDLER = async <State>(ctx: Context<State>) => {
   return new Response("Internal server error", { status: 500 });
 };
 
+const MIN_DENO_VERSION = "2.1.0";
+
 export type ListenOptions =
   & Partial<
     Deno.ServeTcpOptions & Deno.TlsCertifiedKeyPem
@@ -115,6 +118,31 @@ export function createOnListen(
       const remoteAddress = colors.cyan(options.remoteAddress);
       // deno-lint-ignore no-console
       console.log(`    ${remoteLabel}  ${remoteAddress}\n`);
+    }
+
+    // Warn if Deno version is outdated
+    try {
+      if (
+        semver.lessThan(
+          semver.parse(Deno.version.deno),
+          semver.parse(MIN_DENO_VERSION),
+        )
+      ) {
+        // deno-lint-ignore no-console
+        console.log(
+          colors.yellow(
+            `    Warning: Deno ${MIN_DENO_VERSION}+ is recommended. You're on ${Deno.version.deno}.`,
+          ),
+        );
+        // deno-lint-ignore no-console
+        console.log(
+          colors.yellow("    To update, run: deno upgrade"),
+        );
+        // deno-lint-ignore no-console
+        console.log();
+      }
+    } catch {
+      // Ignore version parse errors
     }
   };
 }


### PR DESCRIPTION
## Summary
- Adds a Deno version check to the dev server startup banner
- Prints a yellow warning when running Deno < 2.1.0, with an upgrade command hint
- Helps users who get cryptic errors (e.g. `vite: command not found`, Wasm parse failures) due to outdated Deno

Closes #3489

## Test plan
- [ ] Run dev server with Deno >= 2.1.0 — no warning should appear
- [ ] Run dev server with Deno < 2.1.0 — yellow warning with `deno upgrade` hint should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)