### PR TITLE
docs(1.x/examples/rendering-markdown): fix dead usefresh dynamic-routes link

### DIFF
--- a/docs/1.x/examples/rendering-markdown.md
+++ b/docs/1.x/examples/rendering-markdown.md
@@ -11,7 +11,7 @@ possibilities:
 3. the markdown is on a file
 
 The following file uses
-[dynamic routing](https://usefresh.dev/docs/getting-started/dynamic-routes) to
+[dynamic routing](https://usefresh.dev/docs/concepts/file-routing) to
 handle the three cases. It's assumed this file is called `[slug].tsx`:
 
 ```ts routes/[slug].tsx


### PR DESCRIPTION
Replaces `https://usefresh.dev/docs/getting-started/dynamic-routes` (404 — `getting-started/*` subtree reorganized) with `https://usefresh.dev/docs/concepts/file-routing` (200 — canonical concepts page for dynamic routing).