### PR TITLE
fix: replace --allow-all with scoped permissions on homepage

### DIFF
--- a/www/components/homepage/Hero.tsx
+++ b/www/components/homepage/Hero.tsx
@@ -19,7 +19,7 @@ export function Hero() {
             </p>
             <div class="mt-12 flex flex-wrap justify-center items-stretch md:justify-start gap-4">
               <FancyLink href="/docs/getting-started">Get started</FancyLink>
-              <CopyArea code={`deno run -Ar jsr:@fresh/init`} />
+              <CopyArea code={`deno run -RW --allow-net=jsr.io --allow-run=deno -r jsr:@fresh/init`} />
             </div>
           </div>
           <div class="md:col-span-2 flex justify-center items-end pb-8 md:pb-32">

--- a/www/components/homepage/Hero.tsx
+++ b/www/components/homepage/Hero.tsx
@@ -19,7 +19,9 @@ export function Hero() {
             </p>
             <div class="mt-12 flex flex-wrap justify-center items-stretch md:justify-start gap-4">
               <FancyLink href="/docs/getting-started">Get started</FancyLink>
-              <CopyArea code={`deno run -RW --allow-net=jsr.io --allow-run=deno -r jsr:@fresh/init`} />
+              <CopyArea
+                code={`deno run -RW --allow-net=jsr.io --allow-run=deno -r jsr:@fresh/init`}
+              />
             </div>
           </div>
           <div class="md:col-span-2 flex justify-center items-end pb-8 md:pb-32">


### PR DESCRIPTION
Replace \deno run -Ar\ with \deno run -RW --allow-net=jsr.io --allow-run=deno -r\ on the homepage quick-start command. Limits network access to JSR only and removes --allow-env/--allow-sys/--allow-ffi permissions.\n\nCloses #3838