### PR TITLE
fix: handle URI decode errors gracefully and clean up DiskBuildCache

### DIFF
--- a/packages/fresh/src/app.ts
+++ b/packages/fresh/src/app.ts
@@ -483,10 +483,6 @@ export class App<State> {
           );
         }
 
-        if (method === "HEAD") {
-          return new Response(null, result);
-        }
-
         return result;
       } catch (err) {
         ctx.error = err;

--- a/packages/fresh/src/app.ts
+++ b/packages/fresh/src/app.ts
@@ -483,6 +483,10 @@ export class App<State> {
           );
         }
 
+        if (method === "HEAD") {
+          return new Response(null, result);
+        }
+
         return result;
       } catch (err) {
         ctx.error = err;

--- a/packages/fresh/src/dev/dev_build_cache.ts
+++ b/packages/fresh/src/dev/dev_build_cache.ts
@@ -296,9 +296,8 @@ export class DiskBuildCache<State> implements DevBuildCache<State> {
     await Deno.writeFile(filePath, content);
   }
 
-  // deno-lint-ignore require-await
-  async readFile(_pathname: string): Promise<StaticFile | null> {
-    throw new Error("Not implemented in build mode");
+  readFile(_pathname: string): Promise<StaticFile | null> {
+    return Promise.reject(new Error("Not implemented in build mode"));
   }
 
   async prepare(): Promise<void> {

--- a/packages/fresh/src/router.ts
+++ b/packages/fresh/src/router.ts
@@ -174,7 +174,15 @@ export class UrlPatternRouter<T> implements Router<T> {
 
         // Decode matched params
         for (const [key, value] of Object.entries(match.pathname.groups)) {
-          result.params[key] = value === undefined ? "" : decodeURI(value);
+          if (value === undefined) {
+            result.params[key] = "";
+          } else {
+            try {
+              result.params[key] = decodeURI(value);
+            } catch {
+              result.params[key] = value;
+            }
+          }
         }
       }
 


### PR DESCRIPTION
Two fixes (HEAD body-stripping reverted — Deno does handle it, but FakeServer in tests doesn't):

1. **Malformed URI params**: \decodeURI()\ throws a URIError on malformed percent-encoding (e.g. %GG), causing an uncaught 500 Internal Server Error. Wrap in try/catch and fall back to the raw value.

2. **DiskBuildCache.readFile()**: Replace the \sync\ + \deno-lint-ignore require-await\ pattern with an explicit \Promise.reject()\, which is cleaner and signals the intentional not-implemented status.