### PR TITLE
feat: support trusted-types api

### DIFF
--- a/packages/fresh/src/runtime/client/partials.ts
+++ b/packages/fresh/src/runtime/client/partials.ts
@@ -24,6 +24,29 @@ import type { PartialStateJson } from "../server/preact_hooks.ts";
 import { parse } from "../../jsonify/parse.ts";
 import { INTERNAL_PREFIX, PARTIAL_SEARCH_PARAM } from "../../constants.ts";
 
+type FreshTrustedTypes = { createHTML(s: string): string };
+type TrustedTypesWindow = {
+  trustedTypes?: {
+    createPolicy(name: string, v: FreshTrustedTypes): FreshTrustedTypes;
+  };
+};
+
+const freshTrustedTypes: FreshTrustedTypes = (() => {
+  const noop = { createHTML: (s: string) => s };
+  const window = globalThis as TrustedTypesWindow;
+  if (!window.trustedTypes) return noop;
+  try {
+    return window.trustedTypes.createPolicy(
+      "fresh-partials",
+      {
+        createHTML: (s: string) => s,
+      },
+    );
+  } catch (_e) {
+    return noop;
+  }
+})();
+
 export const PARTIAL_ATTR = "f-partial";
 
 class NoPartialsError extends Error {}
@@ -402,7 +425,10 @@ export async function applyPartials(res: Response): Promise<void> {
   const id = res.headers.get("X-Fresh-Id");
 
   const resText = await res.text();
-  const doc = new DOMParser().parseFromString(resText, "text/html") as Document;
+  const doc = new DOMParser().parseFromString(
+    freshTrustedTypes.createHTML(resText),
+    "text/html",
+  ) as Document;
 
   const state = doc.querySelector(`#__FRSH_STATE_${id}`);
   let allProps: DeserializedProps = [];


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API

I have only encountered only place where fresh uses untrusted input, and while this might be suboptimal, I do not think server-side untrusted input handling is actionable anyway.

I have not added trusted types policy to csp() midleware, as it might vary depending on the packages used, but with this change any user of fresh can configure it on its own. E.g https://delta.rocks has the following CSP, strictest possible for fresh:

```typescript
csp({
    useNonce: true,
    csp: [
      "script-src 'self' 'unsafe-inline'",
      "style-src 'self' 'unsafe-inline'",
      "require-trusted-types-for 'script'",
      // webpack policy is created by freshpack: trustedTypes.policyName = "webpack"
      //     for webpack own runtime script imports
      // fresh-partials used for fresh own partial loading
      "trusted-types webpack fresh-partials",
      "img-src 'self' data:",
      "font-src 'self'",
      "connect-src 'self'",
      "base-uri 'self'",
      "frame-ancestors 'none'",
    ],
  })
  ```
  
While trying to test, I have encountered that `@astral/astral` triggers trusted types violation on its own by default, but was unable to to find the problem here yet
  
Edit: Actually, for delta.rocks I have added a couple of more items here due to wasm usage and injected HTML for documentation for example, but the rest is the same