### PR TITLE
docs: fix wrong API name define.handler -> define.handlers

### DIFF
--- a/docs/latest/advanced/define.md
+++ b/docs/latest/advanced/define.md
@@ -51,7 +51,7 @@ export const otherMiddleware = define.middleware((ctx) => {
 
 ## File routes
 
-The `define.*` helpers include a `define.handler()` and `define.page()` function
+The `define.*` helpers include a `define.handlers()` and `define.page()` function
 to make it easy for TypeScript to establish a relation between the two. That way
 you can pass data from the handler to the component in a type-safe way.
 


### PR DESCRIPTION
The define.md documentation described \define.handler()\ (singular) but the actual API in \packages/fresh/src/define.ts\ is \define.handlers()\ (plural).

The code example on the same page (line 59) already uses the correct name \define.handlers\. This PR fixes the descriptive text on line 54 to match.