### PR TITLE
feat: allow skipping scrolling on partial navigation

### DIFF
--- a/packages/fresh/src/runtime/client/partials.ts
+++ b/packages/fresh/src/runtime/client/partials.ts
@@ -25,6 +25,7 @@ import { parse } from "../../jsonify/parse.ts";
 import { INTERNAL_PREFIX, PARTIAL_SEARCH_PARAM } from "../../constants.ts";
 
 export const PARTIAL_ATTR = "f-partial";
+export const PARTIAL_NO_SCROLL_ATTR = "f-dont-scroll";
 
 class NoPartialsError extends Error {}
 
@@ -170,7 +171,9 @@ document.addEventListener("click", async (e) => {
           await fetchPartials(nextUrl, partialUrl, true);
           updateLinks(nextUrl);
         });
-        scrollTo({ left: 0, top: 0, behavior: "instant" });
+        if (!el.hasAttribute(PARTIAL_NO_SCROLL_ATTR)) {
+          scrollTo({ left: 0, top: 0, behavior: "instant" });
+        }
       } finally {
         if (indicator !== undefined) {
           indicator.value = false;


### PR DESCRIPTION
When using partials to update a small portion of the page, scroll might be undesired

For example, at https://git.delta.rocks/r/jrsonnet/-/rev/7bd5bbd0756a11586a0684061e14507b6c0f7d14/change (A git repo viewer project built with fresh, ignore the code that is being displayed inside)

Go to the bottom, to the diff for file `crates/jrsonnet-evaluator/src/tla.rs`

<img width="1840" height="496" alt="image" src="https://github.com/user-attachments/assets/006add2b-cf88-4378-a8ff-c69e44df836a" />

Here in the top right corner for this file you can change "perspective" between diff/before/after/both, partials are used to only update perspective for this file, and having it scroll back to top is very undesired. The site already has this patch applied to make it behave as intended, the attribute can be dropped from html to see how it should not behave.

<img width="731" height="420" alt="image" src="https://github.com/user-attachments/assets/c357b542-92f6-4aed-8f8a-e4dd92f6fc04" />