### PR TITLE
fix: warn when CSP nonce is missing despite useNonce config

### DIFF
--- a/packages/fresh/src/middlewares/csp.ts
+++ b/packages/fresh/src/middlewares/csp.ts
@@ -129,6 +129,9 @@ export function csp<State>(options: CSPOptions = {}): Middleware<State> {
         return d;
       });
     } else {
+      console.warn(
+        "CSP nonce not found on response. Did you use ctx.render() or a non-render response method like ctx.html()?",
+      );
       directives = merged;
     }
 


### PR DESCRIPTION
When `useNonce: true` is configured in the CSP middleware but the response handler uses `ctx.html()` / `ctx.json()` instead of `ctx.render()`, the nonce is absent and the CSP silently falls back to `unsafe-inline` with zero indication to the developer.

Add a `console.warn` when this happens so developers are aware their CSP is weaker than expected.

Closes #3859