### PR TITLE
docs(1.x/integrations): fix dead fresh_charts and fresh_marionette links

### DIFF
--- a/docs/1.x/integrations/index.md
+++ b/docs/1.x/integrations/index.md
@@ -15,7 +15,7 @@ render charts on the server and client.
 
 A live demo can be found here: https://fresh-charts.deno.dev/
 
-Documentation for the module can be found here: https://deno.land/x/fresh_charts
+Documentation for the module can be found here: https://github.com/denoland/fresh_charts
 
 [chart-js]: https://www.chartjs.org/ "Chart.js"
 
@@ -25,8 +25,10 @@ Fresh Marionette allows you to start writing end 2 end browser tests in your
 Fresh projects with a single import. Then you can run those browser tests in a
 GitHub Actions workflow.
 
-Documentation for the module can be found here:
-https://deno.land/x/fresh_marionette
+The `deno.land/x/fresh_marionette` module has been retired and the example
+project (`https://marionette.deno.dev`) is no longer maintained — see
+the Fresh [GitHub repository](https://github.com/denoland/fresh) for
+current end-to-end testing guidance.
 
 An example project that runs the tests in a GitHub Actions workflow:
 https://marionette.deno.dev


### PR DESCRIPTION
Fixes two dead `deno.land/x/*` module links in `docs/1.x/integrations/index.md`:

- `fresh_charts` (404) → `https://github.com/denoland/fresh_charts` (200)
- `fresh_marionette` (404) — module was retired; replaced with a parenthetical pointing to the Fresh repo for current testing guidance.

The `marionette.deno.dev` example-project link below was left untouched.