### PR TITLE
fix(plugin-vite): register co-located islands added while dev server runs

### DIFF
--- a/packages/plugin-vite/src/plugins/client_snapshot.ts
+++ b/packages/plugin-vite/src/plugins/client_snapshot.ts
@@ -163,7 +163,13 @@ if (import.meta.hot) {
   ];
 }
 
-function isIslandPath(
+/**
+ * A `(_islands)` path segment marks a local island folder, the same
+ * convention the initial route crawl uses.
+ */
+const LOCAL_ISLAND_REG = /[/\\]\(_islands\)[/\\]/;
+
+export function isIslandPath(
   options: ResolvedFreshViteConfig,
   filePath: string,
 ): boolean {
@@ -171,11 +177,11 @@ function isIslandPath(
   if (!relIsland.startsWith("..")) return true;
 
   const relRoutes = path.relative(options.routeDir, filePath);
+  if (relRoutes.startsWith("..")) return false;
 
-  if (!relIsland.startsWith("..") && relRoutes.includes("(_islands)")) {
-    return true;
-  }
-  return false;
+  // Leading separator so that a `(_islands)` folder sitting directly in the
+  // route dir matches too.
+  return LOCAL_ISLAND_REG.test(`${path.SEPARATOR}${relRoutes}`);
 }
 
 function invalidateSnapshots(server: ViteDevServer) {

--- a/packages/plugin-vite/src/plugins/client_snapshot_test.ts
+++ b/packages/plugin-vite/src/plugins/client_snapshot_test.ts
@@ -1,0 +1,58 @@
+import { expect } from "@std/expect/expect";
+import * as path from "@std/path";
+import { isIslandPath } from "./client_snapshot.ts";
+import type { ResolvedFreshViteConfig } from "../utils.ts";
+
+const ROOT = path.join(path.SEPARATOR, "project");
+
+const options = {
+  islandsDir: path.join(ROOT, "islands"),
+  routeDir: path.join(ROOT, "routes"),
+} as ResolvedFreshViteConfig;
+
+Deno.test("client snapshot - isIslandPath detects the islands dir", () => {
+  expect(isIslandPath(options, path.join(ROOT, "islands", "Counter.tsx")))
+    .toBe(true);
+  expect(
+    isIslandPath(options, path.join(ROOT, "islands", "nested", "Counter.tsx")),
+  ).toBe(true);
+});
+
+Deno.test("client snapshot - isIslandPath detects local island folders", () => {
+  expect(
+    isIslandPath(options, path.join(ROOT, "routes", "(_islands)", "Foo.tsx")),
+  ).toBe(true);
+  // Inside a route group.
+  expect(
+    isIslandPath(
+      options,
+      path.join(ROOT, "routes", "(marketing)", "(_islands)", "Foo.tsx"),
+    ),
+  ).toBe(true);
+  // And inside a plain route folder.
+  expect(
+    isIslandPath(
+      options,
+      path.join(ROOT, "routes", "shop", "(_islands)", "Cart.tsx"),
+    ),
+  ).toBe(true);
+});
+
+Deno.test("client snapshot - isIslandPath ignores everything else", () => {
+  expect(isIslandPath(options, path.join(ROOT, "routes", "index.tsx")))
+    .toBe(false);
+  // Another route group is not an island folder.
+  expect(
+    isIslandPath(
+      options,
+      path.join(ROOT, "routes", "(_components)", "Head.tsx"),
+    ),
+  ).toBe(false);
+  // `(_islands)` has to be a path segment, not a substring.
+  expect(
+    isIslandPath(options, path.join(ROOT, "routes", "(_islands)x", "Foo.tsx")),
+  ).toBe(false);
+  // Outside both dirs, even when the name matches.
+  expect(isIslandPath(options, path.join(ROOT, "(_islands)", "Foo.tsx")))
+    .toBe(false);
+});


### PR DESCRIPTION
## Problem

Creating a new island inside a `(_islands)` folder while the dev server is
running does nothing — the island stays unregistered until the server is
restarted. Editing an *existing* island works fine, so it reads like flaky
HMR rather than a missing registration.

The layout is the documented one from
[`concepts/file-routing.md`](https://github.com/denoland/fresh/blob/main/docs/latest/concepts/file-routing.md):

```
routes/
├── (marketing)/
│   └── (_islands)/
│       └── interactive-stats.tsx
└── shop/
    └── (_islands)/
        └── cart.tsx
```

## Cause

`isIslandPath()` in `client_snapshot.ts` gates what the watcher feeds into
the client snapshot, and its co-located branch is unreachable:

```ts
const relIsland = path.relative(options.islandsDir, filePath);
if (!relIsland.startsWith("..")) return true;

const relRoutes = path.relative(options.routeDir, filePath);

if (!relIsland.startsWith("..") && relRoutes.includes("(_islands)")) {
  return true;
}
```

We only reach the second `if` when `relIsland` *does* start with `".."`, so
re-testing the same value is always `false`. `relRoutes` is computed and
then never used for the decision.

The initial crawl in `fs_crawl.ts` handles these islands correctly, which is
why a restart fixes it — only files created after startup are affected.

## Fix

Test `relRoutes`, and match `(_islands)` as a path segment rather than a
substring, matching `GROUP_REG` in `fs_crawl.ts`. Files outside both
directories now bail out early instead of relying on a substring check.

## Tests

`client_snapshot_test.ts` covers the top-level `islands/` dir, both
documented co-located placements (inside a route group and inside a plain
route folder), and the negative cases — `(_components)`, a `(_islands)x`
substring, and a matching folder outside both directories.

Verified the tests fail against the current implementation and pass with the
fix. `deno fmt`, `deno lint`, `deno task check:types` and
`deno test -A packages/plugin-vite/src/plugins/` are clean.

No integration test: the neighbouring dev-server HMR test is already marked
`ignore: true` for flakiness, and the regression is fully captured by the
pure function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
