### PR TITLE
fix: log update check failures via console.warn instead of silent swallow

### DIFF
--- a/packages/fresh/src/dev/builder.ts
+++ b/packages/fresh/src/dev/builder.ts
@@ -171,7 +171,7 @@ export class Builder<State = any> {
   ): Promise<void> {
     // Run update check in background
     updateCheck(UPDATE_INTERVAL).catch((e) =>
-      console.debug("Update check failed:", e),
+      console.warn("Update check failed:", e),
     );
 
     this.config.mode = "development";

--- a/packages/fresh/src/dev/builder.ts
+++ b/packages/fresh/src/dev/builder.ts
@@ -170,7 +170,9 @@ export class Builder<State = any> {
     options: ListenOptions = {},
   ): Promise<void> {
     // Run update check in background
-    updateCheck(UPDATE_INTERVAL).catch(() => {});
+    updateCheck(UPDATE_INTERVAL).catch((e) =>
+      console.debug("Update check failed:", e),
+    );
 
     this.config.mode = "development";
 

--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -223,7 +223,9 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
       },
       async configResolved(vConfig) {
         // Run update check in background
-        updateCheck(UPDATE_INTERVAL).catch(() => {});
+        updateCheck(UPDATE_INTERVAL).catch((e) =>
+          console.debug("Update check failed:", e),
+        );
 
         fConfig.islandsDir = pathWithRoot(fConfig.islandsDir, vConfig.root);
         fConfig.routeDir = pathWithRoot(fConfig.routeDir, vConfig.root);

--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -224,7 +224,7 @@ export function fresh(config?: FreshViteConfig): Plugin[] {
       async configResolved(vConfig) {
         // Run update check in background
         updateCheck(UPDATE_INTERVAL).catch((e) =>
-          console.debug("Update check failed:", e),
+          console.warn("Update check failed:", e),
         );
 
         fConfig.islandsDir = pathWithRoot(fConfig.islandsDir, vConfig.root);


### PR DESCRIPTION
The update check in both the esbuild builder (\packages/fresh/src/dev/builder.ts\) and Vite plugin (\packages/plugin-vite/src/mod.ts\) used \.catch(() => {})\ which silently discards all errors.

Network failures, parse errors, and timeouts during version checking were never surfaced to the developer, even in verbose/debug mode.

This PR logs failures via \console.debug\ so they appear in debug output without cluttering normal dev server logs.