### PR TITLE
fix(csp): warn when useNonce falls back to unsafe-inline

### DIFF
--- a/packages/fresh/src/middlewares/csp.ts
+++ b/packages/fresh/src/middlewares/csp.ts
@@ -129,6 +129,17 @@ export function csp<State>(options: CSPOptions = {}): Middleware<State> {
         return d;
       });
     } else {
+      // The route returned a response without going through ctx.render(),
+      // so Fresh never attached a nonce. The merged directives still
+      // contain 'unsafe-inline' for script-src / style-src and the user's
+      // intent (useNonce: true) was a locked-down policy — warn loudly so
+      // they know the handler needs to switch to ctx.render().
+      // deno-lint-ignore no-console
+      console.warn(
+        `🍋 [fresh] csp middleware: useNonce is true but the response ${
+          ctx.url.pathname
+        } has no nonce (handler likely returned ctx.html/ctx.json/ctx.text instead of ctx.render). Falling back to 'unsafe-inline'.`,
+      );
       directives = merged;
     }
 

--- a/packages/fresh/src/middlewares/csp_test.tsx
+++ b/packages/fresh/src/middlewares/csp_test.tsx
@@ -165,6 +165,60 @@ Deno.test("CSP - useNonce with non-rendered response falls back to unsafe-inline
   expect(cspHeader).toContain("'unsafe-inline'");
 });
 
+Deno.test("CSP - useNonce with non-rendered response warns the developer", async () => {
+  const warnings: string[] = [];
+  const original = console.warn;
+  // deno-lint-ignore no-console
+  console.warn = (msg: string) => {
+    warnings.push(String(msg));
+  };
+  try {
+    const app = new App()
+      .use(csp({ useNonce: true }))
+      .get("/api", () => new Response(JSON.stringify({ ok: true })));
+    const server = new FakeServer(app.handler());
+    const res = await server.get("/api");
+    await res.body?.cancel();
+  } finally {
+    // deno-lint-ignore no-console
+    console.warn = original;
+  }
+
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toContain("/api");
+  expect(warnings[0]).toContain("useNonce is true");
+  expect(warnings[0]).toContain("unsafe-inline");
+});
+
+Deno.test("CSP - useNonce with rendered response does not warn", async () => {
+  const warnings: string[] = [];
+  const original = console.warn;
+  // deno-lint-ignore no-console
+  console.warn = (msg: string) => {
+    warnings.push(String(msg));
+  };
+  try {
+    const app = new App()
+      .use(csp({ useNonce: true }))
+      .get("/", (ctx) => {
+        return ctx.render(
+          <html>
+            <head />
+            <body>hello</body>
+          </html>,
+        );
+      });
+    const server = new FakeServer(app.handler());
+    const res = await server.get("/");
+    await res.body?.cancel();
+  } finally {
+    // deno-lint-ignore no-console
+    console.warn = original;
+  }
+
+  expect(warnings).toHaveLength(0);
+});
+
 Deno.test("CSP - useNonce generates unique nonce per request", async () => {
   const app = new App()
     .use(csp({ useNonce: true }))


### PR DESCRIPTION
Route handlers returning ctx.html() / ctx.json() / ctx.text() instead of ctx.render() never set the nonce, so the CSP middleware silently serves the default 'unsafe-inline' directives. The user opted into useNonce to lock the policy down — silently getting 'unsafe-inline' is a real security regression they can't detect.

Emit a console.warn with the offending pathname so the developer knows which handler needs to switch to ctx.render(). Two new tests assert the warning fires on the fallback path and stays silent on the rendered path.

Fixes #3859.