### PR TITLE
docs(1.x/concepts/server-configuration): fix dead FreshConfig doc URL

### DIFF
--- a/docs/1.x/concepts/server-configuration.md
+++ b/docs/1.x/concepts/server-configuration.md
@@ -15,7 +15,7 @@ export async function start(manifest: Manifest, config: FreshConfig = {});
 
 `Manifest` comes from `fresh.gen.ts`, so nothing to do there. `config` is where
 things get interesting.
-[`FreshConfig`](https://deno.land/x/fresh/server.ts?s=FreshConfig) looks like
+[`FreshConfig`](https://jsr.io/@fresh/core) looks like
 this:
 
 ```ts fresh 🍋


### PR DESCRIPTION
Replaces `https://deno.land/x/fresh/server.ts?s=FreshConfig` (404 — `deno.land/x/*` docs URL pattern retired when Deno moved module docs to JSR) with `https://jsr.io/@fresh/core` (200).