### PR TITLE
chore: fix route matching priority example

### DIFF
--- a/docs/latest/concepts/routing.md
+++ b/docs/latest/concepts/routing.md
@@ -46,11 +46,14 @@ This means the registration order matters for dynamic routes:
 
 ```ts main.ts
 const app = new App()
-  // This is checked first since it's registered first
-  .get("/posts/featured", () => new Response("Featured posts"))
-  // This is checked second - won't match "/posts/featured" because it's
-  // already handled above
-  .get("/posts/:id", (ctx) => new Response(`Post: ${ctx.params.id}`));
+  // Checked first among dynamic routes because it was registered first.
+  .get("/posts/:category/:slug", () => new Response("First"))
+  // This route will never match because every request it matches is already
+  // matched by the route above.
+  .get("/posts/nature/:page", () => new Response("Second"))
+  // Static routes always take precedence over dynamic routes, regardless of
+  // registration order.
+  .get("/posts/featured", () => new Response("Featured posts"));
 ```
 
 ## HTTP method handlers


### PR DESCRIPTION
The current "Route matching priority" example is a bit confusing because the inline comments contradict the preceding explanation

The documentation states that:

1. Static routes are always checked first.
2. Dynamic routes are checked in registration order.

However, the example comments imply that `/posts/featured` is matched first because it was registered first, rather than because it is a static route.

This PR updates the example to:

- demonstrate that registration order only affects dynamic routes;
- clarify that static routes always take precedence regardless of registration order.