### PR TITLE
docs: add JSDoc categories to @fresh/plugin-vite public API

### DIFF
--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -1,3 +1,24 @@
+/**
+ * @module
+ *
+ * The official Vite plugin for the
+ * [Fresh](https://usefresh.dev) web framework for Deno.
+ *
+ * This plugin uses Vite's Environment API to provide dual
+ * client/server builds, HMR, island-based code splitting,
+ * and Deno-native module resolution for Fresh applications.
+ *
+ * @example vite.config.ts
+ * ```ts
+ * import { defineConfig } from "vite";
+ * import { fresh } from "@fresh/plugin-vite";
+ *
+ * export default defineConfig({
+ *   plugins: [fresh()],
+ * });
+ * ```
+ */
+
 import type { Plugin } from "vite";
 import {
   type FreshViteConfig,
@@ -27,7 +48,11 @@ import { isBuiltin } from "node:module";
 import { load as stdLoadEnv } from "@std/dotenv";
 import path from "node:path";
 
+// -- Types ----------------------------------------------------------
+
+/** @category Types */
 export type { FreshViteConfig };
+/** @category Types */
 export type {
   ImportCheck,
   ImportCheckDiagnostic,
@@ -41,6 +66,7 @@ export type {
  *
  * @param config Fresh config options
  * @returns Vite plugin with Fresh support
+ * @category Plugin
  *
  * @example Basic usage
  * ```ts vite.config.ts


### PR DESCRIPTION
﻿### What

Adds @module JSDoc block and @category tags to @fresh/plugin-vite (packages/plugin-vite/src/mod.ts).

| Category | Exports |
|---|---|
| **Plugin** | resh() |
| **Types** | FreshViteConfig, ImportCheck, ImportCheckDiagnostic |

The resh() function already had JSDoc — only added @category Plugin.

### Why

JSR doc score for @fresh/plugin-vite reports poorly documented public symbols. This change adds structured navigation via @category grouping and a package-level @module description.

Refs #3596

### Verification

Docs-only. deno task check:types passes. No runtime behavior affected.
