### PR TITLE
fix: inject client entry on islands-free pages for HMR

### DIFF
--- a/packages/fresh/src/build_cache.ts
+++ b/packages/fresh/src/build_cache.ts
@@ -17,6 +17,12 @@ export interface FileSnapshot {
 export interface BuildSnapshot<State> {
   version: string;
   clientEntry: string;
+  /**
+   * Pathname for an HMR-only client entry. When defined, the SSR runtime
+   * always emits the boot script so HMR listeners attach to pages that
+   * have no islands. Undefined outside of dev.
+   */
+  hmrClientEntry?: string;
   fsRoutes: FsRouteFile<State>[];
   staticFiles: Map<string, FileSnapshot>;
   islands: ServerIslandRegistry;
@@ -51,6 +57,7 @@ export class ProdBuildCache<State> implements BuildCache<State> {
   #snapshot: BuildSnapshot<State>;
   islandRegistry: ServerIslandRegistry;
   clientEntry: string;
+  hmrClientEntry: string | undefined;
   features = { errorOverlay: false };
 
   constructor(public root: string, snapshot: BuildSnapshot<State>) {
@@ -58,6 +65,7 @@ export class ProdBuildCache<State> implements BuildCache<State> {
     this.#snapshot = snapshot;
     this.islandRegistry = snapshot.islands;
     this.clientEntry = snapshot.clientEntry;
+    this.hmrClientEntry = snapshot.hmrClientEntry;
   }
 
   getEntryAssets(): string[] {

--- a/packages/fresh/src/build_cache.ts
+++ b/packages/fresh/src/build_cache.ts
@@ -18,9 +18,9 @@ export interface BuildSnapshot<State> {
   version: string;
   clientEntry: string;
   /**
-   * Pathname for an HMR-only client entry. When defined, the SSR runtime
-   * always emits the boot script so HMR listeners attach to pages that
-   * have no islands. Undefined outside of dev.
+   * When defined, forces the boot script to be emitted in dev so HMR
+   * listeners attach even on island-free pages. The value itself is
+   * currently unused — only its presence matters. Undefined outside of dev.
    */
   hmrClientEntry?: string;
   fsRoutes: FsRouteFile<State>[];

--- a/packages/fresh/src/dev/dev_build_cache.ts
+++ b/packages/fresh/src/dev/dev_build_cache.ts
@@ -458,6 +458,7 @@ export async function generateSnapshotServer(
     outDir: string;
     buildId: string;
     clientEntry: string;
+    hmrClientEntry?: string;
     islands: IslandModChunk[];
     // deno-lint-ignore no-explicit-any
     fsRoutesFiles: FsRouteFileNoMod<any>[];
@@ -524,12 +525,17 @@ export async function generateSnapshotServer(
   const entryAssets = options.entryAssets.map((url) => JSON.stringify(url))
     .join(",\n");
 
+  const hmrClientEntryDecl = options.hmrClientEntry !== undefined
+    ? `export const hmrClientEntry = ${JSON.stringify(options.hmrClientEntry)}`
+    : "";
+
   return `${EDIT_WARNING}
 import { IslandPreparer } from "fresh/internal";
 ${islandImports}
 ${fsRouteImports}
 
 export const clientEntry = ${JSON.stringify(options.clientEntry)}
+${hmrClientEntryDecl}
 export const version = ${JSON.stringify(options.buildId)}
 
 export const islands = new Map();

--- a/packages/fresh/src/runtime/client/dev_hmr.ts
+++ b/packages/fresh/src/runtime/client/dev_hmr.ts
@@ -3,7 +3,7 @@ import { IS_BROWSER } from "../shared.ts";
 let ws: WebSocket;
 let revision = 0;
 
-let reconnectTimer: number;
+let reconnectTimer: ReturnType<typeof setTimeout>;
 const backoff = [
   // Wait 100ms initially, because we could also be
   // disconnected because of a form submit.

--- a/packages/plugin-vite/src/plugins/server_snapshot.ts
+++ b/packages/plugin-vite/src/plugins/server_snapshot.ts
@@ -165,10 +165,18 @@ export function serverSnapshot(options: ResolvedFreshViteConfig): Plugin[] {
           const staticFiles: PendingStaticFile[] = [];
           let islandMods: IslandModChunk[] = [];
           let clientEntry = "/@id/fresh:client-entry";
+          let hmrClientEntry: string | undefined;
           let buildId = "";
           const entryAssets: string[] = [];
 
           if (isDev && server !== undefined) {
+            // The client entry hosts the HMR listener. Set hmrClientEntry so
+            // the SSR runtime always emits a boot script in dev, even when
+            // a page has zero islands. Without this, edits to islands-free
+            // routes never trigger a browser reload because the
+            // `fresh:reload` WebSocket listener is never attached.
+            hmrClientEntry = clientEntry;
+
             for (const id of islands.keys()) {
               const mod = server.environments.client.moduleGraph.getModuleById(
                 id,
@@ -380,6 +388,7 @@ export function serverSnapshot(options: ResolvedFreshViteConfig): Plugin[] {
             staticFiles,
             buildId,
             clientEntry,
+            hmrClientEntry,
             entryAssets,
             fsRoutesFiles: result.routes,
             islands: islandMods,

--- a/packages/plugin-vite/src/plugins/server_snapshot.ts
+++ b/packages/plugin-vite/src/plugins/server_snapshot.ts
@@ -170,11 +170,12 @@ export function serverSnapshot(options: ResolvedFreshViteConfig): Plugin[] {
           const entryAssets: string[] = [];
 
           if (isDev && server !== undefined) {
-            // The client entry hosts the HMR listener. Set hmrClientEntry so
-            // the SSR runtime always emits a boot script in dev, even when
-            // a page has zero islands. Without this, edits to islands-free
-            // routes never trigger a browser reload because the
-            // `fresh:reload` WebSocket listener is never attached.
+            // Set hmrClientEntry so the SSR runtime always emits a boot script
+            // in dev, even when a page has zero islands. Without this, edits
+            // to island-free routes never trigger a browser reload because the
+            // `fresh:reload` WebSocket listener is never attached. The value
+            // is used as a marker only — its presence is what matters, not
+            // what it points to.
             hmrClientEntry = clientEntry;
 
             for (const id of islands.keys()) {

--- a/packages/plugin-vite/tests/dev_server_test.ts
+++ b/packages/plugin-vite/tests/dev_server_test.ts
@@ -69,6 +69,23 @@ integrationTest("vite dev - starts without islands/ dir", async () => {
   });
 });
 
+// Issue: https://github.com/denoland/fresh/issues/3806
+// Pages without islands must still load the client entry in dev so the
+// HMR `fresh:reload` listener attaches and route edits trigger a refresh.
+integrationTest(
+  "vite dev - injects client entry on islands-free pages for HMR",
+  async () => {
+    const fixture = path.join(FIXTURE_DIR, "no_islands");
+    await withDevServer(fixture, async (address) => {
+      const res = await fetch(`${address}/`);
+      const text = await res.text();
+      expect(text).toContain("ok");
+      expect(text).toContain("/@id/fresh:client-entry");
+      expect(text).toMatch(/import\s*\{\s*boot\s*\}/);
+    });
+  },
+);
+
 integrationTest("vite dev - starts without routes/ dir", async () => {
   const fixture = path.join(FIXTURE_DIR, "no_routes");
   await withDevServer(fixture, async (address) => {


### PR DESCRIPTION
## Summary

Fixes denoland/fresh#3806: when a Fresh project has no islands, edits to
a route file in dev mode never refreshed the browser.

The dev server already broadcasts `fresh:reload` over Vite's WebSocket
when an SSR-only module changes (`packages/plugin-vite/src/plugins/dev_server.ts`),
but the listener for that event lives in `@fresh/plugin-vite/client`,
which is only loaded transitively via the client entry boot script. The
SSR runtime only emitted that boot script when the page had at least
one island or `hmrClientEntry` was defined. The Vite plugin never set
`hmrClientEntry`, so islands-free pages had no listener and edits were
silently dropped.

## Fix

Wire `hmrClientEntry` through the build snapshot so the SSR runtime
always emits the boot script in dev:

- Add `hmrClientEntry?: string` to `BuildSnapshot` and surface it on
  `ProdBuildCache` (used by the Vite snapshot loader).
- Have `generateSnapshotServer` emit a `hmrClientEntry` export when one
  is provided.
- Set `hmrClientEntry` to the client entry virtual id in the Vite
  plugin's `server_snapshot.ts` whenever the server is in dev mode.

This piggybacks on the existing FreshRuntimeScript branch that was
clearly written with this case in mind (note the existing comment:
\"Full-document boot: islands / partials / client nav, or Vite/HMR
dev\"); it just wasn't being triggered for the Vite plugin.

## Test plan

- [x] New regression test `vite dev - injects client entry on
      islands-free pages for HMR` in
      `packages/plugin-vite/tests/dev_server_test.ts` asserts the
      no-islands fixture's SSR response contains both
      `/@id/fresh:client-entry` and the `import { boot }` call.
- [x] `deno task ok` passes locally (613 tests passed, 0 failed).
- [x] Existing islands-related dev and build tests (`loads islands`,
      `partial island`, `nested islands`, `remote island`,
      `vite build - *`) all still pass.

Closes bartlomieju/orchid-inbox#85