### PR TITLE
fix: type reconnectTimer as setTimeout return value

### DIFF
--- a/packages/fresh/src/runtime/client/dev_hmr.ts
+++ b/packages/fresh/src/runtime/client/dev_hmr.ts
@@ -3,7 +3,7 @@ import { IS_BROWSER } from "../shared.ts";
 let ws: WebSocket;
 let revision = 0;
 
-let reconnectTimer: number;
+let reconnectTimer: ReturnType<typeof setTimeout>;
 const backoff = [
   // Wait 100ms initially, because we could also be
   // disconnected because of a form submit.


### PR DESCRIPTION
The dev HMR client declares `reconnectTimer` as `number`, but the runtime
type of `setTimeout`'s return value is a `Timeout` object, so `deno check`
now fails with `TS2322: Type 'Timeout' is not assignable to type 'number'`
at `packages/fresh/src/runtime/client/dev_hmr.ts:32`. This is blocking
every PR's type check job. Switching the annotation to
`ReturnType<typeof setTimeout>` keeps the declaration accurate without
committing to a specific runtime's timer type.