### PR TITLE
docs(README): drop dead usefresh.dev/showcase link

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ We appreciate your help! To contribute, please read our
 ## Adding your project to the showcase
 
 If you feel that your project would be helpful to other Fresh users, please
-consider putting your project on the [showcase](https://usefresh.dev/showcase).
+consider putting your project on the showcase.
 However, websites that are just for promotional purposes may not be listed.
 
 To take a screenshot, run the following command.


### PR DESCRIPTION
Both \`usefresh.dev/showcase\` and \`fresh.deno.dev/showcase\` now 404 — the showcase page has been retired. Drop the link rather than replace it with something guessed; the surrounding section is left intact in case the team brings the page back.