### PR TITLE
test: fix flaky partials opt-out tests by adding waitForNavigation()

### DIFF
--- a/packages/fresh/tests/partials_test.tsx
+++ b/packages/fresh/tests/partials_test.tsx
@@ -1413,7 +1413,6 @@ Deno.test({
 
 Deno.test({
   name: "partials - opt out of partial navigation",
-  ignore: true, // TODO: test is flaky
   fn: async () => {
     const app = testApp()
       .get("/partial", (ctx) => {
@@ -1463,7 +1462,10 @@ Deno.test({
         await page.locator(".increment").click();
         await waitForText(page, ".output", "1");
 
-        await page.locator(".update").click();
+        await Promise.all([
+          page.waitForNavigation(),
+          page.locator(".update").click(),
+        ]);
         await page.locator(".done").wait();
 
         await page.waitForFunction(() => {
@@ -1479,7 +1481,6 @@ Deno.test({
 
 Deno.test({
   name: "partials - opt out of partial navigation #2",
-  ignore: true, // TODO: test is flaky
   fn: async () => {
     const app = testApp()
       .get("/partial", (ctx) => {
@@ -1532,7 +1533,10 @@ Deno.test({
         await page.locator(".increment").click();
         await waitForText(page, ".output", "1");
 
-        await page.locator(".update").click();
+        await Promise.all([
+          page.waitForNavigation(),
+          page.locator(".update").click(),
+        ]);
         await page.waitForSelector(".done");
 
         const url = new URL(page.url!);


### PR DESCRIPTION
Two tests in `partials_test.tsx` were marked `ignore: true` due to flakiness.

## Root Cause
Both tests click links with `f-client-nav={false}`, triggering full-page navigations. Neither waited for the navigation to complete:

```ts
// Broken (flaky) — click races with navigation
await page.locator(.update).click();
await page.locator(.done).wait();
```

The third test (`opt out of partial navigation in island`) uses the correct pattern and is NOT flaky:

```ts
// Correct — navigation is awaited
await Promise.all([
    page.waitForNavigation(),
    page.locator(.update).click(),
]);
```

## Fix
Apply the same `Promise.all([waitForNavigation(), click])` pattern to both flaky tests and remove the `ignore: true` markers.

Closes #3858