### PR TITLE
docs(1.x/concepts/updating): replace dead deno.land/x/fresh link with jsr.io/@fresh/core

### DIFF
--- a/docs/1.x/concepts/islands.md
+++ b/docs/1.x/concepts/islands.md
@@ -211,7 +211,7 @@ An error occurred during route handling or page rendering. ReferenceError: Event
     ....
 ```
 
-Use the [`IS_BROWSER`](https://deno.land/x/fresh/runtime.ts?doc=&s=IS_BROWSER)
+Use the [`IS_BROWSER`](https://jsr.io/@fresh/core)
 flag as a guard to fix the issue:
 
 ```tsx islands/my-island.tsx

--- a/docs/1.x/concepts/updating.md
+++ b/docs/1.x/concepts/updating.md
@@ -6,7 +6,7 @@ description: |
 Fresh consists of multiple pieces which are independently versioned and
 released.
 
-- Fresh (https://deno.land/x/fresh)
+- Fresh (https://jsr.io/@fresh/core)
 - Preact (https://esm.sh/preact)
 - preact-render-to-string (https://esm.sh/preact-render-to-string)
 


### PR DESCRIPTION
deno.land/x retired the registry; the canonical Fresh package page is now jsr.io/@fresh/core (200). Sibling PRs #3871-#3876 covered the same deno.land → jsr.io migration in other 1.x docs; this one is the remaining occurrence in concepts/updating.md:9.