### PR TITLE
fix(partials): keep GET form values in the page URL

### DIFF
--- a/packages/fresh/src/runtime/client/partials.ts
+++ b/packages/fresh/src/runtime/client/partials.ts
@@ -304,7 +304,14 @@ document.addEventListener("submit", async (e) => {
         // TODO: Looks like constructor type for URLSearchParam is wrong
         // deno-lint-ignore no-explicit-any
         const qs = new URLSearchParams(new FormData(el, e.submitter) as any);
-        qs.forEach((value, key) => partialUrl.searchParams.append(key, value));
+        qs.forEach((value, key) => {
+          partialUrl.searchParams.append(key, value);
+          // The address bar has to reflect the submitted values too, the way a
+          // native GET form navigation does. Without this the page URL keeps
+          // the bare action and the submitted state is lost on reload, on
+          // copying the link, or on back/forward.
+          actionUrl.searchParams.append(key, value);
+        });
       } else {
         init = { body: new FormData(el, e.submitter), method: lowerMethod };
       }

--- a/packages/fresh/tests/partials_test.tsx
+++ b/packages/fresh/tests/partials_test.tsx
@@ -2746,6 +2746,51 @@ Deno.test({
 });
 
 Deno.test({
+  name: "partials - form submit puts values into the page url",
+  fn: async () => {
+    const app = testApp()
+      .get("/", (ctx) => {
+        const name = ctx.url.searchParams.get("name");
+        return ctx.render(
+          <Doc>
+            <div f-client-nav>
+              <form action="/">
+                <input type="hidden" name="name" value="foo" />
+                <button type="submit" class="update">
+                  update
+                </button>
+              </form>
+              <Partial name="foo">
+                <p class={name === null ? "init" : "done"}>{name ?? "init"}</p>
+              </Partial>
+              <SelfCounter />
+            </div>
+          </Doc>,
+        );
+      });
+
+    await withBrowserApp(app, async (page, address) => {
+      await page.goto(address, { waitUntil: "load" });
+      await page.locator(".ready").wait();
+
+      await page.locator(".increment").click();
+      await waitForText(page, ".output", "1");
+
+      await page.locator(".update").click();
+      await page.locator(".done").wait();
+
+      // Same URL a native GET form navigation would produce.
+      const rawUrl = await page.evaluate(() => window.location.href);
+      const url = new URL(rawUrl);
+      expect(`${url.pathname}${url.search}`).toEqual("/?name=foo");
+
+      // Still a partial update, not a full page load.
+      await waitForText(page, ".output", "1");
+    });
+  },
+});
+
+Deno.test({
   name: "partials - backwards navigation should keep URLs",
   fn: async () => {
     const app = testApp()


### PR DESCRIPTION

## What happens now

Submitting a `GET` form inside `f-client-nav` updates the partial, but the
address bar keeps the bare `action` — the submitted values are gone from it.

```tsx
<div f-client-nav>
  <form action="/">
    <input type="hidden" name="name" value="foo" />
    <button type="submit">update</button>
  </form>
  <Partial name="foo">…</Partial>
</div>
```

| | URL after submit |
| --- | --- |
| native form (no JS) | `/?name=foo` |
| Fresh partial navigation | `/` |

The partial itself receives the values — only the page URL does not reflect them.

## Why it matters

The state a user just produced is no longer in the URL, so it is lost on
reload, cannot be copied or bookmarked, and does not survive back/forward.
For apps that keep UI state in the URL — filters, search, sorting — the same
form behaves differently depending on whether JS is running, which defeats
progressive enhancement.

## Cause

Both URLs start from the same `action` when no `f-partial` is given:

```js
const rawPartialUrl = … ?? el.getAttribute(PARTIAL_ATTR) ?? el.action;
const rawActionUrl  = … ?? el.action;
```

The form fields are then appended to `partialUrl` only, while `actionUrl` is
what `fetchPartials` writes into history. So the two drift apart even though
nothing asked them to.

## Change

Append the fields to the navigated URL as well. With `f-partial` the split
between "page URL" and "data URL" is preserved — only the page URL now carries
the submitted values, as a native navigation would.

## Tests

Added `partials - form submit puts values into the page url`: submits a GET
form, asserts the URL equals `/?name=foo`, and checks island state survives, so
the assertion cannot be satisfied by a full page reload. It fails on `main` and
passes with this change. All existing partials tests pass unchanged.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
