### PR TITLE
fix: expand check_docs coverage to full public API

### DIFF
--- a/tools/check_docs.ts
+++ b/tools/check_docs.ts
@@ -2,4 +2,7 @@ import { checkDocs } from "./check_docs_lib.ts";
 
 await checkDocs([
   import.meta.resolve("../packages/fresh/src/error.ts"),
+  import.meta.resolve("../packages/fresh/src/mod.ts"),
+  import.meta.resolve("../packages/fresh/src/context.ts"),
+  import.meta.resolve("../packages/fresh/src/app.ts"),
 ]);


### PR DESCRIPTION
Currently `tools/check_docs.ts` only validates `packages/fresh/src/error.ts`. The `checkDocs()` library is fully capable of checking multiple specifiers — it runs `deno doc --lint` plus custom assertions on `@param`, `@return`, `@example` tags, etc.

This PR expands the specifier list to cover the key public API entry points:
- `error.ts` (HttpError - existing)
- `mod.ts` (barrel export of all public symbols)
- `context.ts` (Context class)
- `app.ts` (App class)

Closes #3860