### PR TITLE
chore: from web `setTimeout` to Node.js `setTimeout`

### DIFF
--- a/packages/fresh/src/runtime/client/dev_hmr.ts
+++ b/packages/fresh/src/runtime/client/dev_hmr.ts
@@ -3,7 +3,7 @@ import { IS_BROWSER } from "../shared.ts";
 let ws: WebSocket;
 let revision = 0;
 
-let reconnectTimer: number;
+let reconnectTimer: ReturnType<typeof setTimeout>;
 const backoff = [
   // Wait 100ms initially, because we could also be
   // disconnected because of a form submit.


### PR DESCRIPTION
The CI is broken due to the breaking change of `setTimeout` from Deno 2.8.