### PR TITLE
docs: recommend --lock-write over manual lockfile editing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,11 +52,15 @@ with workspace members in `packages/*` and `www/`.
 
 ### Lockfile quirks
 
-The lockfile contains remote specifiers pointing to `refs/heads/main` (e.g.
-`raw.githubusercontent.com/.../refs/heads/main/...`). These hashes go stale when
-upstream pushes. When that happens, manually update the hash in `deno.lock`
-since `deno cache --reload` cannot fix it (see
-https://github.com/denoland/deno/issues/32991).
+The lockfile may contain unpinned remote specifiers whose content can change
+(known limitation, see https://github.com/denoland/deno/issues/32991). If
+`deno install` fails with an integrity check error, run:
+
+    deno install --lock-write
+
+This tells Deno to accept the new content and update the lockfile. The
+`--reload` flag alone is not sufficient here because it re-fetches content but
+still validates against the existing lockfile integrity.
 
 ## Architecture
 


### PR DESCRIPTION
### Problem

When the lockfile contains unpinned remote specifiers (e.g. efs/heads/main), upstream pushes can cause deno install to fail with an integrity check error. The current AGENTS.md instructs contributors to **manually edit the hash** in deno.lock, which is error-prone and unnecessary.

### Root cause

denoland/deno#32991 was closed as working as intended — Deno's integrity check is correct. deno cache --reload re-fetches content but still validates against the old integrity, so it fails. The proper approach is --lock-write, which tells Deno to accept new content and update the lockfile.

### Solution

Replace the manual hash editing instruction in AGENTS.md with the deno install --lock-write command, which is Deno's official recommended fix.