### PR TITLE
chore: add description field to all package deno.json files

### DIFF
--- a/packages/build-id/deno.json
+++ b/packages/build-id/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@fresh/build-id",
   "version": "1.0.1",
+  "description": "Build and deployment ID generation for Fresh",
   "license": "MIT",
   "exports": {
     ".": "./mod.ts"

--- a/packages/examples/deno.json
+++ b/packages/examples/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@fresh/examples",
   "version": "1.0.1",
+  "description": "Example components for Fresh tests",
   "license": "MIT",
   "imports": {
     "fresh": "jsr:@fresh/core@^2.0.0",

--- a/packages/fresh/deno.json
+++ b/packages/fresh/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@fresh/core",
   "version": "2.3.3",
+  "description": "The next-gen web framework for Deno",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/init/deno.json
+++ b/packages/init/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@fresh/init",
   "version": "2.3.3",
+  "description": "Project scaffolding for Fresh",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/plugin-tailwindcss-v3/deno.json
+++ b/packages/plugin-tailwindcss-v3/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@fresh/plugin-tailwind-v3",
   "version": "1.1.0",
+  "description": "TailwindCSS v3 plugin for Fresh",
   "license": "MIT",
   "exports": "./src/mod.ts",
   "imports": {

--- a/packages/plugin-tailwindcss/deno.json
+++ b/packages/plugin-tailwindcss/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@fresh/plugin-tailwind",
   "version": "1.0.0",
+  "description": "TailwindCSS v4 plugin for Fresh",
   "license": "MIT",
   "exports": "./src/mod.ts"
 }

--- a/packages/plugin-vite/deno.json
+++ b/packages/plugin-vite/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@fresh/plugin-vite",
   "version": "1.1.2",
+  "description": "Vite integration plugin for Fresh",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/update/deno.json
+++ b/packages/update/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@fresh/update",
   "version": "2.3.3",
+  "description": "Automated Fresh 1.x to 2.x migration tool",
   "license": "MIT",
   "exports": "./src/mod.ts",
   "exclude": ["**/tmp/*"],


### PR DESCRIPTION
All 8 packages under \packages/\ were missing the \description\ field in their \deno.json\, leaving JSR package pages with blank descriptions.

| Package | Description |
|---|---|
| \@fresh/core\ | The next-gen web framework for Deno |
| \@fresh/plugin-vite\ | Vite integration plugin for Fresh |
| \@fresh/init\ | Project scaffolding for Fresh |
| \@fresh/update\ | Automated Fresh 1.x to 2.x migration tool |
| \@fresh/build-id\ | Build and deployment ID generation for Fresh |
| \@fresh/plugin-tailwind\ | TailwindCSS v4 plugin for Fresh |
| \@fresh/plugin-tailwind-v3\ | TailwindCSS v3 plugin for Fresh |
| \@fresh/examples\ | Example components for Fresh tests |