### PR TITLE
docs: websockets do not work with vite dev server pre-Deno 2.8 and Fresh 2.4

### DIFF
--- a/docs/latest/advanced/websockets.md
+++ b/docs/latest/advanced/websockets.md
@@ -6,6 +6,24 @@ description: |
 Fresh provides built-in helpers for upgrading HTTP connections to WebSockets.
 There are two main approaches depending on your use case.
 
+> [warn]: WebSocket upgrades do not work under the Vite dev server (`deno task
+> dev`). Both `app.ws()` and `ctx.upgrade()` rely on `Deno.upgradeWebSocket()`,
+> which requires Deno's native HTTP server to be handling the request. Vite
+> serves requests through a Node HTTP server and forwards them to Fresh as
+> synthesized `Request` objects, so the 101 upgrade response cannot be
+> completed and the `open` handler is never invoked.
+>
+> To test WebSocket endpoints locally, run a production-style build:
+>
+> ```sh
+> deno task build && deno task start
+> ```
+>
+> This runs `deno serve` directly, so `Deno.upgradeWebSocket()` works as
+> expected. If you need WebSockets during iterative development, run a
+> separate Deno entry point (e.g. `deno serve -A main.ts`) alongside Vite, or
+> host the WebSocket server as a sidecar on its own port.
+
 ## Quick start with `app.ws()`
 
 The simplest way to add a WebSocket endpoint:

--- a/docs/latest/advanced/websockets.md
+++ b/docs/latest/advanced/websockets.md
@@ -6,23 +6,23 @@ description: |
 Fresh provides built-in helpers for upgrading HTTP connections to WebSockets.
 There are two main approaches depending on your use case.
 
-> [warn]: WebSocket upgrades do not work under the Vite dev server (`deno task
-> dev`). Both `app.ws()` and `ctx.upgrade()` rely on `Deno.upgradeWebSocket()`,
-> which requires Deno's native HTTP server to be handling the request. Vite
-> serves requests through a Node HTTP server and forwards them to Fresh as
-> synthesized `Request` objects, so the 101 upgrade response cannot be
-> completed and the `open` handler is never invoked.
+> [info]: WebSocket upgrades under the Vite dev server (`deno task dev`) require
+> **Fresh 2.4+** and **Deno 2.8+**. On older versions `Deno.upgradeWebSocket()`
+> cannot complete the 101 handshake for requests Vite forwards from its Node
+> HTTP server, so `ctx.upgrade()` and `app.ws()` silently hang and the `open`
+> handler is never invoked.
 >
-> To test WebSocket endpoints locally, run a production-style build:
+> If you're stuck on an older Deno or Fresh, exercise WebSocket endpoints with a
+> production-style build instead:
 >
 > ```sh
 > deno task build && deno task start
 > ```
 >
 > This runs `deno serve` directly, so `Deno.upgradeWebSocket()` works as
-> expected. If you need WebSockets during iterative development, run a
-> separate Deno entry point (e.g. `deno serve -A main.ts`) alongside Vite, or
-> host the WebSocket server as a sidecar on its own port.
+> expected. Alternatively, run a separate Deno entry point (e.g.
+> `deno serve -A main.ts`) alongside Vite, or host the WebSocket server as a
+> sidecar on its own port.
 
 ## Quick start with `app.ws()`
 


### PR DESCRIPTION
Updating the docs to reflect the fact that upgrading websocket requests isn't currently supported by the vite dev server.

This cost me some time as there isn't any warning in the console on the server, the upgrade request merely hangs. Perhaps that could be fixed as well, but this update to the docs (while verbose) would document the behavior.