### PR TITLE
docs: update Jaeger docker image from EOL v1 to current v2

### DIFF
--- a/docs/latest/advanced/opentelemetry.md
+++ b/docs/latest/advanced/opentelemetry.md
@@ -114,7 +114,7 @@ with Docker:
 docker run -d --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
-  jaegertracing/all-in-one:latest
+  cr.jaegertracing.io/jaegertracing/jaeger:latest
 ```
 
 Then start your Fresh app pointing at the Jaeger collector:


### PR DESCRIPTION
The Jaeger v1 image \jaegertracing/all-in-one\ reached end-of-life on December 31st, 2025. Replaced with the current v2 image \cr.jaegertracing.io/jaegertracing/jaeger\.\n\nCloses #3833