### PR TITLE
docs: add JSDoc categories to @fresh/core public API

### DIFF
--- a/packages/fresh/src/mod.ts
+++ b/packages/fresh/src/mod.ts
@@ -1,5 +1,44 @@
+/**
+ * @module
+ *
+ * Fresh is a next-gen web framework for Deno, built on
+ * [Preact](https://preactjs.com). It uses an island-based
+ * client hydration model to ship zero JavaScript to the
+ * client by default, with file-system routing and TypeScript
+ * support out of the box.
+ *
+ * @example Quick start
+ * ```ts
+ * import { App, staticFiles } from "@fresh/core";
+ *
+ * const app = new App()
+ *   .use(staticFiles())
+ *   .fsRoutes();
+ *
+ * Deno.serve(app.handler());
+ * ```
+ */
+
+// -- Core -----------------------------------------------------------
+/** @category Core */
 export { App, type ListenOptions } from "./app.ts";
-export { trailingSlashes } from "./middlewares/trailing_slashes.ts";
+/** @category Core */
+export type {
+  Context,
+  FreshContext,
+  Island,
+  WebSocketHandlers,
+  WebSocketUpgradeOptions,
+} from "./context.ts";
+/** @category Core */
+export type { FreshConfig, ResolvedFreshConfig } from "./config.ts";
+/** @category Core */
+export { HttpError } from "./error.ts";
+/** @category Core */
+export type { PageProps } from "./render.ts";
+
+// -- Routing --------------------------------------------------------
+/** @category Routing */
 export {
   type HandlerByMethod,
   type HandlerFn,
@@ -8,26 +47,29 @@ export {
   type RouteData,
   type RouteHandler,
 } from "./handlers.ts";
+/** @category Routing */
 export type { LayoutConfig, Lazy, MaybeLazy, RouteConfig } from "./types.ts";
+/** @category Routing */
+export type { Method } from "./router.ts";
+/** @category Routing */
+export { createDefine, type Define } from "./define.ts";
+
+// -- Middleware -----------------------------------------------------
+/** @category Middleware */
 export type { Middleware, MiddlewareFn } from "./middlewares/mod.ts";
+/** @category Middleware */
+export { trailingSlashes } from "./middlewares/trailing_slashes.ts";
+/** @category Middleware */
 export { staticFiles } from "./middlewares/static_files.ts";
+/** @category Middleware */
 export { csrf, type CsrfOptions } from "./middlewares/csrf.ts";
+/** @category Middleware */
 export { cors, type CORSOptions } from "./middlewares/cors.ts";
+/** @category Middleware */
 export {
   ipFilter,
   type IpFilterOptions,
   type IpFilterRules,
 } from "./middlewares/ip_filter.ts";
+/** @category Middleware */
 export { csp, type CSPOptions } from "./middlewares/csp.ts";
-export type { FreshConfig, ResolvedFreshConfig } from "./config.ts";
-export type {
-  Context,
-  FreshContext,
-  Island,
-  WebSocketHandlers,
-  WebSocketUpgradeOptions,
-} from "./context.ts";
-export { createDefine, type Define } from "./define.ts";
-export type { Method } from "./router.ts";
-export { HttpError } from "./error.ts";
-export type { PageProps } from "./render.ts";


### PR DESCRIPTION
﻿### What

Adds @module JSDoc block and @category tags to the @fresh/core public API entry point (packages/fresh/src/mod.ts).

All 30+ public exports are grouped into three categories:

| Category | Exports |
|---|---|
| **Core** | App, ListenOptions, Context, FreshContext, Island, WebSocketHandlers, WebSocketUpgradeOptions, FreshConfig, ResolvedFreshConfig, HttpError, PageProps |
| **Routing** | page, HandlerFn, HandlerByMethod, PageResponse, RouteData, RouteHandler, LayoutConfig, Lazy, MaybeLazy, RouteConfig, Method, createDefine, Define |
| **Middleware** | Middleware, MiddlewareFn, 	railingSlashes, staticFiles, csrf/CsrfOptions, cors/CORSOptions, ipFilter/IpFilterOptions/IpFilterRules, csp/CSPOptions |

### Why

JSR doc score for @fresh/core reports poorly documented public symbols. This change provides structured navigation and improves discoverability without any runtime changes.

Refs #3596

### Verification

Docs-only change. deno task check:types passes. No runtime behavior affected.
