### PR TITLE
fix: use namespace imports for packages losing default exports on canary

### DIFF
--- a/packages/plugin-tailwindcss/src/mod.ts
+++ b/packages/plugin-tailwindcss/src/mod.ts
@@ -1,5 +1,5 @@
 import type { Builder } from "fresh/dev";
-import twPostcss from "@tailwindcss/postcss";
+import * as twPostcss from "@tailwindcss/postcss";
 import postcss from "postcss";
 import type { TailwindPluginOptions } from "./types.ts";
 
@@ -11,7 +11,7 @@ export function tailwind(
   options: TailwindPluginOptions = {},
 ): void {
   const { exclude, ...tailwindOptions } = options;
-  const instance = postcss(twPostcss({
+  const instance = postcss(twPostcss.default({
     optimize: builder.config.mode === "production",
     ...tailwindOptions,
   }));

--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -6,7 +6,7 @@ import {
 } from "./utils.ts";
 import { deno } from "./plugins/deno.ts";
 
-import prefresh from "@prefresh/vite";
+import * as prefresh from "@prefresh/vite";
 import { serverEntryPlugin } from "./plugins/server_entry.ts";
 import { clientEntryPlugin } from "./plugins/client_entry.ts";
 import { devServer } from "./plugins/dev_server.ts";
@@ -256,7 +256,7 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
     ...clientSnapshot(fConfig),
     buildIdPlugin(),
     ...devServer(fConfig),
-    prefresh({
+    prefresh.default({
       include: [/\.[cm]?[tj]sx?$/],
       exclude: [/node_modules/, /[\\/]+deno[\\/]+npm[\\/]+/],
       parserPlugins: [


### PR DESCRIPTION
﻿### Problem

Deno canary CI fails with TS1192: Module has no default export for two npm packages:

| File | Import | Error |
|---|---|---|
| packages/plugin-tailwindcss/src/mod.ts | import twPostcss from "@tailwindcss/postcss" | TS1192 |
| packages/plugin-vite/src/mod.ts | import prefresh from "@prefresh/vite" | TS1192 |

The default exports exist at runtime but their .d.ts type declarations lose
the default export signature on canary builds.

### Changes

**packages/plugin-tailwindcss/src/mod.ts**
- import twPostcss from "@tailwindcss/postcss" → import * as twPostcss from "@tailwindcss/postcss"
- 	wPostcss({...}) → 	wPostcss.default({...})

**packages/plugin-vite/src/mod.ts**
- import prefresh from "@prefresh/vite" → import * as prefresh from "@prefresh/vite"
- prefresh({...}) → prefresh.default({...})

### Verification

deno task check:types passes on stable Deno v2.7.14.
