### PR TITLE
docs: fix stale API reference link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [Documentation](#-documentation) | [Getting started](#-getting-started) |
-[API Reference](https://deno.land/x/fresh?doc)
+[API Reference](https://jsr.io/@fresh/core/doc)
 
 # fresh
 


### PR DESCRIPTION
The API reference link in README.md pointed to \https://deno.land/x/fresh?doc\ which serves Fresh 1.x docs. Fresh 2.x is published on JSR, so this updates the link to \https://jsr.io/@fresh/core/doc\.