### PR TITLE
docs(1.x/concepts/islands): fix dead IS_BROWSER doc URL

### DIFF
--- a/docs/1.x/concepts/islands.md
+++ b/docs/1.x/concepts/islands.md
@@ -211,7 +211,7 @@ An error occurred during route handling or page rendering. ReferenceError: Event
     ....
 ```
 
-Use the [`IS_BROWSER`](https://deno.land/x/fresh/runtime.ts?doc=&s=IS_BROWSER)
+Use the [`IS_BROWSER`](https://jsr.io/@fresh/core)
 flag as a guard to fix the issue:
 
 ```tsx islands/my-island.tsx


### PR DESCRIPTION
Replaces `https://deno.land/x/fresh/runtime.ts?doc=&s=IS_BROWSER` (404 — `deno.land/x/*` docs URL pattern retired when Deno moved module docs to JSR) with `https://jsr.io/@fresh/core` (200).