### PR TITLE
docs(README): fix dead deno.land/x/fresh API Reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [Documentation](#-documentation) | [Getting started](#-getting-started) |
-[API Reference](https://deno.land/x/fresh?doc)
+[API Reference](https://jsr.io/@fresh/core)
 
 # fresh
 


### PR DESCRIPTION
Replace `deno.land/x/fresh?doc` (302 → 404, registry retired) with `jsr.io/@fresh/core` (200). Sibling to #3879 and the docs/1.x deno.land → jsr.io migrations (#3873-#3876). The top-level README was missed by those.