### PR TITLE
chore(init): use canonical Tailwind classes in generated Home page component

### DIFF
--- a/packages/init/src/init.ts
+++ b/packages/init/src/init.ts
@@ -319,7 +319,7 @@ html {
 .font-bold {
   font-weight: 700;
 }
-.max-w-screen-md {
+.max-w-3xl {
   max-width: 768px;
 }
 .flex-col {
@@ -473,7 +473,7 @@ export default define.page(function Home(ctx) {
       <Head>
         <title>Fresh counter</title>
       </Head>
-      <div class="max-w-screen-md mx-auto flex flex-col items-center justify-center">
+      <div class="max-w-3xl mx-auto flex flex-col items-center justify-center">
         <img
           class="my-6"
           src="/logo.svg"


### PR DESCRIPTION
This change suppresses the `suggestCanonicalClasses` lint warning from the TailwindCSS VSCode extension.