### PR TITLE
temp fix: suppress TS1192 for CJS-type npm packages on TS 6.0 / Deno v2.8.3

### DIFF
--- a/packages/plugin-tailwindcss/src/mod.ts
+++ b/packages/plugin-tailwindcss/src/mod.ts
@@ -1,4 +1,5 @@
 import type { Builder } from "fresh/dev";
+// @ts-ignore TS1192 - @tailwindcss/postcss uses `export =` CJS syntax
 import twPostcss from "@tailwindcss/postcss";
 import postcss from "postcss";
 import type { TailwindPluginOptions } from "./types.ts";

--- a/packages/plugin-vite/src/mod.ts
+++ b/packages/plugin-vite/src/mod.ts
@@ -6,6 +6,7 @@ import {
 } from "./utils.ts";
 import { deno } from "./plugins/deno.ts";
 
+// @ts-ignore TS1192 - @prefresh/vite uses `export =` CJS syntax
 import prefresh from "@prefresh/vite";
 import { serverEntryPlugin } from "./plugins/server_entry.ts";
 import { clientEntryPlugin } from "./plugins/client_entry.ts";


### PR DESCRIPTION
## Problem

Deno v2.8.3 upgraded TypeScript from 5.9.2 to 6.0.3, which changed `export =` in ESM context from a **warning** (TS1203) to a **hard error** (TS1192). This causes `deno check` to fail on any imported npm package whose `.d.ts` uses `export =` CJS syntax but whose `package.json` declares ESM support via `exports.import`.

Two dependencies in this repo are affected:

| Import | File | Package |
|--------|------|---------|
| `import prefresh from "@prefresh/vite"` | `packages/plugin-vite/src/mod.ts:9` | `@prefresh/vite@2.4.11` |
| `import twPostcss from "@tailwindcss/postcss"` | `packages/plugin-tailwindcss/src/mod.ts:2` | `@tailwindcss/postcss@4.1.16` |

```
TS1192: Module '...index.d.ts' has no default export.
```

## Root Cause Analysis

```
Fresh deno.json:          moduleResolution → NodeNext (Deno default)
npm package.json:          exports.import → declares ESM support
npm .d.ts:                 export = → CJS syntax

TS 6.0 + NodeNext → sees exports.import → treats .d.ts as ESM
                  → export = in ESM → TS1192 ERROR
```

This is **reproducible against stock `tsc --moduleResolution NodeNext`** — not a Deno-specific bug. The upstream packages have a self-contradictory setup: `exports.import` says ESM, but type declarations use CJS syntax (`export =`).

The runtime import works correctly — Deno handles CJS→ESM interop at runtime. Only the type checker disagrees.

## Fix

Add `@ts-ignore TS1192` with an explanatory comment on the two affected imports.

## Follow-up

- File issue on `@prefresh/vite` (maintained by @marvinhagemeister, also a Fresh maintainer) to resolve `export =` vs `exports.import` inconsistency
- File issue on `@tailwindcss/postcss` for the same type declaration issue
